### PR TITLE
Track IP address and device info on client registration

### DIFF
--- a/backend/src/Innovayse.API/Auth/AuthController.cs
+++ b/backend/src/Innovayse.API/Auth/AuthController.cs
@@ -64,8 +64,13 @@ public sealed class AuthController(IMessageBus bus, IUserService userService, IC
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> RegisterAsync([FromBody] RegisterRequest request, CancellationToken ct)
     {
+        var ipAddress = Request.Headers["X-Forwarded-For"].FirstOrDefault()
+            ?? HttpContext.Connection.RemoteIpAddress?.ToString();
+        var userAgent = Request.Headers["X-Real-User-Agent"].FirstOrDefault()
+            ?? Request.Headers.UserAgent.ToString();
+
         var result = await bus.InvokeAsync<AuthWithRefreshDto>(
-            new RegisterCommand(request.Email, request.Password, request.FirstName, request.LastName), ct);
+            new RegisterCommand(request.Email, request.Password, request.FirstName, request.LastName, ipAddress, userAgent), ct);
 
         SetRefreshTokenCookie(result.RefreshToken);
         return Ok(result.Auth);

--- a/backend/src/Innovayse.Application/Auth/Commands/Register/RegisterCommand.cs
+++ b/backend/src/Innovayse.Application/Auth/Commands/Register/RegisterCommand.cs
@@ -8,4 +8,6 @@ namespace Innovayse.Application.Auth.Commands.Register;
 /// <param name="Password">Plain-text password. Will be hashed by Identity.</param>
 /// <param name="FirstName">User's first name.</param>
 /// <param name="LastName">User's last name.</param>
-public record RegisterCommand(string Email, string Password, string FirstName, string LastName);
+/// <param name="IpAddress">IP address from the registration request; null if unavailable.</param>
+/// <param name="UserAgent">Browser/device user-agent from the registration request; null if unavailable.</param>
+public record RegisterCommand(string Email, string Password, string FirstName, string LastName, string? IpAddress = null, string? UserAgent = null);

--- a/backend/src/Innovayse.Application/Auth/Commands/Register/RegisterHandler.cs
+++ b/backend/src/Innovayse.Application/Auth/Commands/Register/RegisterHandler.cs
@@ -44,7 +44,12 @@ public sealed class RegisterHandler(
         await refreshTokenRepo.AddAsync(userId, refreshToken, refreshExpiresAt, ct);
         await uow.SaveChangesAsync(ct);
 
-        await bus.PublishAsync(new ClientRegisteredIntegrationEvent(userId, cmd.Email, cmd.FirstName, cmd.LastName));
+        var parsed = UserAgentParser.Parse(cmd.UserAgent);
+
+        await bus.PublishAsync(new ClientRegisteredIntegrationEvent(
+            userId, cmd.Email, cmd.FirstName, cmd.LastName,
+            cmd.IpAddress, cmd.UserAgent,
+            parsed?.DeviceType, parsed?.OperatingSystem, parsed?.Browser));
 
         return new AuthWithRefreshDto(new AuthResultDto(accessToken, expiresAt, Roles.Client), refreshToken);
     }

--- a/backend/src/Innovayse.Application/Auth/Events/ClientRegisteredIntegrationEvent.cs
+++ b/backend/src/Innovayse.Application/Auth/Events/ClientRegisteredIntegrationEvent.cs
@@ -8,4 +8,18 @@ namespace Innovayse.Application.Auth.Events;
 /// <param name="Email">The new user's email address.</param>
 /// <param name="FirstName">The user's first name.</param>
 /// <param name="LastName">The user's last name.</param>
-public record ClientRegisteredIntegrationEvent(string UserId, string Email, string FirstName, string LastName);
+/// <param name="IpAddress">IP address captured during registration; null if unavailable.</param>
+/// <param name="UserAgent">Raw browser/device user-agent captured during registration; null if unavailable.</param>
+/// <param name="DeviceType">Parsed device type (Desktop, Mobile, Tablet); null if unavailable.</param>
+/// <param name="OperatingSystem">Parsed OS from user-agent; null if unavailable.</param>
+/// <param name="Browser">Parsed browser name and version; null if unavailable.</param>
+public record ClientRegisteredIntegrationEvent(
+    string UserId,
+    string Email,
+    string FirstName,
+    string LastName,
+    string? IpAddress = null,
+    string? UserAgent = null,
+    string? DeviceType = null,
+    string? OperatingSystem = null,
+    string? Browser = null);

--- a/backend/src/Innovayse.Application/Clients/Events/CreateClientOnRegisterHandler.cs
+++ b/backend/src/Innovayse.Application/Clients/Events/CreateClientOnRegisterHandler.cs
@@ -28,7 +28,9 @@ public sealed class CreateClientOnRegisterHandler(IClientRepository clientRepo, 
             return;
         }
 
-        var client = Client.Create(evt.UserId, evt.FirstName, evt.LastName, evt.Email);
+        var client = Client.Create(evt.UserId, evt.FirstName, evt.LastName, evt.Email,
+            registrationIp: evt.IpAddress, registrationUserAgent: evt.UserAgent,
+            deviceType: evt.DeviceType, operatingSystem: evt.OperatingSystem, browser: evt.Browser);
         clientRepo.Add(client);
         await uow.SaveChangesAsync(ct);
     }

