### PR TITLE
fix: route client-scope "Create New Quote" to global AddQuoteView wit…

### DIFF
--- a/admin/src/modules/billing/views/AddQuoteView.vue
+++ b/admin/src/modules/billing/views/AddQuoteView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import AppSelect from '../../../components/AppSelect.vue'
 import AppClientSelect from '../../../components/AppClientSelect.vue'
 import AppSpinner from '../../../components/AppSpinner.vue'
@@ -12,6 +12,7 @@ import AppCheckbox from '../../../components/AppCheckbox.vue'
 import { useQuotesStore } from '../stores/quotesStore'
 import { useApi } from '../../../composables/useApi'
 
+const route = useRoute()
 const router = useRouter()
 const store = useQuotesStore()
 const { request } = useApi()
@@ -86,13 +87,18 @@ const form = ref({
   termsAndConditions: '',
 })
 
-function loadClients() {
-  clients.value = [
-    { id: 1, name: 'John Doe', email: 'john@example.com', status: 'active' },
-    { id: 2, name: 'Jane Smith (Acme Corp)', email: 'jane@example.com', status: 'active' },
-    { id: 3, name: 'Bob Johnson', email: 'bob@example.com', status: 'active' },
-    { id: 4, name: 'Alice Williams (Tech Inc)', email: 'alice@example.com', status: 'inactive' },
-  ]
+async function loadClients() {
+  try {
+    const result = await request<{ items: Array<{ id: number; firstName: string; lastName: string; companyName?: string; email: string; status: string }> }>('/clients?page=1&pageSize=100')
+    clients.value = result.items.map(c => ({
+      id: c.id,
+      name: c.companyName ? `${c.firstName} ${c.lastName} (${c.companyName})` : `${c.firstName} ${c.lastName}`,
+      email: c.email,
+      status: c.status,
+    }))
+  } catch {
+    clients.value = []
+  }
 }
 
 function openProductModal() {
@@ -155,6 +161,11 @@ async function submit() {
 
 onMounted(() => {
   loadClients()
+  const qClientId = route.query.clientId as string | undefined
+  if (qClientId) {
+    form.value.clientId = qClientId
+    form.value.quoteType = 'existing'
+  }
 })
 </script>
 

--- a/admin/src/modules/clients/views/ClientQuotesView.vue
+++ b/admin/src/modules/clients/views/ClientQuotesView.vue
@@ -108,7 +108,7 @@ onMounted(() => fetchQuotes())
       <button
         type="button"
         class="gradient-brand px-5 py-2 text-[0.84rem] font-semibold text-white rounded-[10px] transition-opacity"
-        @click="router.push(`/quotes/new?clientId=${clientId}`)"
+        @click="router.push(`/billing/quotes/add?clientId=${clientId}`)"
       >
         + Create New Quote
       </button>


### PR DESCRIPTION
## Summary

When creating a quote from a client's profile page, the button now navigates
to the full global Create Quote form (`AddQuoteView`) instead of the simpler
`QuoteDetailView`. The client is automatically pre-selected via the `clientId`
query parameter, so the admin doesn't have to pick them manually. Also replaces
hardcoded mock client data with a real API fetch.

## Related Issue

Closes #

## Changes

- Changed ClientQuotesView "Create New Quote" button route from `/quotes/new` to `/billing/quotes/add?clientId={id}`
- Added `useRoute()` and `clientId` query param reading in AddQuoteView to pre-select the client on mount
- Replaced hardcoded mock `loadClients()` with real API call to `GET /clients?page=1&pageSize=100`

## Checklist

- [x] Code follows the style rules (`rules/` folder)
- [x] `dotnet format` run (backend changes)
- [x] XML docs added to all new C# members
- [x] JSDoc added to all new exported TypeScript/Vue functions
- [x] No hardcoded secrets or credentials
- [x] Tested locally