### PR TITLE
fix: add client-scoped billable items endpoints for client profile view

### DIFF
--- a/backend/src/Innovayse.API/Clients/ClientBillableItemsController.cs
+++ b/backend/src/Innovayse.API/Clients/ClientBillableItemsController.cs
@@ -1,0 +1,115 @@
+namespace Innovayse.API.Clients;
+
+using Innovayse.API.Billing.Requests;
+using Innovayse.Application.Billing.Commands.CreateBillableItem;
+using Innovayse.Application.Billing.Commands.CreateTimeBillingEntries;
+using Innovayse.Application.Billing.Commands.DeleteBillableItem;
+using Innovayse.Application.Billing.Commands.InvoiceSelectedItems;
+using Innovayse.Application.Billing.DTOs;
+using Innovayse.Application.Billing.Queries.ListClientBillableItems;
+using Innovayse.Domain.Auth;
+using Innovayse.Domain.Billing;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
+
+/// <summary>
+/// Client-scoped endpoints for managing billable items within a client profile.
+/// </summary>
+/// <param name="bus">Wolverine message bus.</param>
+[ApiController]
+[Route("api/clients/{clientId:int}/billable-items")]
+[Authorize(Roles = $"{Roles.Admin},{Roles.Reseller}")]
+public sealed class ClientBillableItemsController(IMessageBus bus) : ControllerBase
+{
+    /// <summary>Returns uninvoiced and paginated invoiced billable items for a client.</summary>
+    /// <param name="clientId">The client's primary key.</param>
+    /// <param name="invoicedPage">1-based page number for invoiced items (default 1).</param>
+    /// <param name="invoicedPageSize">Items per page for invoiced items (default 20).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Billable items result DTO.</returns>
+    [HttpGet]
+    public async Task<ActionResult<ClientBillableItemsResultDto>> GetAllAsync(
+        int clientId,
+        [FromQuery] int invoicedPage = 1,
+        [FromQuery] int invoicedPageSize = 20,
+        CancellationToken ct = default)
+    {
+        var result = await bus.InvokeAsync<ClientBillableItemsResultDto>(
+            new ListClientBillableItemsQuery(clientId, invoicedPage, invoicedPageSize), ct);
+        return Ok(result);
+    }
+
+    /// <summary>Creates a new billable item for a client.</summary>
+    /// <param name="clientId">The client's primary key.</param>
+    /// <param name="request">Billable item creation request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>201 Created with the new billable item ID.</returns>
+    [HttpPost]
+    public async Task<ActionResult<int>> CreateAsync(
+        int clientId,
+        [FromBody] CreateBillableItemRequest request,
+        CancellationToken ct)
+    {
+        var cmd = new CreateBillableItemCommand(
+            clientId,
+            request.Description,
+            request.Amount,
+            request.Currency,
+            request.Type,
+            request.RecurringPeriod,
+            request.NextDueDate);
+
+        var id = await bus.InvokeAsync<int>(cmd, ct);
+        return StatusCode(StatusCodes.Status201Created, id);
+    }
+
+    /// <summary>Creates multiple time billing entries as billable items.</summary>
+    /// <param name="clientId">The client's primary key.</param>
+    /// <param name="request">Time billing entries request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>201 Created with a list of new billable item IDs.</returns>
+    [HttpPost("time-billing")]
+    public async Task<ActionResult<IReadOnlyList<int>>> CreateTimeBillingAsync(
+        int clientId,
+        [FromBody] CreateTimeBillingRequest request,
+        CancellationToken ct)
+    {
+        var entries = request.Entries
+            .Select(e => new TimeBillingEntry(e.ServiceId, e.Description, e.Hours, e.Rate))
+            .ToList();
+
+        var cmd = new CreateTimeBillingEntriesCommand(clientId, entries);
+        var ids = await bus.InvokeAsync<IReadOnlyList<int>>(cmd, ct);
+        return StatusCode(StatusCodes.Status201Created, ids);
+    }
+
+    /// <summary>Creates an invoice from selected uninvoiced billable items.</summary>
+    /// <param name="clientId">The client's primary key.</param>
+    /// <param name="request">Selected item IDs request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>200 OK with the new invoice ID.</returns>
+    [HttpPost("invoice-selected")]
+    public async Task<ActionResult<int>> InvoiceSelectedAsync(
+        int clientId,
+        [FromBody] InvoiceSelectedItemsRequest request,
+        CancellationToken ct)
+    {
+        var cmd = new InvoiceSelectedItemsCommand(clientId, request.BillableItemIds);
+        var invoiceId = await bus.InvokeAsync<int>(cmd, ct);
+        return Ok(invoiceId);
+    }
+
+    /// <summary>Deletes an uninvoiced billable item.</summary>
+    /// <param name="clientId">The client's primary key (route parameter).</param>
+    /// <param name="id">The billable item primary key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>204 No Content.</returns>
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteAsync(int clientId, int id, CancellationToken ct)
+    {
+        await bus.InvokeAsync(new DeleteBillableItemCommand(id), ct);
+        return NoContent();
+    }
+}