--- a/backend/src/Innovayse.Application/Common/UserAgentParser.cs
+++ b/backend/src/Innovayse.Application/Common/UserAgentParser.cs
@@ -1,0 +1,211 @@
+namespace Innovayse.Application.Common;
+
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Lightweight user-agent string parser that extracts device type, OS, and browser.
+/// No external dependencies — uses simple regex matching on known patterns.
+/// </summary>
+public static partial class UserAgentParser
+{
+    /// <summary>Parsed result from a user-agent string.</summary>
+    /// <param name="DeviceType">Desktop, Mobile, or Tablet.</param>
+    /// <param name="OperatingSystem">OS name and version (e.g. "Windows 11", "iOS 17.5").</param>
+    /// <param name="Browser">Browser name and version (e.g. "Chrome 148.0", "Safari 17.5").</param>
+    public record ParsedUserAgent(string DeviceType, string OperatingSystem, string Browser);
+
+    /// <summary>
+    /// Parses a user-agent string into device type, OS, and browser.
+    /// </summary>
+    /// <param name="userAgent">Raw user-agent string.</param>
+    /// <returns>Parsed result, or null if the input is null or empty.</returns>
+    public static ParsedUserAgent? Parse(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return null;
+        }
+
+        var deviceType = ParseDeviceType(userAgent);
+        var os = ParseOperatingSystem(userAgent);
+        var browser = ParseBrowser(userAgent);
+
+        return new ParsedUserAgent(deviceType, os, browser);
+    }
+
+    /// <summary>Determines whether the device is Mobile, Tablet, or Desktop.</summary>
+    /// <param name="ua">Raw user-agent string.</param>
+    /// <returns>Device type string.</returns>
+    private static string ParseDeviceType(string ua)
+    {
+        if (TabletRegex().IsMatch(ua))
+        {
+            return "Tablet";
+        }
+
+        if (MobileRegex().IsMatch(ua))
+        {
+            return "Mobile";
+        }
+
+        return "Desktop";
+    }
+
+    /// <summary>Extracts the operating system name and version from the user-agent.</summary>
+    /// <param name="ua">Raw user-agent string.</param>
+    /// <returns>OS description string.</returns>
+    private static string ParseOperatingSystem(string ua)
+    {
+        // iOS
+        var match = IosRegex().Match(ua);
+        if (match.Success)
+        {
+            var version = match.Groups[1].Value.Replace('_', '.');
+            return $"iOS {version}";
+        }
+
+        // Android
+        match = AndroidRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Android {match.Groups[1].Value}";
+        }
+
+        // Windows
+        match = WindowsNtRegex().Match(ua);
+        if (match.Success)
+        {
+            var ntVersion = match.Groups[1].Value;
+            var windowsName = ntVersion switch
+            {
+                "10.0" => "Windows 10/11",
+                "6.3" => "Windows 8.1",
+                "6.2" => "Windows 8",
+                "6.1" => "Windows 7",
+                "6.0" => "Windows Vista",
+                _ => $"Windows NT {ntVersion}",
+            };
+            return windowsName;
+        }
+
+        // macOS
+        match = MacOsRegex().Match(ua);
+        if (match.Success)
+        {
+            var version = match.Groups[1].Value.Replace('_', '.');
+            return $"macOS {version}";
+        }
+
+        // Chrome OS
+        if (ua.Contains("CrOS", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Chrome OS";
+        }
+
+        // Linux
+        if (ua.Contains("Linux", StringComparison.OrdinalIgnoreCase))
+        {
+            return ua.Contains("x86_64", StringComparison.Ordinal) ? "Linux x86_64" : "Linux";
+        }
+
+        return "Unknown OS";
+    }
+
+    /// <summary>Extracts the browser name and version from the user-agent.</summary>
+    /// <param name="ua">Raw user-agent string.</param>
+    /// <returns>Browser description string.</returns>
+    private static string ParseBrowser(string ua)
+    {
+        // Edge (must check before Chrome since Edge UA contains "Chrome")
+        var match = EdgeRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Edge {match.Groups[1].Value}";
+        }
+
+        // Opera / OPR
+        match = OperaRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Opera {match.Groups[1].Value}";
+        }
+
+        // Samsung Browser
+        match = SamsungBrowserRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Samsung Browser {match.Groups[1].Value}";
+        }
+
+        // Firefox
+        match = FirefoxRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Firefox {match.Groups[1].Value}";
+        }
+
+        // Chrome (check after Edge/Opera/Samsung since they include "Chrome")
+        match = ChromeRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Chrome {match.Groups[1].Value}";
+        }
+
+        // Safari (check last since many browsers include "Safari")
+        match = SafariVersionRegex().Match(ua);
+        if (match.Success)
+        {
+            return $"Safari {match.Groups[1].Value}";
+        }
+
+        return "Unknown Browser";
+    }
+
+    /// <summary>Regex for detecting tablet devices.</summary>
+    [GeneratedRegex(@"iPad|Android(?!.*Mobile)|Tablet", RegexOptions.IgnoreCase)]
+    private static partial Regex TabletRegex();
+
+    /// <summary>Regex for detecting mobile devices.</summary>
+    [GeneratedRegex(@"Mobile|iPhone|iPod|Android.*Mobile|Windows Phone|BlackBerry|Opera Mini|IEMobile", RegexOptions.IgnoreCase)]
+    private static partial Regex MobileRegex();
+
+    /// <summary>Regex for extracting iOS version.</summary>
+    [GeneratedRegex(@"CPU (?:iPhone )?OS (\d+[_\.]\d+(?:[_\.]\d+)?)", RegexOptions.IgnoreCase)]
+    private static partial Regex IosRegex();
+
+    /// <summary>Regex for extracting Android version.</summary>
+    [GeneratedRegex(@"Android (\d+(?:\.\d+)?)", RegexOptions.IgnoreCase)]
+    private static partial Regex AndroidRegex();
+
+    /// <summary>Regex for extracting Windows NT version.</summary>
+    [GeneratedRegex(@"Windows NT (\d+\.\d+)")]
+    private static partial Regex WindowsNtRegex();
+
+    /// <summary>Regex for extracting macOS version.</summary>
+    [GeneratedRegex(@"Mac OS X (\d+[_\.]\d+(?:[_\.]\d+)?)")]
+    private static partial Regex MacOsRegex();
+
+    /// <summary>Regex for extracting Edge version.</summary>
+    [GeneratedRegex(@"Edg(?:e|A|iOS)?/(\d+[\.\d]*)")]
+    private static partial Regex EdgeRegex();
+
+    /// <summary>Regex for extracting Opera version.</summary>
+    [GeneratedRegex(@"(?:OPR|Opera)/(\d+[\.\d]*)")]
+    private static partial Regex OperaRegex();
+
+    /// <summary>Regex for extracting Samsung Browser version.</summary>
+    [GeneratedRegex(@"SamsungBrowser/(\d+[\.\d]*)")]
+    private static partial Regex SamsungBrowserRegex();
+
+    /// <summary>Regex for extracting Firefox version.</summary>
+    [GeneratedRegex(@"Firefox/(\d+[\.\d]*)")]
+    private static partial Regex FirefoxRegex();
+
+    /// <summary>Regex for extracting Chrome version.</summary>
+    [GeneratedRegex(@"Chrome/(\d+[\.\d]*)")]
+    private static partial Regex ChromeRegex();
+
+    /// <summary>Regex for extracting Safari version.</summary>
+    [GeneratedRegex(@"Version/(\d+[\.\d]*).*Safari")]
+    private static partial Regex SafariVersionRegex();
+}

