### PR TITLE
feat: add Downloads module to Support section (Phase 6)

### DIFF
--- a/admin/src/modules/support/views/DownloadsView.vue
+++ b/admin/src/modules/support/views/DownloadsView.vue
@@ -1,18 +1,1159 @@
 <script setup lang="ts">
 /**
- * Placeholder view for Downloads -- to be implemented in a later phase.
+ * Downloads management view -- categories and downloadable files.
+ * Supports nested category navigation, CRUD for both categories and downloads.
  */
+import { ref, computed, onMounted, watch } from 'vue'
+import { useApi } from '../../../composables/useApi'
+import AppSelect from '../../../components/AppSelect.vue'
+import AppCheckbox from '../../../components/AppCheckbox.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
+
+const { request } = useApi()
+
+// --- Types ---
+
+/** Shape of a download category returned by the API. */
+interface DownloadCategory {
+  /** Unique category identifier. */
+  id: number
+  /** Category display name. */
+  name: string
+  /** Category description text. */
+  description: string
+  /** Whether the category is hidden from clients. */
+  isHidden: boolean
+  /** Parent category ID, null for top-level categories. */
+  parentCategoryId: number | null
+  /** Number of downloads in this category. */
+  downloadCount: number
+}
+
+/** Shape of a downloadable file returned by the API. */
+interface DownloadItem {
+  /** Unique download identifier. */
+  id: number
+  /** Download title. */
+  title: string
+  /** Download description text. */
+  description: string
+  /** File type label (e.g. "ZIP File", "PDF"). */
+  type: string
+  /** Name of the downloadable file. */
+  filename: string
+  /** Category this download belongs to. */
+  categoryId: number
+  /** Category name for display purposes. */
+  categoryName: string | null
+  /** Total number of times downloaded. */
+  downloadCount: number
+  /** Whether only logged-in clients can download. */
+  clientsOnly: boolean
+  /** Whether a product purchase is required to download. */
+  productDownload: boolean
+  /** Whether the download is hidden from the client area. */
+  isHidden: boolean
+  /** ISO 8601 creation timestamp. */
+  createdAt: string
+}
+
+// --- State ---
+
+/** Currently active tab: add category or add download. */
+const activeTab = ref<'category' | 'download'>('category')
+
+/** Tab definitions for rendering. */
+const tabs = [
+  { key: 'category' as const, label: 'Add Category' },
+  { key: 'download' as const, label: 'Add Download' },
+]
+
+/** All loaded categories (flat list). */
+const categories = ref<DownloadCategory[]>([])
+
+/** Downloads at the current navigation level. */
+const downloads = ref<DownloadItem[]>([])
+
+/** Whether data is loading. */
+const loading = ref(false)
+
+/** Whether a form submission is in progress. */
+const saving = ref(false)
+
+/** Error message from the last operation. */
+const error = ref<string | null>(null)
+
+/** Current category ID for nested navigation (null = root). */
+const currentCategoryId = ref<number | null>(null)
+
+/** Breadcrumb trail for nested navigation. */
+const breadcrumbs = ref<Array<{ id: number | null; name: string }>>([])
+
+// --- Add Category form ---
+
+/** New category name. */
+const newCategoryName = ref('')
+
+/** New category description. */
+const newCategoryDescription = ref('')
+
+/** Whether the new category should be hidden. */
+const newCategoryHidden = ref(false)
+
+// --- Add Download form ---
+
+/** New download file type. */
+const newDownloadType = ref('ZIP File')
+
+/** New download title. */
+const newDownloadTitle = ref('')
+
+/** New download description. */
+const newDownloadDescription = ref('')
+
+/** New download filename. */
+const newDownloadFilename = ref('')
+
+/** New download category ID. */
+const newDownloadCategoryId = ref<number>(0)
+
+/** Whether the new download is clients-only. */
+const newDownloadClientsOnly = ref(false)
+
+/** Whether the new download requires a product purchase. */
+const newDownloadProductDownload = ref(false)
+
+/** Whether the new download is hidden. */
+const newDownloadHidden = ref(false)
+
+// --- Edit Category modal ---
+
+/** Category currently being edited, null when modal is closed. */
+const editingCategory = ref<DownloadCategory | null>(null)
+
+/** Edit form: category name. */
+const editCategoryName = ref('')
+
+/** Edit form: category description. */
+const editCategoryDescription = ref('')
+
+/** Edit form: hidden flag. */
+const editCategoryHidden = ref(false)
+
+/** Edit form: parent category ID. */
+const editCategoryParentId = ref<number | null>(null)
+
+// --- Edit Download modal ---
+
+/** Download currently being edited, null when modal is closed. */
+const editingDownload = ref<DownloadItem | null>(null)
+
+/** Edit form: download title. */
+const editDownloadTitle = ref('')
+
+/** Edit form: download description. */
+const editDownloadDescription = ref('')
+
+/** Edit form: download type. */
+const editDownloadType = ref('')
+
+/** Edit form: download filename. */
+const editDownloadFilename = ref('')
+
+/** Edit form: download category ID. */
+const editDownloadCategoryId = ref(0)
+
+/** Edit form: clients-only flag. */
+const editDownloadClientsOnly = ref(false)
+
+/** Edit form: product download flag. */
+const editDownloadProductDownload = ref(false)
+
+/** Edit form: hidden flag. */
+const editDownloadHidden = ref(false)
+
+// --- Delete confirmation ---
+
+/** Whether the delete confirmation modal is visible. */
+const showDeleteModal = ref(false)
+
+/** Target for the pending deletion. */
+const deleteTarget = ref<{ type: 'category' | 'download'; id: number; name: string } | null>(null)
+
+/** Whether a deletion is in progress. */
+const deleting = ref(false)
+
+/** Type options for the download type dropdown. */
+const typeOptions = [
+  { value: 'ZIP File', label: 'ZIP File' },
+  { value: 'Executable', label: 'Executable' },
+  { value: 'PDF', label: 'PDF' },
+  { value: 'Other', label: 'Other' },
+]
+
+/** Category options for dropdowns, including a "Top Level" entry. */
+const categoryOptions = computed(() => [
+  { value: 0, label: 'Top Level' },
+  ...categories.value.map(c => ({ value: c.id, label: c.name })),
+])
+
+/** Parent category options for edit modal (excludes the category being edited). */
+const parentCategoryOptions = computed(() => [
+  { value: 0, label: 'Top Level' },
+  ...categories.value
+    .filter(c => c.id !== editingCategory.value?.id)
+    .map(c => ({ value: c.id, label: c.name })),
+])
+
+/** Categories visible at the current navigation level. */
+const visibleCategories = computed(() =>
+  categories.value.filter(c => c.parentCategoryId === currentCategoryId.value)
+)
+
+// --- API methods ---
+
+/**
+ * Fetches all download categories from the server.
+ */
+async function fetchCategories(): Promise<void> {
+  try {
+    categories.value = await request<DownloadCategory[]>('/downloads/categories')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load categories'
+  }
+}
+
+/**
+ * Fetches downloads, optionally filtered by the current category.
+ */
+async function fetchDownloads(): Promise<void> {
+  try {
+    const url = currentCategoryId.value
+      ? `/downloads?categoryId=${currentCategoryId.value}`
+      : '/downloads'
+    downloads.value = await request<DownloadItem[]>(url)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load downloads'
+  }
+}
+
+/**
+ * Loads both categories and downloads. Shows a loading indicator.
+ */
+async function fetchAll(): Promise<void> {
+  loading.value = true
+  error.value = null
+  await Promise.all([fetchCategories(), fetchDownloads()])
+  loading.value = false
+}
+
+/**
+ * Creates a new download category at the current navigation level.
+ */
+async function createCategory(): Promise<void> {
+  if (!newCategoryName.value.trim()) return
+  saving.value = true
+  error.value = null
+  try {
+    await request('/downloads/categories', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: newCategoryName.value.trim(),
+        description: newCategoryDescription.value.trim(),
+        isHidden: newCategoryHidden.value,
+        parentCategoryId: currentCategoryId.value,
+      }),
+    })
+    newCategoryName.value = ''
+    newCategoryDescription.value = ''
+    newCategoryHidden.value = false
+    await fetchAll()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create category'
+  } finally {
+    saving.value = false
+  }
+}
+
+/**
+ * Opens the edit modal for a category and populates form fields.
+ *
+ * @param cat - The category to edit.
+ */
+function openEditCategory(cat: DownloadCategory): void {
+  editingCategory.value = cat
+  editCategoryName.value = cat.name
+  editCategoryDescription.value = cat.description
+  editCategoryHidden.value = cat.isHidden
+  editCategoryParentId.value = cat.parentCategoryId
+}
+
+/**
+ * Saves changes to the category being edited.
+ */
+async function updateCategory(): Promise<void> {
+  if (!editingCategory.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await request(`/downloads/categories/${editingCategory.value.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        name: editCategoryName.value.trim(),
+        description: editCategoryDescription.value.trim(),
+        isHidden: editCategoryHidden.value,
+        parentCategoryId: editCategoryParentId.value === 0 ? null : editCategoryParentId.value,
+      }),
+    })
+    editingCategory.value = null
+    await fetchAll()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to update category'
+  } finally {
+    saving.value = false
+  }
+}
+
+/**
+ * Creates a new download file entry.
+ */
+async function createDownload(): Promise<void> {
+  if (!newDownloadTitle.value.trim()) return
+  saving.value = true
+  error.value = null
+  try {
+    await request('/downloads', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: newDownloadTitle.value.trim(),
+        description: newDownloadDescription.value.trim(),
+        type: newDownloadType.value,
+        filename: newDownloadFilename.value.trim(),
+        categoryId: newDownloadCategoryId.value || null,
+        clientsOnly: newDownloadClientsOnly.value,
+        productDownload: newDownloadProductDownload.value,
+        isHidden: newDownloadHidden.value,
+      }),
+    })
+    resetDownloadForm()
+    await fetchAll()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create download'
+  } finally {
+    saving.value = false
+  }
+}
+
+/**
+ * Resets the add download form to its default state.
+ */
+function resetDownloadForm(): void {
+  newDownloadType.value = 'ZIP File'
+  newDownloadTitle.value = ''
+  newDownloadDescription.value = ''
+  newDownloadFilename.value = ''
+  newDownloadCategoryId.value = currentCategoryId.value ?? 0
+  newDownloadClientsOnly.value = false
+  newDownloadProductDownload.value = false
+  newDownloadHidden.value = false
+}
+
+/**
+ * Opens the edit modal for a download and populates form fields.
+ *
+ * @param dl - The download item to edit.
+ */
+function openEditDownload(dl: DownloadItem): void {
+  editingDownload.value = dl
+  editDownloadTitle.value = dl.title
+  editDownloadDescription.value = dl.description
+  editDownloadType.value = dl.type
+  editDownloadFilename.value = dl.filename
+  editDownloadCategoryId.value = dl.categoryId
+  editDownloadClientsOnly.value = dl.clientsOnly
+  editDownloadProductDownload.value = dl.productDownload
+  editDownloadHidden.value = dl.isHidden
+}
+
+/**
+ * Saves changes to the download being edited.
+ */
+async function updateDownload(): Promise<void> {
+  if (!editingDownload.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await request(`/downloads/${editingDownload.value.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        title: editDownloadTitle.value.trim(),
+        description: editDownloadDescription.value.trim(),
+        type: editDownloadType.value,
+        filename: editDownloadFilename.value.trim(),
+        categoryId: editDownloadCategoryId.value || null,
+        clientsOnly: editDownloadClientsOnly.value,
+        productDownload: editDownloadProductDownload.value,
+        isHidden: editDownloadHidden.value,
+      }),
+    })
+    editingDownload.value = null
+    await fetchAll()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to update download'
+  } finally {
+    saving.value = false
+  }
+}
+
+/**
+ * Opens the delete confirmation modal for a category or download.
+ *
+ * @param type - Whether deleting a category or download.
+ * @param id - The ID of the item to delete.
+ * @param name - Display name for the confirmation message.
+ */
+function confirmDelete(type: 'category' | 'download', id: number, name: string): void {
+  deleteTarget.value = { type, id, name }
+  showDeleteModal.value = true
+}
+
+/**
+ * Executes the pending deletion after confirmation.
+ */
+async function handleDelete(): Promise<void> {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  error.value = null
+  try {
+    const { type, id } = deleteTarget.value
+    const endpoint = type === 'category'
+      ? `/downloads/categories/${id}`
+      : `/downloads/${id}`
+    await request(endpoint, { method: 'DELETE' })
+    showDeleteModal.value = false
+    deleteTarget.value = null
+    await fetchAll()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to delete item'
+  } finally {
+    deleting.value = false
+  }
+}
+
+/**
+ * Navigates into a sub-category, updating breadcrumbs and fetching its contents.
+ *
+ * @param cat - The category to navigate into.
+ */
+function navigateToCategory(cat: DownloadCategory): void {
+  breadcrumbs.value.push({ id: cat.id, name: cat.name })
+  currentCategoryId.value = cat.id
+  fetchDownloads()
+}
+
+/**
+ * Navigates back to the root (Download Home), clearing breadcrumbs.
+ */
+function navigateHome(): void {
+  currentCategoryId.value = null
+  breadcrumbs.value = []
+  fetchDownloads()
+}
+
+/**
+ * Navigates to a specific breadcrumb level, trimming deeper entries.
+ *
+ * @param index - The breadcrumb index to navigate to.
+ */
+function navigateToBreadcrumb(index: number): void {
+  const crumb = breadcrumbs.value[index]
+  breadcrumbs.value = breadcrumbs.value.slice(0, index + 1)
+  currentCategoryId.value = crumb.id
+  fetchDownloads()
+}
+
+/** Sync the new download category ID when navigating into a category. */
+watch(currentCategoryId, (id) => {
+  newDownloadCategoryId.value = id ?? 0
+})
+
+onMounted(() => {
+  fetchAll()
+})
 </script>
 
 <template>
   <div class="p-4 sm:p-6 lg:p-8 w-full">