--- a/backend/src/Innovayse.Application/Billing/DTOs/ClientBillableItemDto.cs
+++ b/backend/src/Innovayse.Application/Billing/DTOs/ClientBillableItemDto.cs
@@ -1,0 +1,26 @@
+namespace Innovayse.Application.Billing.DTOs;
+
+/// <summary>DTO representing a billable item in client-scoped views.</summary>
+/// <param name="Id">Billable item primary key.</param>
+/// <param name="ClientId">FK to the owning client.</param>
+/// <param name="Description">Human-readable charge description.</param>
+/// <param name="Amount">Charge amount.</param>
+/// <param name="Currency">Currency code.</param>
+/// <param name="Type">Item type (OneTime or Recurring).</param>
+/// <param name="RecurringPeriod">Recurring period; null if one-time.</param>
+/// <param name="IsInvoiced">Whether the item has been invoiced.</param>
+/// <param name="InvoiceId">FK to invoice; null if uninvoiced.</param>
+/// <param name="NextDueDate">Next due date for recurring items.</param>
+/// <param name="CreatedAt">Creation timestamp (UTC).</param>
+public record ClientBillableItemDto(
+    int Id,
+    int ClientId,
+    string Description,
+    decimal Amount,
+    string Currency,
+    string Type,
+    string? RecurringPeriod,
+    bool IsInvoiced,
+    int? InvoiceId,
+    DateTimeOffset? NextDueDate,
+    DateTimeOffset CreatedAt);

--- a/backend/src/Innovayse.Application/Billing/DTOs/ClientBillableItemsResultDto.cs
+++ b/backend/src/Innovayse.Application/Billing/DTOs/ClientBillableItemsResultDto.cs
@@ -1,0 +1,12 @@
+namespace Innovayse.Application.Billing.DTOs;
+
+using Innovayse.Application.Common;
+
+/// <summary>Combined result of uninvoiced and invoiced billable items for a client profile view.</summary>
+/// <param name="UninvoicedItems">All uninvoiced billable items for the client.</param>
+/// <param name="UninvoicedTotal">Sum of all uninvoiced item amounts.</param>
+/// <param name="InvoicedItems">Paginated list of invoiced billable items.</param>
+public record ClientBillableItemsResultDto(
+    IReadOnlyList<ClientBillableItemDto> UninvoicedItems,
+    decimal UninvoicedTotal,
+    PagedResult<ClientBillableItemDto> InvoicedItems);

--- a/backend/src/Innovayse.Application/Billing/Queries/ListClientBillableItems/ListClientBillableItemsHandler.cs
+++ b/backend/src/Innovayse.Application/Billing/Queries/ListClientBillableItems/ListClientBillableItemsHandler.cs
@@ -1,0 +1,51 @@
+namespace Innovayse.Application.Billing.Queries.ListClientBillableItems;
+
+using Innovayse.Application.Billing.DTOs;
+using Innovayse.Application.Common;
+using Innovayse.Domain.Billing;
+using Innovayse.Domain.Billing.Interfaces;
+
+/// <summary>
+/// Returns uninvoiced items (all) and invoiced items (paginated) for a client.
+/// </summary>
+public sealed class ListClientBillableItemsHandler(IBillableItemRepository repo)
+{
+    /// <summary>
+    /// Handles <see cref="ListClientBillableItemsQuery"/>.
+    /// </summary>
+    /// <param name="qry">The list billable items query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A result containing uninvoiced items, their total, and paginated invoiced items.</returns>
+    public async Task<ClientBillableItemsResultDto> HandleAsync(ListClientBillableItemsQuery qry, CancellationToken ct)
+    {
+        var uninvoiced = await repo.ListUninvoicedAsync(qry.ClientId, ct);
+        var uninvoicedDtos = uninvoiced.Select(MapToDto).ToList();
+        var uninvoicedTotal = uninvoiced.Sum(x => x.Amount);
+
+        var (invoicedItems, totalCount) = await repo.ListInvoicedByClientAsync(
+            qry.ClientId, qry.InvoicedPage, qry.InvoicedPageSize, ct);
+        var invoicedDtos = invoicedItems.Select(MapToDto).ToList();
+
+        var pagedInvoiced = new PagedResult<ClientBillableItemDto>(
+            invoicedDtos, totalCount, qry.InvoicedPage, qry.InvoicedPageSize);
+
+        return new ClientBillableItemsResultDto(uninvoicedDtos, uninvoicedTotal, pagedInvoiced);
+    }
+
+    /// <summary>Maps a domain billable item to its DTO representation.</summary>
+    /// <param name="item">The domain entity.</param>
+    /// <returns>The DTO.</returns>
+    private static ClientBillableItemDto MapToDto(BillableItem item) =>
+        new(
+            item.Id,
+            item.ClientId,
+            item.Description,
+            item.Amount,
+            item.Currency,
+            item.Type.ToString(),
+            item.RecurringPeriod,
+            item.IsInvoiced,
+            item.InvoiceId,
+            item.NextDueDate,
+            item.CreatedAt);
+}