--- a/backend/src/Innovayse.Domain/Clients/Client.cs
+++ b/backend/src/Innovayse.Domain/Clients/Client.cs
@@ -117,6 +117,21 @@ public sealed class Client : AggregateRoot
     /// <summary>Gets the UTC timestamp when the client account was created.</summary>
     public DateTimeOffset CreatedAt { get; private set; }
 
+    /// <summary>Gets the IP address captured during self-registration, or <see langword="null"/> for admin-created clients.</summary>
+    public string? RegistrationIp { get; private set; }
+
+    /// <summary>Gets the raw browser/device user-agent captured during self-registration, or <see langword="null"/> for admin-created clients.</summary>
+    public string? RegistrationUserAgent { get; private set; }
+
+    /// <summary>Gets the device type (Desktop, Mobile, Tablet) parsed from the user-agent, or <see langword="null"/> for admin-created clients.</summary>
+    public string? DeviceType { get; private set; }
+
+    /// <summary>Gets the operating system parsed from the user-agent, or <see langword="null"/> for admin-created clients.</summary>
+    public string? OperatingSystem { get; private set; }
+
+    /// <summary>Gets the browser name and version parsed from the user-agent, or <see langword="null"/> for admin-created clients.</summary>
+    public string? Browser { get; private set; }
+
     /// <summary>Gets the additional contacts linked to this client.</summary>
     public IReadOnlyList<Contact> Contacts => _contacts.AsReadOnly();
 