+
+    <!-- Header -->
     <div class="mb-5">
       <h1 class="font-display font-bold text-[1.25rem] text-text-primary leading-none">Downloads</h1>
-      <p class="text-[0.78rem] text-text-secondary mt-1">Manage downloadable files and resources</p>
+      <p class="text-[0.78rem] text-text-secondary mt-1">Manage downloadable files and categories</p>
     </div>
-    <div class="bg-surface-card border border-border rounded-2xl flex flex-col items-center justify-center py-16 gap-3">
-      <p class="text-[0.875rem] font-medium text-text-secondary">Coming Soon</p>
-      <p class="text-[0.78rem] text-text-muted">This feature is under development.</p>
+
+    <!-- Error -->
+    <div
+      v-if="error"
+      class="text-sm text-status-red bg-status-red/8 border border-status-red/20 rounded-xl p-4 mb-4"
+    >
+      {{ error }}
     </div>
+
+    <!-- Tab strip -->
+    <div class="flex flex-wrap gap-2 mb-5">
+      <button
+        v-for="tab in tabs"
+        :key="tab.key"
+        type="button"
+        class="px-3.5 py-1.5 text-[0.78rem] font-medium border rounded-[10px] transition-colors"
+        :class="activeTab === tab.key
+          ? 'bg-primary-500/10 text-primary-400 border-primary-500/20'
+          : 'bg-white/[0.04] text-text-secondary border-border hover:bg-white/[0.06]'"
+        @click="activeTab = tab.key"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- ===== Add Category Tab ===== -->
+    <div v-if="activeTab === 'category'" class="mb-5">
+      <div class="bg-surface-card border border-border rounded-2xl p-5 space-y-4">
+
+        <!-- Name + Hidden -->
+        <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+          <div class="flex-1">
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Category Name
+            </label>
+            <input
+              v-model="newCategoryName"
+              type="text"
+              placeholder="Enter category name"
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+            />
+          </div>
+          <div class="flex items-center gap-3 sm:pb-0.5">
+            <AppCheckbox v-model="newCategoryHidden" />
+            <span
+              class="text-[0.82rem] text-text-secondary cursor-pointer whitespace-nowrap"
+              @click="newCategoryHidden = !newCategoryHidden"
+            >
+              Check to Hide
+            </span>
+          </div>
+        </div>
+
+        <!-- Description -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Description
+          </label>
+          <input
+            v-model="newCategoryDescription"
+            type="text"
+            placeholder="Category description"
+            class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+          />
+        </div>
+
+        <!-- Submit -->
+        <div class="flex justify-center">
+          <button
+            type="button"
+            :disabled="saving || !newCategoryName.trim()"
+            class="gradient-brand px-5 py-2 text-[0.84rem] font-semibold text-white rounded-[10px] transition-opacity disabled:opacity-50"
+            @click="createCategory"
+          >
+            <span v-if="saving" class="flex items-center gap-2">
+              <span class="w-3.5 h-3.5 rounded-full border-2 border-white/20 border-t-white animate-spin" />
+              Saving...
+            </span>
+            <span v-else>Add Category</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Add Download Tab ===== -->
+    <div v-if="activeTab === 'download'" class="mb-5">
+      <div class="bg-surface-card border border-border rounded-2xl p-5 space-y-4">
+
+        <!-- Type -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Type
+          </label>
+          <AppSelect v-model="newDownloadType" :options="typeOptions" />
+        </div>
+
+        <!-- Title -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Title
+          </label>
+          <input
+            v-model="newDownloadTitle"
+            type="text"
+            placeholder="Enter download title"
+            class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+          />
+        </div>
+
+        <!-- Description -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Description
+          </label>
+          <textarea
+            v-model="newDownloadDescription"
+            rows="3"
+            placeholder="Enter description..."
+            class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors resize-y"
+          />
+        </div>
+
+        <!-- Filename -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Filename
+          </label>
+          <input
+            v-model="newDownloadFilename"
+            type="text"
+            placeholder="Enter filename..."
+            class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+          />
+        </div>
+
+        <!-- Category -->
+        <div>
+          <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+            Category
+          </label>
+          <AppSelect v-model="newDownloadCategoryId" :options="categoryOptions" placeholder="Select category" />
+        </div>
+
+        <!-- Checkboxes -->
+        <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4">
+          <div class="flex items-center gap-3">
+            <AppCheckbox v-model="newDownloadClientsOnly" />
+            <span
+              class="text-[0.82rem] text-text-secondary cursor-pointer"
+              @click="newDownloadClientsOnly = !newDownloadClientsOnly"
+            >
+              Clients Only
+            </span>
+          </div>
+          <div class="flex items-center gap-3">
+            <AppCheckbox v-model="newDownloadProductDownload" />
+            <span
+              class="text-[0.82rem] text-text-secondary cursor-pointer"
+              @click="newDownloadProductDownload = !newDownloadProductDownload"
+            >
+              Product Download
+            </span>
+          </div>
+          <div class="flex items-center gap-3">
+            <AppCheckbox v-model="newDownloadHidden" />
+            <span
+              class="text-[0.82rem] text-text-secondary cursor-pointer"
+              @click="newDownloadHidden = !newDownloadHidden"
+            >
+              Hidden
+            </span>
+          </div>
+        </div>
+        <p class="text-[0.72rem] text-text-muted -mt-2">
+          Clients Only restricts to logged-in clients. Product Download requires a product or addon purchase. Hidden removes from client area.
+        </p>
+
+        <!-- Buttons -->
+        <div class="flex items-center gap-3">
+          <button
+            type="button"
+            :disabled="saving || !newDownloadTitle.trim()"
+            class="gradient-brand px-5 py-2 text-[0.84rem] font-semibold text-white rounded-[10px] transition-opacity disabled:opacity-50"
+            @click="createDownload"
+          >
+            <span v-if="saving" class="flex items-center gap-2">
+              <span class="w-3.5 h-3.5 rounded-full border-2 border-white/20 border-t-white animate-spin" />
+              Saving...
+            </span>
+            <span v-else>Add Download</span>
+          </button>
+          <button
+            type="button"
+            class="px-5 py-2 text-[0.84rem] font-medium text-text-secondary bg-white/[0.04] border border-border rounded-[10px] hover:bg-white/[0.06] transition-colors"
+            @click="resetDownloadForm"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Breadcrumb -->
+    <div class="text-[0.78rem] text-text-muted mb-4">
+      <span>You are here: </span>
+      <button
+        type="button"
+        class="font-medium transition-colors"
+        :class="breadcrumbs.length > 0 ? 'text-primary-400 hover:text-primary-300' : 'text-text-secondary'"
+        @click="navigateHome"
+      >
+        Download Home
+      </button>
+      <template v-for="(crumb, idx) in breadcrumbs" :key="crumb.id">
+        <span class="mx-1.5 text-text-muted">&gt;</span>
+        <button
+          v-if="idx < breadcrumbs.length - 1"
+          type="button"
+          class="text-primary-400 hover:text-primary-300 font-medium transition-colors"
+          @click="navigateToBreadcrumb(idx)"
+        >
+          {{ crumb.name }}
+        </button>
+        <span v-else class="text-text-secondary font-medium">{{ crumb.name }}</span>
+      </template>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center gap-3 text-text-secondary text-sm py-8">
+      <span class="w-4 h-4 rounded-full border-2 border-primary-500/20 border-t-primary-500 animate-spin" />
+      Loading...
+    </div>
+
+    <template v-else>
+
+      <!-- ===== Categories Section ===== -->
+      <template v-if="visibleCategories.length > 0">
+        <div class="bg-surface-card border border-border rounded-2xl overflow-hidden mb-5">
+          <!-- Section header -->
+          <div class="px-5 py-3 bg-white/[0.02] border-b border-border">
+            <h2 class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Categories</h2>
+          </div>
+
+          <!-- Category grid -->
+          <div class="p-5">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div
+                v-for="cat in visibleCategories"
+                :key="cat.id"
+                class="bg-white/[0.02] border border-border rounded-xl p-4 hover:bg-white/[0.04] transition-colors"
+              >
+                <!-- Header row -->
+                <div class="flex items-start justify-between gap-3 mb-1.5">
+                  <div class="flex items-center gap-2.5 min-w-0">
+                    <!-- Folder icon -->
+                    <svg
+                      class="w-5 h-5 text-primary-400 shrink-0"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                    </svg>
+                    <button
+                      type="button"
+                      class="text-[0.88rem] font-medium text-text-primary hover:text-primary-400 transition-colors truncate"
+                      @click="navigateToCategory(cat)"
+                    >
+                      {{ cat.name }}
+                      <span class="text-text-muted text-[0.78rem] font-normal">({{ cat.downloadCount }})</span>
+                    </button>
+                  </div>
+                  <div class="flex items-center gap-1.5 shrink-0">
+                    <!-- Edit button -->
+                    <button
+                      type="button"
+                      class="text-text-muted hover:text-primary-400 transition-colors p-0.5"
+                      @click="openEditCategory(cat)"
+                    >
+                      <svg
+                        class="w-3.5 h-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                      </svg>
+                    </button>
+                    <!-- Delete button -->
+                    <button
+                      type="button"
+                      class="text-text-muted hover:text-status-red transition-colors p-0.5"
+                      @click="confirmDelete('category', cat.id, cat.name)"
+                    >
+                      <svg
+                        class="w-3.5 h-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <line x1="15" y1="9" x2="9" y2="15" />
+                        <line x1="9" y1="9" x2="15" y2="15" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <!-- Description -->
+                <p v-if="cat.description" class="text-[0.78rem] text-text-muted ml-7.5 line-clamp-2">
+                  {{ cat.description }}
+                </p>
+                <!-- Hidden badge -->
+                <span
+                  v-if="cat.isHidden"
+                  class="inline-block mt-2 ml-7.5 px-2 py-0.5 rounded-full text-[0.68rem] font-medium text-status-yellow bg-status-yellow/10 border border-status-yellow/20"
+                >
+                  Hidden
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- ===== Files Section ===== -->
+      <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+        <!-- Section header -->
+        <div class="px-5 py-3 bg-white/[0.02] border-b border-border">
+          <h2 class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Files</h2>
+        </div>
+
+        <!-- Download list -->
+        <div v-if="downloads.length > 0" class="divide-y divide-border">
+          <div
+            v-for="dl in downloads"
+            :key="dl.id"
+            class="px-5 py-4 hover:bg-white/[0.02] transition-colors"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="flex items-center gap-2.5 min-w-0">
+                <!-- File icon -->
+                <svg
+                  class="w-5 h-5 text-text-muted shrink-0"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                </svg>
+                <button
+                  type="button"
+                  class="text-[0.88rem] font-medium text-text-primary hover:text-primary-400 transition-colors truncate"
+                  @click="openEditDownload(dl)"
+                >
+                  {{ dl.title }}
+                </button>
+              </div>
+              <button
+                type="button"
+                class="text-status-red hover:text-status-red/80 transition-colors p-0.5 shrink-0"
+                @click="confirmDelete('download', dl.id, dl.title)"
+              >
+                <svg
+                  class="w-3.5 h-3.5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            </div>
+            <p v-if="dl.description" class="text-[0.78rem] text-text-muted ml-7.5 mt-1 line-clamp-2">
+              {{ dl.description }}
+            </p>
+            <div class="flex items-center gap-3 ml-7.5 mt-1.5">
+              <span class="text-[0.72rem] text-text-muted/60">Downloads: {{ dl.downloadCount }}</span>
+              <span
+                v-if="dl.clientsOnly"
+                class="px-1.5 py-0.5 rounded text-[0.65rem] font-medium text-primary-400 bg-primary-500/10"
+              >
+                Clients Only
+              </span>
+              <span
+                v-if="dl.isHidden"
+                class="px-1.5 py-0.5 rounded text-[0.65rem] font-medium text-status-yellow bg-status-yellow/10"
+              >
+                Hidden
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Empty state -->
+        <div v-else class="flex flex-col items-center justify-center py-12 gap-2">
+          <p class="text-[0.875rem] font-medium text-text-secondary">No Downloads Found</p>
+          <p class="text-[0.78rem] text-text-muted">Add a download using the form above.</p>
+        </div>
+      </div>
+    </template>
+
+    <!-- ===== Edit Category Modal ===== -->
+    <Teleport to="body">
+      <div
+        v-if="editingCategory"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        @click.self="editingCategory = null"
+      >
+        <div class="bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-md p-6 space-y-4">
+          <div class="flex items-center justify-between mb-1">
+            <h2 class="text-text-primary font-semibold text-[1rem]">Edit Category</h2>
+            <button
+              type="button"
+              class="text-text-muted hover:text-text-primary transition-colors"
+              @click="editingCategory = null"
+            >
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Parent Category -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Parent Category
+            </label>
+            <AppSelect
+              :model-value="editCategoryParentId ?? 0"
+              :options="parentCategoryOptions"
+              @update:model-value="editCategoryParentId = $event === 0 ? null : $event"
+            />
+          </div>
+
+          <!-- Name -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Category Name
+            </label>
+            <input
+              v-model="editCategoryName"
+              type="text"
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+            />
+          </div>
+
+          <!-- Description -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Description
+            </label>
+            <input
+              v-model="editCategoryDescription"
+              type="text"
+              placeholder="Category description"
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+            />
+          </div>
+
+          <!-- Hidden -->
+          <div class="flex items-center gap-3">
+            <AppCheckbox v-model="editCategoryHidden" />
+            <span
+              class="text-[0.82rem] text-text-secondary cursor-pointer"
+              @click="editCategoryHidden = !editCategoryHidden"
+            >
+              Hidden
+            </span>
+          </div>
+
+          <!-- Buttons -->
+          <div class="flex items-center gap-3 pt-2">
+            <button
+              type="button"
+              :disabled="saving || !editCategoryName.trim()"
+              class="gradient-brand px-5 py-2 text-[0.84rem] font-semibold text-white rounded-[10px] transition-opacity disabled:opacity-50"
+              @click="updateCategory"
+            >
+              Save Changes
+            </button>
+            <button
+              type="button"
+              class="px-5 py-2 text-[0.84rem] font-medium text-text-secondary bg-white/[0.04] border border-border rounded-[10px] hover:bg-white/[0.06] transition-colors"
+              @click="editingCategory = null"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- ===== Edit Download Modal ===== -->
+    <Teleport to="body">
+      <div
+        v-if="editingDownload"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 overflow-y-auto py-8"
+        @click.self="editingDownload = null"
+      >
+        <div class="bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4">
+          <div class="flex items-center justify-between mb-1">
+            <h2 class="text-text-primary font-semibold text-[1rem]">Edit Download</h2>
+            <button
+              type="button"
+              class="text-text-muted hover:text-text-primary transition-colors"
+              @click="editingDownload = null"
+            >
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Category -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Category
+            </label>
+            <AppSelect v-model="editDownloadCategoryId" :options="categoryOptions" placeholder="Select category" />
+          </div>
+
+          <!-- Type -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Type
+            </label>
+            <AppSelect v-model="editDownloadType" :options="typeOptions" />
+          </div>
+
+          <!-- Title -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Title
+            </label>
+            <input
+              v-model="editDownloadTitle"
+              type="text"
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+            />
+          </div>
+
+          <!-- Description -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Description
+            </label>
+            <textarea
+              v-model="editDownloadDescription"
+              rows="3"
+              placeholder="Description..."
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors resize-y"
+            />
+          </div>
+
+          <!-- Filename -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Filename
+            </label>
+            <input
+              v-model="editDownloadFilename"
+              type="text"
+              class="w-full bg-white/[0.04] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors"
+            />
+          </div>
+
+          <!-- Downloads count (read-only) -->
+          <div>
+            <label class="block text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">
+              Downloads
+            </label>
+            <input
+              :value="editingDownload.downloadCount"
+              type="number"
+              disabled
+              class="w-full bg-white/[0.02] border border-border rounded-[10px] px-3 py-2.5 text-[0.82rem] text-text-muted cursor-not-allowed"
+            />
+          </div>
+
+          <!-- Checkboxes -->
+          <div class="flex flex-col sm:flex-row sm:flex-wrap gap-4">
+            <div class="flex items-center gap-3">
+              <AppCheckbox v-model="editDownloadClientsOnly" />
+              <span
+                class="text-[0.82rem] text-text-secondary cursor-pointer"
+                @click="editDownloadClientsOnly = !editDownloadClientsOnly"
+              >
+                Clients Only
+              </span>
+            </div>
+            <div class="flex items-center gap-3">
+              <AppCheckbox v-model="editDownloadProductDownload" />
+              <span
+                class="text-[0.82rem] text-text-secondary cursor-pointer"
+                @click="editDownloadProductDownload = !editDownloadProductDownload"
+              >
+                Product Download
+              </span>
+            </div>
+            <div class="flex items-center gap-3">
+              <AppCheckbox v-model="editDownloadHidden" />
+              <span
+                class="text-[0.82rem] text-text-secondary cursor-pointer"
+                @click="editDownloadHidden = !editDownloadHidden"
+              >
+                Hidden
+              </span>
+            </div>
+          </div>
+
+          <!-- Buttons -->
+          <div class="flex items-center gap-3 pt-2">
+            <button
+              type="button"
+              :disabled="saving || !editDownloadTitle.trim()"
+              class="gradient-brand px-5 py-2 text-[0.84rem] font-semibold text-white rounded-[10px] transition-opacity disabled:opacity-50"
+              @click="updateDownload"
+            >
+              Save Changes
+            </button>
+            <button
+              type="button"
+              class="px-5 py-2 text-[0.84rem] font-medium text-text-secondary bg-white/[0.04] border border-border rounded-[10px] hover:bg-white/[0.06] transition-colors"
+              @click="editingDownload = null"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- ===== Delete Confirmation Modal ===== -->
+    <ConfirmModal
+      v-if="showDeleteModal && deleteTarget"
+      :title="`Delete ${deleteTarget.type === 'category' ? 'Category' : 'Download'}`"
+      :message="`Are you sure you want to delete '${deleteTarget.name}'? This action cannot be undone.`"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deleting"
+      variant="danger"
+      @confirm="handleDelete"
+      @close="showDeleteModal = false; deleteTarget = null"
+    />
+
   </div>
 </template>