--- a/backend/src/Innovayse.Application/Billing/Queries/ListClientBillableItems/ListClientBillableItemsQuery.cs
+++ b/backend/src/Innovayse.Application/Billing/Queries/ListClientBillableItems/ListClientBillableItemsQuery.cs
@@ -1,0 +1,7 @@
+namespace Innovayse.Application.Billing.Queries.ListClientBillableItems;
+
+/// <summary>Query to list billable items (uninvoiced + paginated invoiced) for a client.</summary>
+/// <param name="ClientId">The client's primary key.</param>
+/// <param name="InvoicedPage">1-based page number for invoiced items (default 1).</param>
+/// <param name="InvoicedPageSize">Page size for invoiced items (default 20).</param>
+public record ListClientBillableItemsQuery(int ClientId, int InvoicedPage = 1, int InvoicedPageSize = 20);

--- a/backend/src/Innovayse.Domain/Billing/Interfaces/IBillableItemRepository.cs
+++ b/backend/src/Innovayse.Domain/Billing/Interfaces/IBillableItemRepository.cs
@@ -40,6 +40,17 @@ public interface IBillableItemRepository
     Task<IReadOnlyList<BillableItem>> ListRecurringAsync(int clientId, CancellationToken ct);
 
     /// <summary>
+    /// Returns a paginated list of invoiced billable items for a specific client.
+    /// </summary>
+    /// <param name="clientId">The client's primary key.</param>
+    /// <param name="page">1-based page number.</param>
+    /// <param name="pageSize">Number of items per page.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Tuple of items for the current page and total matching count.</returns>
+    Task<(IReadOnlyList<BillableItem> Items, int TotalCount)> ListInvoicedByClientAsync(
+        int clientId, int page, int pageSize, CancellationToken ct);
+
+    /// <summary>
     /// Returns all billable items due for cron-triggered invoicing.
     /// </summary>
     Task<IReadOnlyList<BillableItem>> GetDueForCronInvoicingAsync(CancellationToken ct);

--- a/backend/src/Innovayse.Infrastructure/Billing/BillableItemRepository.cs
+++ b/backend/src/Innovayse.Infrastructure/Billing/BillableItemRepository.cs
@@ -41,6 +41,21 @@ public sealed class BillableItemRepository(AppDbContext db) : IBillableItemRepos
             .ToListAsync(ct);
 
     /// <inheritdoc/>
+    public async Task<(IReadOnlyList<BillableItem> Items, int TotalCount)> ListInvoicedByClientAsync(
+        int clientId, int page, int pageSize, CancellationToken ct)
+    {
+        var query = db.BillableItems
+            .Where(x => x.ClientId == clientId && x.IsInvoiced)
+            .OrderByDescending(x => x.CreatedAt);
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+        return (items, total);
+    }
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<BillableItem>> GetDueForCronInvoicingAsync(CancellationToken ct)
     {
         var now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary

Fix broken client profile pages (Billable Items, Quotes) after merging with the global billing branch. The frontend calls client-scoped routes (`/api/clients/{id}/billable-items`, `/api/quotes/client/{id}`) that didn't exist because the merge replaced them with global billing routes (`/api/billing/billable-items`, `/api/billing/quotes`). This PR adds the missing client-scoped controllers and DTOs alongside the global ones without modifying them.

## Related Issue

Post-merge fix — no tracked issue. Resolves 404 errors on client profile Billable Items and Quotes tabs.

## Changes

**Client-scoped Billable Items (`/api/clients/{clientId}/billable-items`):**
- `ClientBillableItemsController` in `/API/Clients/` with GET (uninvoiced + paginated invoiced), POST, POST time-billing, POST invoice-selected, DELETE
- `ClientBillableItemDto` and `ClientBillableItemsResultDto` — separate DTOs from the global `BillableItemDto`
- `ListClientBillableItemsQuery` + `ListClientBillableItemsHandler` returning split uninvoiced/invoiced view
- `ListInvoicedByClientAsync` added to `IBillableItemRepository` + EF implementation

**Client-scoped Quotes (`/api/quotes`):**
- `ClientQuotesController` in `/API/Clients/` with GET by client, GET by id, POST, PUT, POST duplicate, POST convert-to-invoice, DELETE
- Reuses existing `ListClientQuotesQuery`, `CreateQuoteCommand`, `UpdateQuoteCommand` — no new application layer code needed
- Controller adapted to current domain entity signatures (differs from pre-merge versions)

**No global billing files were modified** — `/api/billing/billable-items` and `/api/billing/quotes` remain untouched.

## Checklist

- [x] Code follows the style rules (`rules/` folder)
- [x] `dotnet format` run (backend changes)
- [x] XML docs added to all new C# members
- [x] No hardcoded secrets or credentials
- [x] Tested locally