@@ -134,8 +149,13 @@ public sealed class Client : AggregateRoot
     /// <param name="lastName">The client's last name.</param>
     /// <param name="email">The client's email address (used for the domain event).</param>
     /// <param name="companyName">Optional company name.</param>
+    /// <param name="registrationIp">IP address from self-registration; null for admin-created clients.</param>
+    /// <param name="registrationUserAgent">Raw user-agent from self-registration; null for admin-created clients.</param>
+    /// <param name="deviceType">Parsed device type (Desktop, Mobile, Tablet); null for admin-created clients.</param>
+    /// <param name="operatingSystem">Parsed OS name from user-agent; null for admin-created clients.</param>
+    /// <param name="browser">Parsed browser name and version; null for admin-created clients.</param>
     /// <returns>A new, unpersisted <see cref="Client"/> instance.</returns>
-    public static Client Create(string userId, string firstName, string lastName, string email, string? companyName = null)
+    public static Client Create(string userId, string firstName, string lastName, string email, string? companyName = null, string? registrationIp = null, string? registrationUserAgent = null, string? deviceType = null, string? operatingSystem = null, string? browser = null)
     {
         var client = new Client
         {
@@ -144,7 +164,12 @@ public sealed class Client : AggregateRoot
             LastName = lastName,
             CompanyName = companyName,
             Status = ClientStatus.Active,
-            CreatedAt = DateTimeOffset.UtcNow
+            CreatedAt = DateTimeOffset.UtcNow,
+            RegistrationIp = registrationIp,
+            RegistrationUserAgent = registrationUserAgent,
+            DeviceType = deviceType,
+            OperatingSystem = operatingSystem,
+            Browser = browser,
         };
 
         // ClientId is 0 here — EF Core assigns the real Id after SaveChanges.

--- a/backend/src/Innovayse.Infrastructure/Clients/Configurations/ClientConfiguration.cs
+++ b/backend/src/Innovayse.Infrastructure/Clients/Configurations/ClientConfiguration.cs
@@ -45,6 +45,12 @@ public sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
 
         builder.Property(x => x.CreatedAt).IsRequired();
 
+        builder.Property(x => x.RegistrationIp).HasMaxLength(45);
+        builder.Property(x => x.RegistrationUserAgent).HasMaxLength(500);
+        builder.Property(x => x.DeviceType).HasMaxLength(20);
+        builder.Property(x => x.OperatingSystem).HasMaxLength(50);
+        builder.Property(x => x.Browser).HasMaxLength(50);
+
         builder.Ignore(x => x.DomainEvents);
 
         builder.HasMany(x => x.Contacts)

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260603103248_AddClientRegistrationTracking.Designer.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260603103248_AddClientRegistrationTracking.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Innovayse.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Innovayse.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603103248_AddClientRegistrationTracking")]
+    partial class AddClientRegistrationTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -402,10 +405,6 @@ namespace Innovayse.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("character varying(256)");
 
-                    b.Property<string>("Browser")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
                     b.Property<string>("City")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
@@ -429,10 +428,6 @@ namespace Innovayse.Infrastructure.Migrations
                     b.Property<string>("Currency")
                         .HasMaxLength(3)
                         .HasColumnType("character varying(3)");
-
-                    b.Property<string>("DeviceType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<bool>("DisableCcProcessing")
                         .HasColumnType("boolean");
@@ -470,10 +465,6 @@ namespace Innovayse.Infrastructure.Migrations
 
                     b.Property<bool>("NotifySupport")
                         .HasColumnType("boolean");
-
-                    b.Property<string>("OperatingSystem")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
 
                     b.Property<bool>("OverdueNotices")
                         .HasColumnType("boolean");

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260603103248_AddClientRegistrationTracking.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260603103248_AddClientRegistrationTracking.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Innovayse.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClientRegistrationTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RegistrationIp",
+                table: "clients",
+                type: "character varying(45)",
+                maxLength: 45,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RegistrationUserAgent",
+                table: "clients",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RegistrationIp",
+                table: "clients");
+
+            migrationBuilder.DropColumn(
+                name: "RegistrationUserAgent",
+                table: "clients");
+        }
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260603115605_AddClientDeviceInfo.Designer.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260603115605_AddClientDeviceInfo.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Innovayse.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Innovayse.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603115605_AddClientDeviceInfo")]
+    partial class AddClientDeviceInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260603115605_AddClientDeviceInfo.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260603115605_AddClientDeviceInfo.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Innovayse.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClientDeviceInfo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Browser",
+                table: "clients",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceType",
+                table: "clients",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OperatingSystem",
+                table: "clients",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Browser",
+                table: "clients");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceType",
+                table: "clients");
+
+            migrationBuilder.DropColumn(
+                name: "OperatingSystem",
+                table: "clients");
+        }
+    }
+}