--- a/backend/src/Innovayse.API/Support/DownloadsController.cs
+++ b/backend/src/Innovayse.API/Support/DownloadsController.cs
@@ -1,0 +1,173 @@
+namespace Innovayse.API.Support;
+
+using Innovayse.API.Support.Requests;
+using Innovayse.Application.Support.Commands.CreateDownload;
+using Innovayse.Application.Support.Commands.CreateDownloadCategory;
+using Innovayse.Application.Support.Commands.DeleteDownload;
+using Innovayse.Application.Support.Commands.DeleteDownloadCategory;
+using Innovayse.Application.Support.Commands.UpdateDownload;
+using Innovayse.Application.Support.Commands.UpdateDownloadCategory;
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Application.Support.Queries.GetDownload;
+using Innovayse.Application.Support.Queries.ListDownloadCategories;
+using Innovayse.Application.Support.Queries.ListDownloads;
+using Innovayse.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
+
+/// <summary>
+/// Admin endpoints for managing downloadable files and download categories.
+/// </summary>
+/// <param name="bus">Wolverine message bus.</param>
+[ApiController]
+[Route("api/downloads")]
+[Authorize(Roles = Roles.Admin)]
+public sealed class DownloadsController(IMessageBus bus) : ControllerBase
+{
+    // ── Categories ──────────────────────────────────────────────────────
+
+    /// <summary>Returns all download categories with download counts.</summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of category DTOs.</returns>
+    [HttpGet("categories")]
+    public async Task<ActionResult<IReadOnlyList<DownloadCategoryDto>>> GetCategoriesAsync(CancellationToken ct)
+    {
+        var result = await bus.InvokeAsync<IReadOnlyList<DownloadCategoryDto>>(
+            new ListDownloadCategoriesQuery(), ct);
+        return Ok(result);
+    }
+
+    /// <summary>Creates a new download category.</summary>
+    /// <param name="request">Category details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>201 Created with the new category ID.</returns>
+    [HttpPost("categories")]
+    public async Task<ActionResult<int>> CreateCategoryAsync(
+        [FromBody] CreateDownloadCategoryRequest request, CancellationToken ct)
+    {
+        var id = await bus.InvokeAsync<int>(
+            new CreateDownloadCategoryCommand(
+                request.Name,
+                request.Description,
+                request.IsHidden,
+                request.ParentCategoryId),
+            ct);
+        return StatusCode(201, id);
+    }
+
+    /// <summary>Updates an existing download category.</summary>
+    /// <param name="id">Category primary key.</param>
+    /// <param name="request">Updated category details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>204 No Content on success.</returns>
+    [HttpPut("categories/{id:int}")]
+    public async Task<IActionResult> UpdateCategoryAsync(
+        int id, [FromBody] UpdateDownloadCategoryRequest request, CancellationToken ct)
+    {
+        await bus.InvokeAsync(
+            new UpdateDownloadCategoryCommand(
+                id,
+                request.Name,
+                request.Description,
+                request.IsHidden,
+                request.ParentCategoryId),
+            ct);
+        return NoContent();
+    }
+
+    /// <summary>Deletes a download category.</summary>
+    /// <param name="id">Category primary key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>204 No Content on success.</returns>
+    [HttpDelete("categories/{id:int}")]
+    public async Task<IActionResult> DeleteCategoryAsync(int id, CancellationToken ct)
+    {
+        await bus.InvokeAsync(new DeleteDownloadCategoryCommand(id), ct);
+        return NoContent();
+    }
+
+    // ── Downloads ───────────────────────────────────────────────────────
+
+    /// <summary>Returns downloads, optionally filtered by category.</summary>
+    /// <param name="categoryId">Optional category ID filter.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of download DTOs.</returns>
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<DownloadDto>>> GetAllAsync(
+        [FromQuery] int? categoryId, CancellationToken ct)
+    {
+        var result = await bus.InvokeAsync<IReadOnlyList<DownloadDto>>(
+            new ListDownloadsQuery(categoryId), ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns a single download by ID.</summary>
+    /// <param name="id">Download primary key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching download DTO.</returns>
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<DownloadDto>> GetByIdAsync(int id, CancellationToken ct)
+    {
+        var result = await bus.InvokeAsync<DownloadDto>(
+            new GetDownloadQuery(id), ct);
+        return Ok(result);
+    }
+
+    /// <summary>Creates a new download entry.</summary>
+    /// <param name="request">Download details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>201 Created with the new download ID.</returns>
+    [HttpPost]
+    public async Task<ActionResult<int>> CreateAsync(
+        [FromBody] CreateDownloadRequest request, CancellationToken ct)
+    {
+        var id = await bus.InvokeAsync<int>(
+            new CreateDownloadCommand(
+                request.Title,
+                request.Description,
+                request.Type,
+                request.Filename,
+                request.CategoryId,
+                request.ClientsOnly,
+                request.ProductDownload,
+                request.IsHidden),
+            ct);
+        return StatusCode(201, id);
+    }
+
+    /// <summary>Updates an existing download entry.</summary>
+    /// <param name="id">Download primary key.</param>
+    /// <param name="request">Updated download details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>204 No Content on success.</returns>
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> UpdateAsync(
+        int id, [FromBody] UpdateDownloadRequest request, CancellationToken ct)
+    {
+        await bus.InvokeAsync(
+            new UpdateDownloadCommand(
+                id,
+                request.Title,
+                request.Description,
+                request.Type,
+                request.Filename,
+                request.CategoryId,
+                request.ClientsOnly,
+                request.ProductDownload,
+                request.IsHidden),
+            ct);
+        return NoContent();
+    }
+
+    /// <summary>Deletes a download entry.</summary>
+    /// <param name="id">Download primary key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>204 No Content on success.</returns>
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteAsync(int id, CancellationToken ct)
+    {
+        await bus.InvokeAsync(new DeleteDownloadCommand(id), ct);
+        return NoContent();
+    }
+}

--- a/backend/src/Innovayse.API/Support/Requests/CreateDownloadCategoryRequest.cs
+++ b/backend/src/Innovayse.API/Support/Requests/CreateDownloadCategoryRequest.cs
@@ -1,0 +1,8 @@
+namespace Innovayse.API.Support.Requests;
+
+/// <summary>Request body for creating a download category.</summary>
+/// <param name="Name">Category display name.</param>
+/// <param name="Description">Category description text.</param>
+/// <param name="IsHidden">Whether the category should be hidden from clients.</param>
+/// <param name="ParentCategoryId">Optional parent category ID for nesting.</param>
+public record CreateDownloadCategoryRequest(string Name, string Description, bool IsHidden, int? ParentCategoryId = null);

--- a/backend/src/Innovayse.API/Support/Requests/CreateDownloadRequest.cs
+++ b/backend/src/Innovayse.API/Support/Requests/CreateDownloadRequest.cs
@@ -1,0 +1,20 @@
+namespace Innovayse.API.Support.Requests;
+
+/// <summary>Request body for creating a download entry.</summary>
+/// <param name="Title">Display title.</param>
+/// <param name="Description">Download description text.</param>
+/// <param name="Type">File type label (e.g. "ZIP File", "PDF").</param>
+/// <param name="Filename">Stored filename.</param>
+/// <param name="CategoryId">Category identifier.</param>
+/// <param name="ClientsOnly">Whether the download is restricted to authenticated clients.</param>
+/// <param name="ProductDownload">Whether the download is associated with a product.</param>
+/// <param name="IsHidden">Whether the download is hidden from listings.</param>
+public record CreateDownloadRequest(
+    string Title,
+    string Description,
+    string Type,
+    string Filename,
+    int CategoryId,
+    bool ClientsOnly,
+    bool ProductDownload,
+    bool IsHidden);

--- a/backend/src/Innovayse.API/Support/Requests/UpdateDownloadCategoryRequest.cs
+++ b/backend/src/Innovayse.API/Support/Requests/UpdateDownloadCategoryRequest.cs
@@ -1,0 +1,8 @@
+namespace Innovayse.API.Support.Requests;
+
+/// <summary>Request body for updating a download category.</summary>
+/// <param name="Name">Updated category display name.</param>
+/// <param name="Description">Updated category description text.</param>
+/// <param name="IsHidden">Whether the category should be hidden from clients.</param>
+/// <param name="ParentCategoryId">Optional parent category ID for nesting.</param>
+public record UpdateDownloadCategoryRequest(string Name, string Description, bool IsHidden, int? ParentCategoryId);

--- a/backend/src/Innovayse.API/Support/Requests/UpdateDownloadRequest.cs
+++ b/backend/src/Innovayse.API/Support/Requests/UpdateDownloadRequest.cs
@@ -1,0 +1,20 @@
+namespace Innovayse.API.Support.Requests;
+
+/// <summary>Request body for updating a download entry.</summary>
+/// <param name="Title">Updated display title.</param>
+/// <param name="Description">Updated description text.</param>
+/// <param name="Type">Updated file type label.</param>
+/// <param name="Filename">Updated stored filename.</param>
+/// <param name="CategoryId">Updated category identifier.</param>
+/// <param name="ClientsOnly">Whether the download is restricted to authenticated clients.</param>
+/// <param name="ProductDownload">Whether the download is associated with a product.</param>
+/// <param name="IsHidden">Whether the download is hidden from listings.</param>
+public record UpdateDownloadRequest(
+    string Title,
+    string Description,
+    string Type,
+    string Filename,
+    int CategoryId,
+    bool ClientsOnly,
+    bool ProductDownload,
+    bool IsHidden);

--- a/backend/src/Innovayse.Application/Support/Commands/CreateDownload/CreateDownloadCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/CreateDownload/CreateDownloadCommand.cs
@@ -1,0 +1,20 @@
+namespace Innovayse.Application.Support.Commands.CreateDownload;
+
+/// <summary>Command to create a new download entry.</summary>
+/// <param name="Title">The display title.</param>
+/// <param name="Description">The download description text.</param>
+/// <param name="Type">The file type label (e.g. "ZIP File", "PDF").</param>
+/// <param name="Filename">The stored filename.</param>
+/// <param name="CategoryId">The category identifier.</param>
+/// <param name="ClientsOnly">Whether the download is restricted to authenticated clients.</param>
+/// <param name="ProductDownload">Whether the download is associated with a product.</param>
+/// <param name="IsHidden">Whether the download is hidden from listings.</param>
+public record CreateDownloadCommand(
+    string Title,
+    string Description,
+    string Type,
+    string Filename,
+    int CategoryId,
+    bool ClientsOnly,
+    bool ProductDownload,
+    bool IsHidden);

--- a/backend/src/Innovayse.Application/Support/Commands/CreateDownload/CreateDownloadHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/CreateDownload/CreateDownloadHandler.cs
@@ -1,0 +1,34 @@
+namespace Innovayse.Application.Support.Commands.CreateDownload;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Creates a new download entry.
+/// </summary>
+public sealed class CreateDownloadHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="CreateDownloadCommand"/>.
+    /// </summary>
+    /// <param name="command">The create download command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The ID of the newly created download.</returns>
+    public async Task<int> HandleAsync(CreateDownloadCommand command, CancellationToken ct)
+    {
+        var download = Download.Create(
+            command.Title,
+            command.Description,
+            command.Type,
+            command.Filename,
+            command.CategoryId,
+            command.ClientsOnly,
+            command.ProductDownload,
+            command.IsHidden);
+
+        repo.Add(download);
+        await uow.SaveChangesAsync(ct);
+        return download.Id;
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/CreateDownloadCategory/CreateDownloadCategoryCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/CreateDownloadCategory/CreateDownloadCategoryCommand.cs
@@ -1,0 +1,8 @@
+namespace Innovayse.Application.Support.Commands.CreateDownloadCategory;
+
+/// <summary>Command to create a new download category.</summary>
+/// <param name="Name">The category display name.</param>
+/// <param name="Description">The category description text.</param>
+/// <param name="IsHidden">Whether the category should be hidden from clients.</param>
+/// <param name="ParentCategoryId">Optional parent category ID for nesting.</param>
+public record CreateDownloadCategoryCommand(string Name, string Description, bool IsHidden, int? ParentCategoryId = null);

--- a/backend/src/Innovayse.Application/Support/Commands/CreateDownloadCategory/CreateDownloadCategoryHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/CreateDownloadCategory/CreateDownloadCategoryHandler.cs
@@ -1,0 +1,30 @@
+namespace Innovayse.Application.Support.Commands.CreateDownloadCategory;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Creates a new download category.
+/// </summary>
+public sealed class CreateDownloadCategoryHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="CreateDownloadCategoryCommand"/>.
+    /// </summary>
+    /// <param name="command">The create category command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The ID of the newly created category.</returns>
+    public async Task<int> HandleAsync(CreateDownloadCategoryCommand command, CancellationToken ct)
+    {
+        var category = DownloadCategory.Create(
+            command.Name,
+            command.Description,
+            command.IsHidden,
+            command.ParentCategoryId);
+
+        repo.AddCategory(category);
+        await uow.SaveChangesAsync(ct);
+        return category.Id;
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/DeleteDownload/DeleteDownloadCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/DeleteDownload/DeleteDownloadCommand.cs
@@ -1,0 +1,5 @@
+namespace Innovayse.Application.Support.Commands.DeleteDownload;
+
+/// <summary>Command to delete a download by ID.</summary>
+/// <param name="Id">The download identifier to delete.</param>
+public record DeleteDownloadCommand(int Id);

--- a/backend/src/Innovayse.Application/Support/Commands/DeleteDownload/DeleteDownloadHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/DeleteDownload/DeleteDownloadHandler.cs
@@ -1,0 +1,25 @@
+namespace Innovayse.Application.Support.Commands.DeleteDownload;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Deletes a download entry.
+/// </summary>
+public sealed class DeleteDownloadHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="DeleteDownloadCommand"/>.
+    /// </summary>
+    /// <param name="command">The delete download command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the download is not found.</exception>
+    public async Task HandleAsync(DeleteDownloadCommand command, CancellationToken ct)
+    {
+        var download = await repo.FindByIdAsync(command.Id, ct)
+            ?? throw new InvalidOperationException($"Download {command.Id} not found.");
+
+        repo.Remove(download);
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/DeleteDownloadCategory/DeleteDownloadCategoryCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/DeleteDownloadCategory/DeleteDownloadCategoryCommand.cs
@@ -1,0 +1,5 @@
+namespace Innovayse.Application.Support.Commands.DeleteDownloadCategory;
+
+/// <summary>Command to delete a download category by ID.</summary>
+/// <param name="Id">The category identifier to delete.</param>
+public record DeleteDownloadCategoryCommand(int Id);

--- a/backend/src/Innovayse.Application/Support/Commands/DeleteDownloadCategory/DeleteDownloadCategoryHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/DeleteDownloadCategory/DeleteDownloadCategoryHandler.cs
@@ -1,0 +1,25 @@
+namespace Innovayse.Application.Support.Commands.DeleteDownloadCategory;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Deletes a download category.
+/// </summary>
+public sealed class DeleteDownloadCategoryHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="DeleteDownloadCategoryCommand"/>.
+    /// </summary>
+    /// <param name="command">The delete category command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the category is not found.</exception>
+    public async Task HandleAsync(DeleteDownloadCategoryCommand command, CancellationToken ct)
+    {
+        var category = await repo.FindCategoryByIdAsync(command.Id, ct)
+            ?? throw new InvalidOperationException($"Download category {command.Id} not found.");
+
+        repo.RemoveCategory(category);
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/UpdateDownload/UpdateDownloadCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/UpdateDownload/UpdateDownloadCommand.cs
@@ -1,0 +1,22 @@
+namespace Innovayse.Application.Support.Commands.UpdateDownload;
+
+/// <summary>Command to update an existing download entry.</summary>
+/// <param name="Id">The download identifier.</param>
+/// <param name="Title">The new display title.</param>
+/// <param name="Description">The new description text.</param>
+/// <param name="Type">The new file type label.</param>
+/// <param name="Filename">The new stored filename.</param>
+/// <param name="CategoryId">The new category identifier.</param>
+/// <param name="ClientsOnly">Whether the download is restricted to authenticated clients.</param>
+/// <param name="ProductDownload">Whether the download is associated with a product.</param>
+/// <param name="IsHidden">Whether the download is hidden from listings.</param>
+public record UpdateDownloadCommand(
+    int Id,
+    string Title,
+    string Description,
+    string Type,
+    string Filename,
+    int CategoryId,
+    bool ClientsOnly,
+    bool ProductDownload,
+    bool IsHidden);

--- a/backend/src/Innovayse.Application/Support/Commands/UpdateDownload/UpdateDownloadHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/UpdateDownload/UpdateDownloadHandler.cs
@@ -1,0 +1,34 @@
+namespace Innovayse.Application.Support.Commands.UpdateDownload;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Updates an existing download entry.
+/// </summary>
+public sealed class UpdateDownloadHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="UpdateDownloadCommand"/>.
+    /// </summary>
+    /// <param name="command">The update download command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the download is not found.</exception>
+    public async Task HandleAsync(UpdateDownloadCommand command, CancellationToken ct)
+    {
+        var download = await repo.FindByIdAsync(command.Id, ct)
+            ?? throw new InvalidOperationException($"Download {command.Id} not found.");
+
+        download.Update(
+            command.Title,
+            command.Description,
+            command.Type,
+            command.Filename,
+            command.CategoryId,
+            command.ClientsOnly,
+            command.ProductDownload,
+            command.IsHidden);
+
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/UpdateDownloadCategory/UpdateDownloadCategoryCommand.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/UpdateDownloadCategory/UpdateDownloadCategoryCommand.cs
@@ -1,0 +1,9 @@
+namespace Innovayse.Application.Support.Commands.UpdateDownloadCategory;
+
+/// <summary>Command to update an existing download category.</summary>
+/// <param name="Id">The category identifier.</param>
+/// <param name="Name">The new category display name.</param>
+/// <param name="Description">The new category description text.</param>
+/// <param name="IsHidden">Whether the category should be hidden from clients.</param>
+/// <param name="ParentCategoryId">Optional parent category ID for nesting.</param>
+public record UpdateDownloadCategoryCommand(int Id, string Name, string Description, bool IsHidden, int? ParentCategoryId);

--- a/backend/src/Innovayse.Application/Support/Commands/UpdateDownloadCategory/UpdateDownloadCategoryHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/UpdateDownloadCategory/UpdateDownloadCategoryHandler.cs
@@ -1,0 +1,25 @@
+namespace Innovayse.Application.Support.Commands.UpdateDownloadCategory;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Updates an existing download category.
+/// </summary>
+public sealed class UpdateDownloadCategoryHandler(IDownloadRepository repo, IUnitOfWork uow)
+{
+    /// <summary>
+    /// Handles <see cref="UpdateDownloadCategoryCommand"/>.
+    /// </summary>
+    /// <param name="command">The update category command.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the category is not found.</exception>
+    public async Task HandleAsync(UpdateDownloadCategoryCommand command, CancellationToken ct)
+    {
+        var category = await repo.FindCategoryByIdAsync(command.Id, ct)
+            ?? throw new InvalidOperationException($"Download category {command.Id} not found.");
+
+        category.Update(command.Name, command.Description, command.IsHidden, command.ParentCategoryId);
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/DTOs/DownloadCategoryDto.cs
+++ b/backend/src/Innovayse.Application/Support/DTOs/DownloadCategoryDto.cs
@@ -1,0 +1,16 @@
+namespace Innovayse.Application.Support.DTOs;
+
+/// <summary>DTO representing a download category with its download count.</summary>
+/// <param name="Id">Category primary key.</param>
+/// <param name="Name">Category display name.</param>
+/// <param name="Description">Category description text.</param>
+/// <param name="IsHidden">Whether the category is hidden from clients.</param>
+/// <param name="ParentCategoryId">FK to parent category, or null if top-level.</param>
+/// <param name="DownloadCount">Number of downloads in this category.</param>
+public record DownloadCategoryDto(
+    int Id,
+    string Name,
+    string Description,
+    bool IsHidden,
+    int? ParentCategoryId,
+    int DownloadCount);

--- a/backend/src/Innovayse.Application/Support/DTOs/DownloadDto.cs
+++ b/backend/src/Innovayse.Application/Support/DTOs/DownloadDto.cs
@@ -1,0 +1,28 @@
+namespace Innovayse.Application.Support.DTOs;
+
+/// <summary>DTO representing a downloadable file.</summary>
+/// <param name="Id">Download primary key.</param>
+/// <param name="Title">Display title.</param>
+/// <param name="Description">Download description text.</param>
+/// <param name="Type">File type label (e.g. "ZIP File", "PDF").</param>
+/// <param name="Filename">Stored filename on disk or object storage.</param>
+/// <param name="CategoryId">FK to the download category.</param>
+/// <param name="CategoryName">Resolved category display name, or null if not resolved.</param>
+/// <param name="DownloadCount">Total number of times this file has been downloaded.</param>
+/// <param name="ClientsOnly">Whether the download is restricted to authenticated clients.</param>
+/// <param name="ProductDownload">Whether the download is associated with a product.</param>
+/// <param name="IsHidden">Whether the download is hidden from listings.</param>
+/// <param name="CreatedAt">UTC timestamp when the download was created.</param>
+public record DownloadDto(
+    int Id,
+    string Title,
+    string Description,
+    string Type,
+    string Filename,
+    int CategoryId,
+    string? CategoryName,
+    int DownloadCount,
+    bool ClientsOnly,
+    bool ProductDownload,
+    bool IsHidden,
+    DateTimeOffset CreatedAt);

--- a/backend/src/Innovayse.Application/Support/Queries/GetDownload/GetDownloadHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/GetDownload/GetDownloadHandler.cs
@@ -1,0 +1,39 @@
+namespace Innovayse.Application.Support.Queries.GetDownload;
+
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Loads a single download and maps it to <see cref="DownloadDto"/>.
+/// </summary>
+public sealed class GetDownloadHandler(IDownloadRepository repo)
+{
+    /// <summary>
+    /// Handles <see cref="GetDownloadQuery"/>.
+    /// </summary>
+    /// <param name="query">The get download query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching <see cref="DownloadDto"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the download is not found.</exception>
+    public async Task<DownloadDto> HandleAsync(GetDownloadQuery query, CancellationToken ct)
+    {
+        var download = await repo.FindByIdAsync(query.Id, ct)
+            ?? throw new InvalidOperationException($"Download {query.Id} not found.");
+
+        var category = await repo.FindCategoryByIdAsync(download.CategoryId, ct);
+
+        return new DownloadDto(
+            download.Id,
+            download.Title,
+            download.Description,
+            download.Type,
+            download.Filename,
+            download.CategoryId,
+            category?.Name,
+            download.DownloadCount,
+            download.ClientsOnly,
+            download.ProductDownload,
+            download.IsHidden,
+            download.CreatedAt);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Queries/GetDownload/GetDownloadQuery.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/GetDownload/GetDownloadQuery.cs
@@ -1,0 +1,5 @@
+namespace Innovayse.Application.Support.Queries.GetDownload;
+
+/// <summary>Query to retrieve a single download by ID.</summary>
+/// <param name="Id">The download primary key.</param>
+public record GetDownloadQuery(int Id);

--- a/backend/src/Innovayse.Application/Support/Queries/ListDownloadCategories/ListDownloadCategoriesHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListDownloadCategories/ListDownloadCategoriesHandler.cs
@@ -1,0 +1,37 @@
+namespace Innovayse.Application.Support.Queries.ListDownloadCategories;
+
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Returns all download categories with download counts per category.
+/// </summary>
+public sealed class ListDownloadCategoriesHandler(IDownloadRepository repo)
+{
+    /// <summary>
+    /// Handles <see cref="ListDownloadCategoriesQuery"/>.
+    /// </summary>
+    /// <param name="query">The list categories query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A read-only list of category DTOs with download counts.</returns>
+    public async Task<IReadOnlyList<DownloadCategoryDto>> HandleAsync(
+        ListDownloadCategoriesQuery query, CancellationToken ct)
+    {
+        var categories = await repo.ListCategoriesAsync(ct);
+        var result = new List<DownloadCategoryDto>(categories.Count);
+
+        foreach (var c in categories)
+        {
+            var count = await repo.CountByCategoryIdAsync(c.Id, ct);
+            result.Add(new DownloadCategoryDto(
+                c.Id,
+                c.Name,
+                c.Description,
+                c.IsHidden,
+                c.ParentCategoryId,
+                count));
+        }
+
+        return result;
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Queries/ListDownloadCategories/ListDownloadCategoriesQuery.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListDownloadCategories/ListDownloadCategoriesQuery.cs
@@ -1,0 +1,4 @@
+namespace Innovayse.Application.Support.Queries.ListDownloadCategories;
+
+/// <summary>Query to retrieve all download categories.</summary>
+public record ListDownloadCategoriesQuery;

--- a/backend/src/Innovayse.Application/Support/Queries/ListDownloads/ListDownloadsHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListDownloads/ListDownloadsHandler.cs
@@ -1,0 +1,40 @@
+namespace Innovayse.Application.Support.Queries.ListDownloads;
+
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Returns downloads optionally filtered by category, with resolved category names.
+/// </summary>
+public sealed class ListDownloadsHandler(IDownloadRepository repo)
+{
+    /// <summary>
+    /// Handles <see cref="ListDownloadsQuery"/>.
+    /// </summary>
+    /// <param name="query">The list downloads query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A read-only list of download DTOs with resolved category names.</returns>
+    public async Task<IReadOnlyList<DownloadDto>> HandleAsync(ListDownloadsQuery query, CancellationToken ct)
+    {
+        var downloads = await repo.ListByCategoryAsync(query.CategoryId, ct);
+        var categories = await repo.ListCategoriesAsync(ct);
+
+        var categoryNames = categories.ToDictionary(c => c.Id, c => c.Name);
+
+        return downloads
+            .Select(d => new DownloadDto(
+                d.Id,
+                d.Title,
+                d.Description,
+                d.Type,
+                d.Filename,
+                d.CategoryId,
+                categoryNames.GetValueOrDefault(d.CategoryId),
+                d.DownloadCount,
+                d.ClientsOnly,
+                d.ProductDownload,
+                d.IsHidden,
+                d.CreatedAt))
+            .ToList();
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Queries/ListDownloads/ListDownloadsQuery.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListDownloads/ListDownloadsQuery.cs
@@ -1,0 +1,5 @@
+namespace Innovayse.Application.Support.Queries.ListDownloads;
+
+/// <summary>Query to retrieve downloads, optionally filtered by category.</summary>
+/// <param name="CategoryId">Optional category ID to filter by. Pass null to list all downloads.</param>
+public record ListDownloadsQuery(int? CategoryId);

--- a/backend/src/Innovayse.Domain/Support/Download.cs
+++ b/backend/src/Innovayse.Domain/Support/Download.cs
@@ -1,0 +1,117 @@
+namespace Innovayse.Domain.Support;
+
+using Innovayse.Domain.Common;
+
+/// <summary>
+/// Represents a downloadable file that can be associated with a category
+/// and optionally restricted to authenticated clients or linked to products.
+/// </summary>
+public sealed class Download : Entity
+{
+    /// <summary>Gets the display title of this download.</summary>
+    public string Title { get; private set; } = string.Empty;
+
+    /// <summary>Gets the description of this download.</summary>
+    public string Description { get; private set; } = string.Empty;
+
+    /// <summary>Gets the file type label (e.g. "ZIP File", "Executable", "PDF").</summary>
+    public string Type { get; private set; } = string.Empty;
+
+    /// <summary>Gets the stored filename on disk or object storage.</summary>
+    public string Filename { get; private set; } = string.Empty;
+
+    /// <summary>Gets the FK to the category this download belongs to.</summary>
+    public int CategoryId { get; private set; }
+
+    /// <summary>Gets the total number of times this file has been downloaded.</summary>
+    public int DownloadCount { get; private set; }
+
+    /// <summary>Gets a value indicating whether this download is restricted to authenticated clients.</summary>
+    public bool ClientsOnly { get; private set; }
+
+    /// <summary>Gets a value indicating whether this download is associated with a product.</summary>
+    public bool ProductDownload { get; private set; }
+
+    /// <summary>Gets a value indicating whether this download is hidden from listings.</summary>
+    public bool IsHidden { get; private set; }
+
+    /// <summary>Gets the UTC timestamp when this download was created.</summary>
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>EF Core parameterless constructor — do not call directly.</summary>
+    private Download() : base(0) { }
+
+    /// <summary>
+    /// Creates a new <see cref="Download"/> with the provided details.
+    /// </summary>
+    /// <param name="title">The display title.</param>
+    /// <param name="description">The download description.</param>
+    /// <param name="type">The file type label.</param>
+    /// <param name="filename">The stored filename.</param>
+    /// <param name="categoryId">The category identifier.</param>
+    /// <param name="clientsOnly">Whether the download is restricted to clients.</param>
+    /// <param name="productDownload">Whether the download is associated with a product.</param>
+    /// <param name="isHidden">Whether the download is hidden from listings.</param>
+    /// <returns>A new <see cref="Download"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="title"/> is null or whitespace.</exception>
+    public static Download Create(
+        string title,
+        string description,
+        string type,
+        string filename,
+        int categoryId,
+        bool clientsOnly,
+        bool productDownload,
+        bool isHidden)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        return new Download
+        {
+            Title = title,
+            Description = description ?? string.Empty,
+            Type = type ?? "ZIP File",
+            Filename = filename ?? string.Empty,
+            CategoryId = categoryId,
+            ClientsOnly = clientsOnly,
+            ProductDownload = productDownload,
+            IsHidden = isHidden,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    /// <summary>
+    /// Updates the details of this download.
+    /// </summary>
+    /// <param name="title">The new display title.</param>
+    /// <param name="description">The new description.</param>
+    /// <param name="type">The new file type label.</param>
+    /// <param name="filename">The new stored filename.</param>
+    /// <param name="categoryId">The new category identifier.</param>
+    /// <param name="clientsOnly">Whether the download is restricted to clients.</param>
+    /// <param name="productDownload">Whether the download is associated with a product.</param>
+    /// <param name="isHidden">Whether the download is hidden from listings.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="title"/> is null or whitespace.</exception>
+    public void Update(
+        string title,
+        string description,
+        string type,
+        string filename,
+        int categoryId,
+        bool clientsOnly,
+        bool productDownload,
+        bool isHidden)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        Title = title;
+        Description = description ?? string.Empty;
+        Type = type ?? "ZIP File";
+        Filename = filename ?? string.Empty;
+        CategoryId = categoryId;
+        ClientsOnly = clientsOnly;
+        ProductDownload = productDownload;
+        IsHidden = isHidden;
+    }
+
+    /// <summary>Increments the download counter by one.</summary>
+    public void IncrementDownloadCount() => DownloadCount++;
+}

--- a/backend/src/Innovayse.Domain/Support/DownloadCategory.cs
+++ b/backend/src/Innovayse.Domain/Support/DownloadCategory.cs
@@ -1,0 +1,63 @@
+namespace Innovayse.Domain.Support;
+
+using Innovayse.Domain.Common;
+
+/// <summary>
+/// Represents a download category used to organise downloadable files.
+/// Categories can be hidden from public view and support hierarchical nesting.
+/// </summary>
+public sealed class DownloadCategory : Entity
+{
+    /// <summary>Gets the display name of this category.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>Gets the description of this category.</summary>
+    public string Description { get; private set; } = string.Empty;
+
+    /// <summary>Gets a value indicating whether this category is hidden from clients.</summary>
+    public bool IsHidden { get; private set; }
+
+    /// <summary>Gets the FK to the parent category for nesting, or null if top-level.</summary>
+    public int? ParentCategoryId { get; private set; }
+
+    /// <summary>EF Core parameterless constructor — do not call directly.</summary>
+    private DownloadCategory() : base(0) { }
+
+    /// <summary>
+    /// Creates a new <see cref="DownloadCategory"/> with the provided details.
+    /// </summary>
+    /// <param name="name">The category display name.</param>
+    /// <param name="description">The category description.</param>
+    /// <param name="isHidden">Whether the category should be hidden from clients.</param>
+    /// <param name="parentCategoryId">Optional parent category ID for nesting.</param>
+    /// <returns>A new <see cref="DownloadCategory"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
+    public static DownloadCategory Create(string name, string description, bool isHidden, int? parentCategoryId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return new DownloadCategory
+        {
+            Name = name,
+            Description = description ?? string.Empty,
+            IsHidden = isHidden,
+            ParentCategoryId = parentCategoryId,
+        };
+    }
+
+    /// <summary>
+    /// Updates the details of this category.
+    /// </summary>
+    /// <param name="name">The new category display name.</param>
+    /// <param name="description">The new category description.</param>
+    /// <param name="isHidden">Whether the category should be hidden from clients.</param>
+    /// <param name="parentCategoryId">Optional parent category ID for nesting.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
+    public void Update(string name, string description, bool isHidden, int? parentCategoryId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+        Description = description ?? string.Empty;
+        IsHidden = isHidden;
+        ParentCategoryId = parentCategoryId;
+    }
+}

--- a/backend/src/Innovayse.Domain/Support/Interfaces/IDownloadRepository.cs
+++ b/backend/src/Innovayse.Domain/Support/Interfaces/IDownloadRepository.cs
@@ -1,0 +1,72 @@
+namespace Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Repository abstraction for <see cref="Download"/> and <see cref="DownloadCategory"/> entity persistence.
+/// Implementations live in the Infrastructure layer.
+/// </summary>
+public interface IDownloadRepository
+{
+    /// <summary>
+    /// Finds a download by its primary key.
+    /// </summary>
+    /// <param name="id">The download identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching <see cref="Download"/>, or <see langword="null"/> if not found.</returns>
+    Task<Download?> FindByIdAsync(int id, CancellationToken ct);
+
+    /// <summary>
+    /// Stages a new download for insertion on the next <c>SaveChanges</c> call.
+    /// </summary>
+    /// <param name="download">The download to add.</param>
+    void Add(Download download);
+
+    /// <summary>
+    /// Stages a download for deletion on the next <c>SaveChanges</c> call.
+    /// </summary>
+    /// <param name="download">The download to remove.</param>
+    void Remove(Download download);
+
+    /// <summary>
+    /// Returns downloads filtered by category, ordered by creation date descending.
+    /// When <paramref name="categoryId"/> is <see langword="null"/>, returns all downloads.
+    /// </summary>
+    /// <param name="categoryId">Optional category filter.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A read-only list of downloads.</returns>
+    Task<IReadOnlyList<Download>> ListByCategoryAsync(int? categoryId, CancellationToken ct);
+
+    /// <summary>
+    /// Finds a download category by its primary key.
+    /// </summary>
+    /// <param name="id">The category identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching <see cref="DownloadCategory"/>, or <see langword="null"/> if not found.</returns>
+    Task<DownloadCategory?> FindCategoryByIdAsync(int id, CancellationToken ct);
+
+    /// <summary>
+    /// Stages a new category for insertion on the next <c>SaveChanges</c> call.
+    /// </summary>
+    /// <param name="category">The category to add.</param>
+    void AddCategory(DownloadCategory category);
+
+    /// <summary>
+    /// Stages a category for deletion on the next <c>SaveChanges</c> call.
+    /// </summary>
+    /// <param name="category">The category to remove.</param>
+    void RemoveCategory(DownloadCategory category);
+
+    /// <summary>
+    /// Returns all download categories ordered by name.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A read-only list of all categories.</returns>
+    Task<IReadOnlyList<DownloadCategory>> ListCategoriesAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Counts the number of downloads in a specific category.
+    /// </summary>
+    /// <param name="categoryId">The category identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of downloads in the category.</returns>
+    Task<int> CountByCategoryIdAsync(int categoryId, CancellationToken ct);
+}

--- a/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
@@ -165,6 +165,7 @@ public static class DependencyInjection
         services.AddScoped<IKbCategoryRepository, KbCategoryRepository>();
         services.AddScoped<INetworkIssueRepository, NetworkIssueRepository>();
         services.AddScoped<IPredefinedReplyRepository, PredefinedReplyRepository>();
+        services.AddScoped<IDownloadRepository, DownloadRepository>();
 
         // Notifications
         services.Configure<SmtpSettings>(configuration.GetSection("Smtp"));

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260601172314_AddDownloadsModule.Designer.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260601172314_AddDownloadsModule.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Innovayse.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Innovayse.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260601172314_AddDownloadsModule")]
+    partial class AddDownloadsModule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260601172314_AddDownloadsModule.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260601172314_AddDownloadsModule.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Innovayse.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadsModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "download_categories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    IsHidden = table.Column<bool>(type: "boolean", nullable: false),
+                    ParentCategoryId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_download_categories", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "downloads",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    Type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Filename = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    CategoryId = table.Column<int>(type: "integer", nullable: false),
+                    DownloadCount = table.Column<int>(type: "integer", nullable: false),
+                    ClientsOnly = table.Column<bool>(type: "boolean", nullable: false),
+                    ProductDownload = table.Column<bool>(type: "boolean", nullable: false),
+                    IsHidden = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_downloads", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_downloads_download_categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "download_categories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_download_categories_ParentCategoryId",
+                table: "download_categories",
+                column: "ParentCategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_downloads_CategoryId",
+                table: "downloads",
+                column: "CategoryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "downloads");
+
+            migrationBuilder.DropTable(
+                name: "download_categories");
+        }
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/AppDbContext.cs
@@ -121,6 +121,12 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : Ident
     /// <summary>Gets the server groups table.</summary>
     public DbSet<ServerGroup> ServerGroups => Set<ServerGroup>();
 
+    /// <summary>Gets the download categories table.</summary>
+    public DbSet<DownloadCategory> DownloadCategories => Set<DownloadCategory>();
+
+    /// <summary>Gets the downloads table.</summary>
+    public DbSet<Download> Downloads => Set<Download>();
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Innovayse.Infrastructure/Persistence/Configurations/DownloadCategoryConfiguration.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/Configurations/DownloadCategoryConfiguration.cs
@@ -1,0 +1,23 @@
+namespace Innovayse.Infrastructure.Persistence.Configurations;
+
+using Innovayse.Domain.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>EF Core table configuration for <see cref="DownloadCategory"/>.</summary>
+public sealed class DownloadCategoryConfiguration : IEntityTypeConfiguration<DownloadCategory>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<DownloadCategory> builder)
+    {
+        builder.ToTable("download_categories");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(255);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+        builder.Property(x => x.IsHidden).IsRequired();
+        builder.Property(x => x.ParentCategoryId);
+
+        builder.HasIndex(x => x.ParentCategoryId);
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Persistence/Configurations/DownloadConfiguration.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/Configurations/DownloadConfiguration.cs
@@ -1,0 +1,34 @@
+namespace Innovayse.Infrastructure.Persistence.Configurations;
+
+using Innovayse.Domain.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>EF Core table configuration for <see cref="Download"/>.</summary>
+public sealed class DownloadConfiguration : IEntityTypeConfiguration<Download>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Download> builder)
+    {
+        builder.ToTable("downloads");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Title).IsRequired().HasMaxLength(500);
+        builder.Property(x => x.Description).HasColumnType("text");
+        builder.Property(x => x.Type).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.Filename).HasMaxLength(500);
+        builder.Property(x => x.CategoryId).IsRequired();
+        builder.Property(x => x.DownloadCount).IsRequired();
+        builder.Property(x => x.ClientsOnly).IsRequired();
+        builder.Property(x => x.ProductDownload).IsRequired();
+        builder.Property(x => x.IsHidden).IsRequired();
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasOne<DownloadCategory>()
+            .WithMany()
+            .HasForeignKey(x => x.CategoryId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => x.CategoryId);
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Support/DownloadRepository.cs
+++ b/backend/src/Innovayse.Infrastructure/Support/DownloadRepository.cs
@@ -1,0 +1,56 @@
+namespace Innovayse.Infrastructure.Support;
+
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Interfaces;
+using Innovayse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>EF Core implementation of <see cref="IDownloadRepository"/>.</summary>
+/// <param name="db">The application database context.</param>
+public sealed class DownloadRepository(AppDbContext db) : IDownloadRepository
+{
+    /// <inheritdoc/>
+    public async Task<Download?> FindByIdAsync(int id, CancellationToken ct) =>
+        await db.Downloads.FirstOrDefaultAsync(d => d.Id == id, ct);
+
+    /// <inheritdoc/>
+    public void Add(Download download) => db.Downloads.Add(download);
+
+    /// <inheritdoc/>
+    public void Remove(Download download) => db.Downloads.Remove(download);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Download>> ListByCategoryAsync(int? categoryId, CancellationToken ct)
+    {
+        var query = db.Downloads.AsQueryable();
+
+        if (categoryId.HasValue)
+        {
+            query = query.Where(d => d.CategoryId == categoryId.Value);
+        }
+
+        return await query
+            .OrderByDescending(d => d.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DownloadCategory?> FindCategoryByIdAsync(int id, CancellationToken ct) =>
+        await db.DownloadCategories.FirstOrDefaultAsync(c => c.Id == id, ct);
+
+    /// <inheritdoc/>
+    public void AddCategory(DownloadCategory category) => db.DownloadCategories.Add(category);
+
+    /// <inheritdoc/>
+    public void RemoveCategory(DownloadCategory category) => db.DownloadCategories.Remove(category);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<DownloadCategory>> ListCategoriesAsync(CancellationToken ct) =>
+        await db.DownloadCategories
+            .OrderBy(c => c.Name)
+            .ToListAsync(ct);
+
+    /// <inheritdoc/>
+    public async Task<int> CountByCategoryIdAsync(int categoryId, CancellationToken ct) =>
+        await db.Downloads.CountAsync(d => d.CategoryId == categoryId, ct);
+}


### PR DESCRIPTION
## Summary

Adds the Downloads sub-page (Phase 6) to the admin Support section, completing
the full Support module. Admins can manage downloadable file categories and files
with nested navigation, matching the WHMCS reference design. Categories support
nesting via parent category, visibility control (hidden from clients), and
downloads track metadata (type, filename, permissions, download count) with
file upload support to be wired up later.

## Related Issue

Closes #

## Changes

- Created `DownloadCategory` and `Download` domain entities with factory methods
- Created `IDownloadRepository` interface and EF Core implementation
- Added EF configurations for `download_categories` and `downloads` tables
- Added 6 command/handler pairs: Create/Update/Delete for both categories and downloads
- Added 3 query/handler pairs: ListDownloadCategories (with counts), ListDownloads (filterable by category), GetDownload
- Created `DownloadsController` at `api/downloads` with 9 endpoints (full CRUD for categories + files)
- Created 4 request DTOs for create/update operations
- Registered `IDownloadRepository` in DI and added DbSets to `AppDbContext`
- Added EF migration `AddDownloadsModule`
- Rewrote `DownloadsView.vue` from placeholder to full implementation (1159 lines)
- Built tabbed UI (Add Category / Add Download) with forms, nested breadcrumb navigation, category grid, file list, edit/delete modals
- Fixed API route paths from `/admin/downloads` to `/downloads`

## Checklist

- [x] Code follows the style rules (`rules/` folder)
- [x] `dotnet format` run (backend changes)
- [x] XML docs added to all new C# members
- [x] JSDoc added to all new exported TypeScript/Vue functions
- [x] No hardcoded secrets or credentials
- [x] Tested locally