--- a/client/server/api/portal/auth/register.post.ts
+++ b/client/server/api/portal/auth/register.post.ts
@@ -15,9 +15,16 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
+    const clientIp = getRequestIP(event, { xForwardedFor: true }) ?? ''
+    const clientUserAgent = getRequestHeader(event, 'user-agent') ?? ''
+
     return await internalApiCall<Record<string, unknown>>(event, '/auth/register', {
       method: 'POST',
-      body: { firstName: firstname, lastName: lastname, email, password }
+      body: { firstName: firstname, lastName: lastname, email, password },
+      headers: {
+        'X-Forwarded-For': clientIp,
+        'X-Real-User-Agent': clientUserAgent,
+      },
     })
   } catch (err: unknown) {
     const e = err as { statusCode?: number; statusMessage?: string }

--- a/client/server/utils/api.ts
+++ b/client/server/utils/api.ts
@@ -29,6 +29,7 @@ export async function internalApiCall<T>(
   options: {
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
     body?: unknown
+    headers?: Record<string, string>
   } = {}
 ): Promise<T> {
   const config = useRuntimeConfig()
@@ -37,6 +38,7 @@ export async function internalApiCall<T>(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    ...options.headers,
   }
 
   if (token) {


### PR DESCRIPTION
## Summary

- Capture client IP address, raw user-agent, and parsed device info (device type, OS, browser) during self-registration
- Forward real client IP and User-Agent from Nuxt server proxy to backend via `X-Forwarded-For` and `X-Real-User-Agent` headers
- Parse user-agent server-side into separate DB columns using a lightweight regex-based `UserAgentParser`
- Admin-created clients have all tracking fields set to null (only self-registration is tracked)

## Test plan

- [x] Register from desktop browser → DB stores: `Desktop`, `Linux x86_64`, `Chrome 148.0.0.0`, client IP, raw UA
- [x] Admin-created clients → all 5 registration tracking fields are `null`
- [x] `dotnet build` — 0 errors
- [x] Nuxt proxy correctly forwards real browser User-Agent (not `node`)
- [x] Nuxt proxy correctly forwards client IP via `X-Forwarded-For`
- [x] Backend falls back to `RemoteIpAddress` and `User-Agent` header when forwarded headers are absent (direct API calls)

Fixes #15