### PR TITLE
feat: implement 19 report views with real backend data

### DIFF
--- a/admin/src/components/DateRangePicker.vue
+++ b/admin/src/components/DateRangePicker.vue
@@ -18,6 +18,24 @@ const currentMonth = ref(new Date())
 
 const popupRef = ref<HTMLElement | null>(null)
 const inputRef = ref<HTMLInputElement | null>(null)
+const wrapperRef = ref<HTMLElement | null>(null)
+
+const popupStyle = ref({ top: '0px', left: '0px' })
+
+function updatePopupPosition() {
+  if (!wrapperRef.value) return
+  const rect = wrapperRef.value.getBoundingClientRect()
+  const popupWidth = Math.min(900, window.innerWidth - 32)
+  let left = rect.left
+  if (left + popupWidth > window.innerWidth - 16) {
+    left = window.innerWidth - popupWidth - 16
+  }
+  if (left < 8) left = 8
+  popupStyle.value = {
+    top: `${rect.bottom + window.scrollY + 8}px`,
+    left: `${left}px`,
+  }
+}
 const inputText = ref('')
 const previewStart = ref<Date | null>(null)
 const previewEnd = ref<Date | null>(null)
@@ -99,7 +117,10 @@ onUnmounted(() => {
 })
 
 const handleClickOutside = (e: MouseEvent) => {
-  if (popupRef.value && !popupRef.value.contains(e.target as Node)) {
+  if (
+    popupRef.value && !popupRef.value.contains(e.target as Node) &&
+    wrapperRef.value && !wrapperRef.value.contains(e.target as Node)
+  ) {
     isOpen.value = false
   }
 }
@@ -409,21 +430,22 @@ const dayNames = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 </script>
 
 <template>
-  <div class="relative" ref="popupRef">
+  <div class="relative" ref="wrapperRef">
     <!-- Input field -->
     <input
       ref="inputRef"
       v-model="inputText"
       type="text"
       placeholder="DD/MM/YYYY - DD/MM/YYYY"
-      @click="isOpen = true"
+      @click="() => { updatePopupPosition(); isOpen = true }"
       @input="handleInput"
-      @focus="isOpen = true"
+      @focus="() => { updatePopupPosition(); isOpen = true }"
       class="w-full px-3 py-2 text-[0.82rem] text-text-primary bg-white/[0.05] border border-border rounded-[9px] focus:outline-none focus:border-primary-500/40 transition-colors"
     />
 
-    <!-- Popup -->
-    <div v-if="isOpen" class="absolute top-full mt-2 left-0 z-50 bg-surface-card rounded-[10px] shadow-2xl p-0 w-[900px] max-w-[calc(100vw-4rem)] border border-border">
+    <!-- Popup teleported to body -->
+    <Teleport to="body">
+    <div v-if="isOpen" ref="popupRef" :style="{ position: 'fixed', top: popupStyle.top, left: popupStyle.left, width: '900px', maxWidth: 'calc(100vw - 32px)' }" class="z-[9999] bg-surface-card rounded-[10px] shadow-2xl p-0 border border-border">
       <div class="flex h-[400px]">
         <!-- Left sidebar with presets -->
         <div class="w-[150px] border-r border-border p-4 flex flex-col gap-2">
@@ -519,5 +541,6 @@ const dayNames = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
         </div>
       </div>
     </div>
+    </Teleport>
   </div>
 </template>

--- a/admin/src/components/FieldSelector.vue
+++ b/admin/src/components/FieldSelector.vue
@@ -82,6 +82,11 @@ onUnmounted(() => document.removeEventListener('mousedown', onOutsideClick))
             </label>
           </div>
         </div>
+
+        <!-- Apply -->
+        <div class="px-3 pb-3 pt-1 border-t border-border flex justify-end">
+          <button type="button" class="px-3 py-1 gradient-brand text-white text-[0.72rem] font-semibold rounded-[7px] transition-opacity hover:opacity-90" @click="open = false">Apply</button>
+        </div>
       </div>
     </Transition>
   </div>

--- a/admin/src/modules/reports/views/AnnualIncomeView.vue
+++ b/admin/src/modules/reports/views/AnnualIncomeView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { Bar } from 'vue-chartjs'
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
 
@@ -76,5 +77,6 @@ onMounted(load)
         <span class="text-status-green font-medium">${{ row.amount.toFixed(2) }}</span>
       </div>
     </div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ClientReportView.vue
+++ b/admin/src/modules/reports/views/ClientReportView.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import ReportComingSoon from '../components/ReportComingSoon.vue'
 </script>
 
 <template>
   <ReportPage title="Client">
     <ReportComingSoon />
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ClientStatementView.vue
+++ b/admin/src/modules/reports/views/ClientStatementView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppClientSelect from '../../../components/AppClientSelect.vue'
 import DateRangePicker from '../../../components/DateRangePicker.vue'
 import { useApi } from '../../../composables/useApi'
@@ -101,5 +102,6 @@ onMounted(loadClients)
 
       <div class="text-[0.68rem] text-text-muted mt-4 text-right">Report Generated at {{ new Date().toLocaleString() }}</div>
     </template>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ClientsByCountryView.vue
+++ b/admin/src/modules/reports/views/ClientsByCountryView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { Bar } from 'vue-chartjs'
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import WorldMap from '../components/WorldMap.vue'
 import { useApi } from '../../../composables/useApi'
 
@@ -138,5 +139,6 @@ onMounted(load)
       </div>
       <div class="text-[0.68rem] text-text-muted">Report Generated at {{ new Date().toLocaleString() }}</div>
     </div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ClientsReportView.vue
+++ b/admin/src/modules/reports/views/ClientsReportView.vue
@@ -1,10 +1,189 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import FilterCard from '../../../components/FilterCard.vue'
+import AdvancedFilters, { type FilterRow, type FieldOption } from '../../../components/AdvancedFilters.vue'
+import FieldSelector from '../../../components/FieldSelector.vue'
+import DateRangePicker from '../../../components/DateRangePicker.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+interface ClientRow {
+  id: number; firstName: string; lastName: string; companyName: string | null
+  email: string; address1: string | null; address2: string | null; city: string | null
+  state: string | null; postCode: string | null; country: string | null; phone: string | null
+  currency: string | null; creditBalance: number; status: string; createdAt: string; notes: string | null
+}
+const rows = ref<ClientRow[]>([])
+const totalCount = ref(0)
+
+const filterFields: FieldOption[] = [
+  { value: 'firstName', label: 'First Name' },
+  { value: 'lastName', label: 'Last Name' },
+  { value: 'companyName', label: 'Company Name' },
+  { value: 'email', label: 'Email' },
+  { value: 'country', label: 'Country' },
+  { value: 'city', label: 'City' },
+  { value: 'phone', label: 'Phone Number' },
+  { value: 'currency', label: 'Currency' },
+  { value: 'status', label: 'Status' },
+]
+
+const activeFilters = ref<FilterRow[]>([])
+const createdRange = ref<[string, string] | null>(null)
+const page = ref(1); const pageSize = 50
+
+const allColumns = [
+  { key: 'id', label: 'ID' },
+  { key: 'firstName', label: 'First Name' },
+  { key: 'lastName', label: 'Last Name' },
+  { key: 'companyName', label: 'Company Name' },
+  { key: 'email', label: 'Email' },
+  { key: 'address1', label: 'Address 1' },
+  { key: 'address2', label: 'Address 2' },
+  { key: 'city', label: 'City' },
+  { key: 'state', label: 'State' },
+  { key: 'postCode', label: 'Postcode' },
+  { key: 'country', label: 'Country' },
+  { key: 'phone', label: 'Phone Number' },
+  { key: 'currency', label: 'Currency' },
+  { key: 'creditBalance', label: 'Credit' },
+  { key: 'status', label: 'Status' },
+  { key: 'createdAt', label: 'Creation Date' },
+  { key: 'notes', label: 'Notes' },
+] as const
+
+type ColKey = typeof allColumns[number]['key']
+const visibleCols = ref<Set<ColKey>>(new Set())
+
+const activeCols = computed(() => allColumns.filter(c => visibleCols.value.has(c.key)))
+const totalPages = computed(() => Math.ceil(totalCount.value / pageSize))
+
+function toggleCol(key: string) {
+  const k = key as ColKey
+  if (visibleCols.value.has(k)) visibleCols.value.delete(k)
+  else visibleCols.value.add(k)
+}
+function selectAllCols() { allColumns.forEach(c => visibleCols.value.add(c.key)) }
+function clearAllCols() { visibleCols.value.clear() }
+
+function cellValue(row: ClientRow, key: ColKey): string {
+  const v = row[key]
+  if (v == null || v === '') return '—'
+  if (key === 'creditBalance') return `$${(v as number).toFixed(2)}`
+  return String(v)
+}
+
+const statusBg = (s: string) => ({
+  Active: 'bg-status-green/10 text-status-green',
+  Inactive: 'bg-gray-500/10 text-gray-400',
+  Suspended: 'bg-status-red/10 text-status-red',
+}[s] ?? 'text-text-secondary')
+
+function buildParams(): string {
+  const p = new URLSearchParams()
+  const statusFilter = activeFilters.value.find(f => f.field === 'status')
+  if (statusFilter) p.set('status', statusFilter.value)
+  const countryFilter = activeFilters.value.find(f => f.field === 'country')
+  if (countryFilter) p.set('country', countryFilter.value)
+  if (createdRange.value) { p.set('createdFrom', createdRange.value[0]); p.set('createdTo', createdRange.value[1]) }
+  p.set('page', String(page.value))
+  p.set('pageSize', String(pageSize))
+  return p.toString()
+}
+
+function applyLocalFilters(items: ClientRow[]): ClientRow[] {
+  return items.filter(row => {
+    for (const f of activeFilters.value) {
+      if (f.field === 'status' || f.field === 'country') continue
+      const rowVal = String(row[f.field as ColKey] ?? '').toLowerCase()
+      const search = f.value.toLowerCase()
+      if (f.condition === 'exact' && rowVal !== search) return false
+      if (f.condition === 'contains' && !rowVal.includes(search)) return false
+    }
+    return true
+  })
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    const data = await request<{ items: ClientRow[]; totalCount: number }>(`/reports/clients?${buildParams()}`)
+    rows.value = applyLocalFilters(data.items)
+    totalCount.value = data.totalCount
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+function applyFilters() { page.value = 1; load() }
+function goPage(p: number) { page.value = p; load() }
+function printReport() { window.print() }
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Clients">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage title="Clients" description="This report can be used to generate a custom export of clients by applying up to 5 filters. CSV Export is available via the Tools menu to the right." :loading :error>
+    <template #filters>
+      <FilterCard>
+        <template #fields>
+          <div class="grid grid-cols-2 gap-3 items-end">
+            <div>
+              <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Fields to Include</label>
+              <FieldSelector :fields="allColumns" :selected="visibleCols" @toggle="toggleCol" @select-all="selectAllCols" @clear-all="clearAllCols" />
+            </div>
+            <div>
+              <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Creation Date Range</label>
+              <DateRangePicker v-model="createdRange" />
+            </div>
+          </div>
+        </template>
+
+        <AdvancedFilters :fields="filterFields" @update:filters="activeFilters = $event" />
+
+        <template #actions>
+          <div class="flex items-center justify-center gap-3 pt-3 border-t border-border/50">
+            <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="applyFilters">Generate</button>
+            <button class="px-4 py-2 bg-white/[0.04] border border-border text-text-secondary text-[0.78rem] font-medium rounded-[9px] hover:bg-white/[0.08] transition-colors" @click="printReport">Print</button>
+          </div>
+        </template>
+      </FilterCard>
+    </template>
+
+    <div class="text-[0.78rem] text-text-secondary mb-3">{{ totalCount }} client(s) found</div>
+
+    <div class="bg-surface-card border border-border rounded-2xl overflow-x-auto">
+      <table class="w-full text-[0.82rem]">
+        <thead>
+          <tr class="border-b border-border bg-white/[0.02]">
+            <th v-for="col in activeCols" :key="col.key" class="px-4 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted whitespace-nowrap">{{ col.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="rows.length === 0 && !loading">
+            <td :colspan="activeCols.length || 1" class="px-4 py-8 text-center text-text-secondary">No clients found. Click Filter to load results.</td>
+          </tr>
+          <tr v-for="row in rows" :key="row.id" class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+            <td v-for="col in activeCols" :key="col.key" class="px-4 py-3 whitespace-nowrap">
+              <span v-if="col.key === 'status'" :class="['text-[0.72rem] px-2 py-0.5 rounded-full font-medium', statusBg(row.status)]">{{ row.status }}</span>
+              <span v-else-if="col.key === 'id'" class="text-text-muted font-mono">#{{ row.id }}</span>
+              <span v-else-if="col.key === 'email'" class="text-primary-400">{{ row.email }}</span>
+              <span v-else :class="['firstName','lastName','companyName'].includes(col.key) ? 'text-text-primary font-medium' : 'text-text-secondary'">{{ cellValue(row, col.key) }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 mt-4">
+      <button v-for="p in totalPages" :key="p"
+        class="px-3 py-1 rounded-lg text-[0.78rem] transition-colors"
+        :class="p === page ? 'bg-primary-500 text-white' : 'bg-white/[0.04] text-text-secondary hover:bg-white/[0.08]'"
+        @click="goPage(p)">{{ p }}</button>
+    </div>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/DailyPerformanceView.vue
+++ b/admin/src/modules/reports/views/DailyPerformanceView.vue
@@ -4,6 +4,7 @@ import { Line } from 'vue-chartjs'
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js'
 import DateRangePicker from '../../../components/DateRangePicker.vue'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import { useApi } from '../../../composables/useApi'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
@@ -92,5 +93,6 @@ onMounted(load)
         <span>{{ row.cancellationRequests }}</span>
       </div>
     </div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/DomainsReportView.vue
+++ b/admin/src/modules/reports/views/DomainsReportView.vue
@@ -1,10 +1,207 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import FilterCard from '../../../components/FilterCard.vue'
+import AdvancedFilters, { type FilterRow, type FieldOption } from '../../../components/AdvancedFilters.vue'
+import FieldSelector from '../../../components/FieldSelector.vue'
+import DateRangePicker from '../../../components/DateRangePicker.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+interface DomainRow {
+  id: number; clientId: number; clientName: string; orderId: number | null; orderType: string
+  domainName: string; firstPaymentAmount: number; recurringAmount: number
+  registrationPeriod: number; registrationDate: string; expiryDate: string
+  nextDueDate: string; registrar: string | null; paymentMethod: string | null
+  status: string; notes: string | null
+}
+const rows = ref<DomainRow[]>([])
+const totalCount = ref(0)
+
+const filterFields: FieldOption[] = [
+  { value: 'domainName', label: 'Domain Name' },
+  { value: 'clientName', label: 'Client Name' },
+  { value: 'registrar', label: 'Registrar' },
+  { value: 'paymentMethod', label: 'Payment Method' },
+  { value: 'status', label: 'Status' },
+  { value: 'orderType', label: 'Reg Type' },
+]
+
+const activeFilters = ref<FilterRow[]>([])
+const registeredRange = ref<[string, string] | null>(null)
+const expiryRange = ref<[string, string] | null>(null)
+const nextDueRange = ref<[string, string] | null>(null)
+const page = ref(1); const pageSize = 50
+
+const allColumns = [
+  { key: 'id', label: 'ID' },
+  { key: 'clientId', label: 'User ID' },
+  { key: 'clientName', label: 'Client Name' },
+  { key: 'orderId', label: 'Order ID' },
+  { key: 'orderType', label: 'Reg Type' },
+  { key: 'domainName', label: 'Domain Name' },
+  { key: 'firstPaymentAmount', label: 'First Payment Amount' },
+  { key: 'recurringAmount', label: 'Recurring Amount' },
+  { key: 'registrationPeriod', label: 'Registration Period' },
+  { key: 'registrationDate', label: 'Registration Date' },
+  { key: 'expiryDate', label: 'Expiry Date' },
+  { key: 'nextDueDate', label: 'Next Due Date' },
+  { key: 'registrar', label: 'Registrar' },
+  { key: 'paymentMethod', label: 'Payment Method' },
+  { key: 'status', label: 'Status' },
+  { key: 'notes', label: 'Notes' },
+] as const
+
+type ColKey = typeof allColumns[number]['key']
+const visibleCols = ref<Set<ColKey>>(new Set())
+
+const activeCols = computed(() => allColumns.filter(c => visibleCols.value.has(c.key)))
+const totalPages = computed(() => Math.ceil(totalCount.value / pageSize))
+
+function toggleCol(key: string) {
+  const k = key as ColKey
+  if (visibleCols.value.has(k)) visibleCols.value.delete(k)
+  else visibleCols.value.add(k)
+}
+function selectAllCols() { allColumns.forEach(c => visibleCols.value.add(c.key)) }
+function clearAllCols() { visibleCols.value.clear() }
+
+function cellValue(row: DomainRow, key: ColKey): string {
+  const v = row[key]
+  if (v == null || v === '') return '—'
+  if (['firstPaymentAmount', 'recurringAmount'].includes(key)) return `$${(v as number).toFixed(2)}`
+  if (key === 'registrationPeriod') return `${v} yr`
+  return String(v)
+}
+
+const statusBg = (s: string) => ({
+  Active: 'bg-status-green/10 text-status-green',
+  Expired: 'bg-status-red/10 text-status-red',
+  Pending: 'bg-status-yellow/10 text-status-yellow',
+  Cancelled: 'bg-gray-500/10 text-gray-400',
+  Transferred: 'bg-blue-500/10 text-blue-400',
+}[s] ?? 'text-text-secondary')
+
+function buildParams(): string {
+  const p = new URLSearchParams()
+  const statusF = activeFilters.value.find(f => f.field === 'status')
+  if (statusF) p.set('status', statusF.value)
+  const registrarF = activeFilters.value.find(f => f.field === 'registrar')
+  if (registrarF) p.set('registrar', registrarF.value)
+  if (registeredRange.value) { p.set('registeredFrom', registeredRange.value[0]); p.set('registeredTo', registeredRange.value[1]) }
+  if (expiryRange.value) { p.set('expiresFrom', expiryRange.value[0]); p.set('expiresTo', expiryRange.value[1]) }
+  if (nextDueRange.value) { p.set('nextDueFrom', nextDueRange.value[0]); p.set('nextDueTo', nextDueRange.value[1]) }
+  p.set('page', String(page.value))
+  p.set('pageSize', String(pageSize))
+  return p.toString()
+}
+
+function applyLocalFilters(items: DomainRow[]): DomainRow[] {
+  return items.filter(row => {
+    for (const f of activeFilters.value) {
+      if (['status', 'registrar'].includes(f.field)) continue
+      const rowVal = String(row[f.field as ColKey] ?? '').toLowerCase()
+      const search = f.value.toLowerCase()
+      if (f.condition === 'exact' && rowVal !== search) return false
+      if (f.condition === 'contains' && !rowVal.includes(search)) return false
+    }
+    return true
+  })
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    const data = await request<{ items: DomainRow[]; totalCount: number }>(`/reports/domains?${buildParams()}`)
+    rows.value = applyLocalFilters(data.items)
+    totalCount.value = data.totalCount
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+function applyFilters() { page.value = 1; load() }
+function goPage(p: number) { page.value = p; load() }
+function printReport() { window.print() }
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Domains" description="Domain registrations and expiry status">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage title="Domains" description="This report can be used to generate a custom export of domains by applying up to 5 filters. CSV Export is available via the Tools menu to the right." :loading :error>
+    <template #filters>
+      <FilterCard>
+        <template #fields>
+          <div class="flex flex-col gap-3">
+            <!-- Row 1: Fields to Include + Registration Date Range -->
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Fields to Include</label>
+                <FieldSelector :fields="allColumns" :selected="visibleCols" @toggle="toggleCol" @select-all="selectAllCols" @clear-all="clearAllCols" />
+              </div>
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Registration Date Range</label>
+                <DateRangePicker v-model="registeredRange" />
+              </div>
+            </div>
+            <!-- Row 2: Next Due Date Range + Expiry Date Range -->
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Next Due Date Range</label>
+                <DateRangePicker v-model="nextDueRange" />
+              </div>
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Expiry Date Range</label>
+                <DateRangePicker v-model="expiryRange" />
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <AdvancedFilters :fields="filterFields" @update:filters="activeFilters = $event" />
+
+        <template #actions>
+          <div class="flex items-center justify-center gap-3 pt-3 border-t border-border/50">
+            <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="applyFilters">Generate</button>
+            <button class="px-4 py-2 bg-white/[0.04] border border-border text-text-secondary text-[0.78rem] font-medium rounded-[9px] hover:bg-white/[0.08] transition-colors" @click="printReport">Print</button>
+          </div>
+        </template>
+      </FilterCard>
+    </template>
+
+    <div class="text-[0.78rem] text-text-secondary mb-3">{{ totalCount }} domain(s) found</div>
+
+    <div class="bg-surface-card border border-border rounded-2xl overflow-x-auto">
+      <table class="w-full text-[0.82rem]">
+        <thead>
+          <tr class="border-b border-border bg-white/[0.02]">
+            <th v-for="col in activeCols" :key="col.key" class="px-4 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted whitespace-nowrap">{{ col.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="rows.length === 0 && !loading">
+            <td :colspan="activeCols.length || 1" class="px-4 py-8 text-center text-text-secondary">No domains found.</td>
+          </tr>
+          <tr v-for="row in rows" :key="row.id" class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+            <td v-for="col in activeCols" :key="col.key" class="px-4 py-3 whitespace-nowrap">
+              <span v-if="col.key === 'status'" :class="['text-[0.72rem] px-2 py-0.5 rounded-full font-medium', statusBg(row.status)]">{{ row.status }}</span>
+              <span v-else-if="col.key === 'id'" class="text-text-muted font-mono">#{{ row.id }}</span>
+              <span v-else-if="col.key === 'domainName'" class="text-primary-400 font-medium">{{ row.domainName }}</span>
+              <span v-else class="text-text-secondary">{{ cellValue(row, col.key) }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 mt-4">
+      <button v-for="p in totalPages" :key="p"
+        class="px-3 py-1 rounded-lg text-[0.78rem] transition-colors"
+        :class="p === page ? 'bg-primary-500 text-white' : 'bg-white/[0.04] text-text-secondary hover:bg-white/[0.08]'"
+        @click="goPage(p)">{{ p }}</button>
+    </div>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/IncomeByProductView.vue
+++ b/admin/src/modules/reports/views/IncomeByProductView.vue
@@ -1,10 +1,117 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import AppSelect from '../../../components/AppSelect.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const now = new Date()
+const selectedYear = ref(now.getFullYear())
+const selectedMonth = ref(now.getMonth() + 1)
+const selectedCurrency = ref('USD')
+
+const monthOptions = ['January','February','March','April','May','June','July','August','September','October','November'].concat(['December'])
+  .map((name, i) => ({ value: i + 1, label: name }))
+const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
+const currencyOptions = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'RUB', label: 'RUB — Russian Ruble' },
+  { value: 'AMD', label: 'AMD — Armenian Dram' },
+]
+const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
+const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+
+interface ProductRow { productId: number; productName: string; unitsSold: number; totalIncome: number }
+interface Group { groupName: string; products: ProductRow[]; groupUnitsSold: number; groupIncome: number }
+interface ReportData { month: number; year: number; groups: Group[]; totalUnitsSold: number; totalIncome: number }
+
+const data = ref<ReportData | null>(null)
+
+const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const reportTitle = computed(() => data.value
+  ? `Income by Product for ${monthNames[data.value.month - 1]} ${data.value.year}`
+  : 'Income by Product')
+
+function fmt(n: number) {
+  const converted = n * rates[selectedCurrency.value]
+  return `${symbols[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    data.value = await request<ReportData>(`/reports/income-by-product-grouped?year=${selectedYear.value}&month=${selectedMonth.value}`)
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Income by Product" description="Revenue breakdown by product/service">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage :title="reportTitle" description="This report gives a breakdown per product/service of income paid in a given month." :loading :error>
+    <template #filters>
+      <div class="bg-surface-card border border-border rounded-2xl p-4 mb-6">
+        <div class="flex items-end gap-3">
+          <div class="w-[160px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Month</label>
+            <AppSelect v-model="selectedMonth" :options="monthOptions" />
+          </div>
+          <div class="w-[110px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Year</label>
+            <AppSelect v-model="selectedYear" :options="yearOptions" />
+          </div>
+          <div class="w-[180px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Currency</label>
+            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+          </div>
+          <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
+        </div>
+      </div>
+    </template>
+
+    <template v-if="data">
+      <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+        <table class="w-full text-[0.82rem]">
+          <thead>
+            <tr class="border-b border-border bg-white/[0.02]">
+              <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Product Name</th>
+              <th class="px-5 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Units Sold</th>
+              <th class="px-5 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="group in data.groups" :key="group.groupName">
+              <tr class="bg-white/[0.03] border-b border-border">
+                <td colspan="3" class="px-5 py-2 text-[0.75rem] font-semibold text-text-primary">{{ group.groupName }}</td>
+              </tr>
+              <tr v-for="product in group.products" :key="product.productId"
+                class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+                <td class="px-5 py-2.5 pl-10 text-text-secondary">{{ product.productName }}</td>
+                <td class="px-5 py-2.5 text-right" :class="product.unitsSold > 0 ? 'text-text-primary font-medium' : 'text-text-muted'">{{ product.unitsSold }}</td>
+                <td class="px-5 py-2.5 text-right" :class="product.totalIncome > 0 ? 'text-status-green font-medium' : 'text-text-muted'">{{ fmt(product.totalIncome) }}</td>
+              </tr>
+              <tr class="border-b border-border bg-white/[0.02]">
+                <td class="px-5 py-2 pl-10 text-[0.72rem] font-semibold text-text-muted">Sub Total</td>
+                <td class="px-5 py-2 text-right text-[0.78rem] font-semibold text-text-primary">{{ group.groupUnitsSold }}</td>
+                <td class="px-5 py-2 text-right text-[0.78rem] font-semibold text-text-primary">{{ fmt(group.groupIncome) }}</td>
+              </tr>
+            </template>
+          </tbody>
+          <tfoot>
+            <tr class="border-t-2 border-border bg-white/[0.03]">
+              <td class="px-5 py-3 text-[0.78rem] font-bold text-text-primary">Total</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-text-primary">{{ data.totalUnitsSold }}</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-status-green">{{ fmt(data.totalIncome) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </template>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/IncomeForecastView.vue
+++ b/admin/src/modules/reports/views/IncomeForecastView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { Line } from 'vue-chartjs'
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import { useApi } from '../../../composables/useApi'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
@@ -58,5 +59,6 @@ onMounted(load)
         <span class="text-status-green font-medium">${{ row.total.toFixed(2) }}</span>
       </div>
     </div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/InvoicesReportView.vue
+++ b/admin/src/modules/reports/views/InvoicesReportView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import FilterCard from '../../../components/FilterCard.vue'
 import AdvancedFilters, { type FilterRow, type FieldOption } from '../../../components/AdvancedFilters.vue'
 import FieldSelector from '../../../components/FieldSelector.vue'
@@ -230,5 +231,6 @@ onMounted(load)
     <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 mt-4">
       <button v-for="p in totalPages" :key="p" class="px-3 py-1 rounded-lg text-[0.78rem] transition-colors" :class="p === page ? 'bg-primary-500 text-white' : 'bg-white/[0.04] text-text-secondary hover:bg-white/[0.08]'" @click="goPage(p)">{{ p }}</button>
     </div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/MonthlyOrdersView.vue
+++ b/admin/src/modules/reports/views/MonthlyOrdersView.vue
@@ -1,10 +1,121 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import AppSelect from '../../../components/AppSelect.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const now = new Date()
+const selectedYear = ref(now.getFullYear())
+const selectedMonth = ref(now.getMonth() + 1)
+
+interface ProductRow { productId: number; productName: string; unitsSold: number; value: number }
+interface Group { groupName: string; products: ProductRow[]; groupUnitsSold: number; groupValue: number }
+interface ReportData { month: number; year: number; groups: Group[]; totalUnitsSold: number; totalValue: number }
+
+const data = ref<ReportData | null>(null)
+
+const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const monthOptions = monthNames.map((name, i) => ({ value: i + 1, label: name }))
+const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
+
+const currencyOptions = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'RUB', label: 'RUB — Russian Ruble' },
+  { value: 'AMD', label: 'AMD — Armenian Dram' },
+]
+const selectedCurrency = ref('USD')
+const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
+const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+
+const reportTitle = computed(() => data.value
+  ? `Sales by Product for ${monthNames[data.value.month - 1]} ${data.value.year}`
+  : 'Monthly Orders')
+
+function fmt(n: number) {
+  const converted = n * rates[selectedCurrency.value]
+  return `${symbols[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    data.value = await request<ReportData>(`/reports/monthly-orders?year=${selectedYear.value}&month=${selectedMonth.value}`)
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Monthly Orders" description="Order volume and trends by month">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage :title="reportTitle" description="This report gives a breakdown of the number of units sold of each product per month." :loading :error>
+    <!-- Filters -->
+    <template #filters>
+      <div class="bg-surface-card border border-border rounded-2xl p-4 mb-6">
+        <div class="flex items-end gap-3">
+          <div class="w-[160px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Month</label>
+            <AppSelect v-model="selectedMonth" :options="monthOptions" />
+          </div>
+          <div class="w-[110px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Year</label>
+            <AppSelect v-model="selectedYear" :options="yearOptions" />
+          </div>
+          <div class="w-[180px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Currency</label>
+            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+          </div>
+          <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
+        </div>
+      </div>
+    </template>
+
+    <template v-if="data">
+      <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+        <table class="w-full text-[0.82rem]">
+          <thead>
+            <tr class="border-b border-border bg-white/[0.02]">
+              <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Product Name</th>
+              <th class="px-5 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Units Sold</th>
+              <th class="px-5 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="group in data.groups" :key="group.groupName">
+              <!-- Group header -->
+              <tr class="bg-white/[0.03] border-b border-border">
+                <td colspan="3" class="px-5 py-2 text-[0.75rem] font-semibold text-text-primary">{{ group.groupName }}</td>
+              </tr>
+              <!-- Products -->
+              <tr v-for="product in group.products" :key="product.productId"
+                class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+                <td class="px-5 py-2.5 pl-10 text-text-secondary">{{ product.productName }}</td>
+                <td class="px-5 py-2.5 text-right" :class="product.unitsSold > 0 ? 'text-text-primary font-medium' : 'text-text-muted'">{{ product.unitsSold }}</td>
+                <td class="px-5 py-2.5 text-right" :class="product.value > 0 ? 'text-status-green font-medium' : 'text-text-muted'">{{ fmt(product.value) }}</td>
+              </tr>
+              <!-- Sub Total -->
+              <tr class="border-b border-border bg-white/[0.02]">
+                <td class="px-5 py-2 pl-10 text-[0.72rem] font-semibold text-text-muted">Sub Total</td>
+                <td class="px-5 py-2 text-right text-[0.78rem] font-semibold text-text-primary">{{ group.groupUnitsSold }}</td>
+                <td class="px-5 py-2 text-right text-[0.78rem] font-semibold text-text-primary">{{ fmt(group.groupValue) }}</td>
+              </tr>
+            </template>
+          </tbody>
+          <tfoot>
+            <tr class="border-t-2 border-border bg-white/[0.03]">
+              <td class="px-5 py-3 text-[0.78rem] font-bold text-text-primary">Total</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-text-primary">{{ data.totalUnitsSold }}</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-status-green">{{ fmt(data.totalValue) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </template>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/MonthlyTransactionsView.vue
+++ b/admin/src/modules/reports/views/MonthlyTransactionsView.vue
@@ -1,10 +1,156 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { Line } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import AppSelect from '../../../components/AppSelect.vue'
+import { useApi } from '../../../composables/useApi'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const now = new Date()
+const selectedYear = ref(now.getFullYear())
+const selectedMonth = ref(now.getMonth() + 1)
+const selectedCurrency = ref('USD')
+
+const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const monthOptions = monthNames.map((name, i) => ({ value: i + 1, label: name }))
+const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
+const currencyOptions = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'RUB', label: 'RUB — Russian Ruble' },
+  { value: 'AMD', label: 'AMD — Armenian Dram' },
+]
+const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
+const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+
+interface DailyRow { date: string; amountIn: number; fees: number; amountOut: number; balance: number }
+interface ReportData { month: number; year: number; rows: DailyRow[]; totalAmountIn: number; totalFees: number; totalAmountOut: number }
+
+const data = ref<ReportData | null>(null)
+
+const tableRows = computed(() => data.value?.rows ?? [])
+
+const reportTitle = computed(() => data.value
+  ? `Monthly Transactions Report for ${monthNames[data.value.month - 1]} ${data.value.year}`
+  : 'Monthly Transactions')
+
+function fmt(n: number) {
+  const v = n * rates[selectedCurrency.value]
+  return `${symbols[selectedCurrency.value]}${v.toFixed(2)}`
+}
+
+const chartData = computed(() => {
+  const rows = data.value?.rows ?? []
+  const r = rates[selectedCurrency.value]
+  return {
+    labels: rows.map(r => r.date.slice(5)), // MM-DD
+    datasets: [
+      { label: 'Amount In',  data: rows.map(x => x.amountIn  * r), borderColor: '#10b981', backgroundColor: 'rgba(16,185,129,0.08)', fill: true, tension: 0.4, pointRadius: 3 },
+      { label: 'Fees',       data: rows.map(x => x.fees      * r), borderColor: '#f59e0b', backgroundColor: 'rgba(245,158,11,0.08)',  fill: true, tension: 0.4, pointRadius: 3 },
+      { label: 'Amount Out', data: rows.map(x => x.amountOut * r), borderColor: '#ef4444', backgroundColor: 'rgba(239,68,68,0.08)',   fill: true, tension: 0.4, pointRadius: 3 },
+    ],
+  }
+})
+
+const chartOptions = {
+  responsive: true, maintainAspectRatio: false,
+  plugins: {
+    legend: { position: 'right' as const, labels: { color: '#94a3b8', boxWidth: 12, padding: 16 } },
+    tooltip: { mode: 'index' as const, intersect: false },
+  },
+  scales: {
+    x: { grid: { color: 'rgba(255,255,255,0.05)' }, ticks: { color: '#64748b' } },
+    y: { grid: { color: 'rgba(255,255,255,0.05)' }, ticks: { color: '#64748b' } },
+  },
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    data.value = await request<ReportData>(`/reports/daily-transactions?year=${selectedYear.value}&month=${selectedMonth.value}`)
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Monthly Transactions" description="All transactions grouped by month">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage :title="reportTitle" description="This report provides a summary of daily pay transactions for a given month. The Amount Out figure includes both expenditure transactions and refunds." :loading :error>
+    <template #filters>
+      <div class="bg-surface-card border border-border rounded-2xl p-4 mb-6">
+        <div class="flex items-end gap-3 flex-wrap">
+          <div class="w-[160px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Month</label>
+            <AppSelect v-model="selectedMonth" :options="monthOptions" />
+          </div>
+          <div class="w-[110px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Year</label>
+            <AppSelect v-model="selectedYear" :options="yearOptions" />
+          </div>
+          <div class="w-[190px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Choose Currency</label>
+            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+          </div>
+          <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
+        </div>
+      </div>
+    </template>
+
+    <template v-if="data">
+      <!-- Chart -->
+      <div class="bg-surface-card border border-border rounded-2xl p-6 mb-6">
+        <div v-if="data.rows.length > 0" class="h-72">
+          <Line :data="chartData" :options="chartOptions" />
+        </div>
+        <div v-else class="h-32 flex items-center justify-center text-text-muted text-[0.82rem]">
+          No transaction data for this month.
+        </div>
+      </div>
+
+      <!-- Table -->
+      <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+        <table class="w-full text-[0.82rem]">
+          <thead>
+            <tr class="border-b border-border bg-white/[0.02]">
+              <th class="px-5 py-3 text-left   text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Date</th>
+              <th class="px-5 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Amount In</th>
+              <th class="px-5 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Fees</th>
+              <th class="px-5 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Amount Out</th>
+              <th class="px-5 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="tableRows.length === 0">
+              <td colspan="5" class="px-5 py-8 text-center text-text-secondary">No transactions found for this month.</td>
+            </tr>
+            <tr v-for="row in tableRows" :key="row.date"
+              class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+              <td class="px-5 py-2.5 font-mono text-text-muted">{{ row.date }}</td>
+              <td class="px-5 py-2.5 text-right" :class="row.amountIn > 0 ? 'text-status-green font-medium' : 'text-text-muted'">{{ fmt(row.amountIn) }}</td>
+              <td class="px-5 py-2.5 text-right" :class="row.fees > 0 ? 'text-status-yellow font-medium' : 'text-text-muted'">{{ fmt(row.fees) }}</td>
+              <td class="px-5 py-2.5 text-right" :class="row.amountOut > 0 ? 'text-status-red font-medium' : 'text-text-muted'">{{ fmt(row.amountOut) }}</td>
+              <td class="px-5 py-2.5 text-right font-medium" :class="row.balance >= 0 ? 'text-text-primary' : 'text-status-red'">{{ fmt(row.balance) }}</td>
+            </tr>
+          </tbody>
+          <tfoot v-if="tableRows.length > 0">
+            <tr class="border-t-2 border-border bg-white/[0.03]">
+              <td class="px-5 py-3 text-[0.78rem] font-bold text-text-primary">Total</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-status-green">{{ fmt(data.totalAmountIn) }}</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-status-yellow">{{ fmt(data.totalFees) }}</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-status-red">{{ fmt(data.totalAmountOut) }}</td>
+              <td class="px-5 py-3 text-right text-[0.88rem] font-bold text-text-primary">{{ fmt(data.totalAmountIn - data.totalFees - data.totalAmountOut) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </template>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ProductSuspensionsView.vue
+++ b/admin/src/modules/reports/views/ProductSuspensionsView.vue
@@ -1,10 +1,57 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+interface Row { serviceId: number; clientName: string; productName: string; domain: string | null; nextDueDate: string | null; suspendReason: string | null }
+
+const rows = ref<Row[]>([])
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    rows.value = await request<Row[]>('/reports/product-suspensions')
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Product Suspensions">
-    <ReportComingSoon />
+  <ReportPage title="Product Suspensions" description="This report allows you to review all suspended products and the reasons specified for their suspensions." :loading :error>
+    <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+      <table class="w-full text-[0.82rem]">
+        <thead>
+          <tr class="border-b border-border bg-white/[0.02]">
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Service ID</th>
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Client Name</th>
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Product Name</th>
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Domain</th>
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Next Due Date</th>
+            <th class="px-5 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Suspend Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="rows.length === 0">
+            <td colspan="6" class="px-5 py-8 text-center text-text-secondary">No Data Found For This Report</td>
+          </tr>
+          <tr v-for="row in rows" :key="row.serviceId"
+            class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+            <td class="px-5 py-2.5 font-mono text-text-muted">{{ row.serviceId }}</td>
+            <td class="px-5 py-2.5 text-text-primary">{{ row.clientName }}</td>
+            <td class="px-5 py-2.5 text-text-primary">{{ row.productName }}</td>
+            <td class="px-5 py-2.5 text-text-secondary">{{ row.domain ?? '—' }}</td>
+            <td class="px-5 py-2.5 font-mono" :class="row.nextDueDate ? 'text-status-red' : 'text-text-muted'">{{ row.nextDueDate ?? '—' }}</td>
+            <td class="px-5 py-2.5 text-text-secondary italic">{{ row.suspendReason ?? '—' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <ReportTimestamp />
   </ReportPage>
 </template>

--- a/admin/src/modules/reports/views/SalesTaxView.vue
+++ b/admin/src/modules/reports/views/SalesTaxView.vue
@@ -1,10 +1,130 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import AppSelect from '../../../components/AppSelect.vue'
+import DateRangePicker from '../../../components/DateRangePicker.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const now = new Date()
+const dateRange = ref<[string, string]>([
+  `${now.getFullYear()}-01-01`,
+  `${now.getFullYear()}-12-31`,
+])
+const selectedCurrency = ref('USD')
+
+const currencyOptions = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'RUB', label: 'RUB — Russian Ruble' },
+  { value: 'AMD', label: 'AMD — Armenian Dram' },
+]
+const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
+const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+
+interface SalesTaxRow { id: number; clientName: string; invoiceDate: string; datePaid: string | null; subTotal: number; tax: number; credit: number; total: number }
+interface ReportData { totalInvoices: number; totalInvoiced: number; taxLevel1Liability: number; taxLevel2Liability: number; rows: SalesTaxRow[] }
+
+const data = ref<ReportData | null>(null)
+
+function fmt(n: number) {
+  const v = n * rates[selectedCurrency.value]
+  return `${symbols[selectedCurrency.value]}${v.toFixed(2)} ${selectedCurrency.value}`
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    const params = new URLSearchParams()
+    if (dateRange.value) { params.set('from', dateRange.value[0]); params.set('to', dateRange.value[1]) }
+    data.value = await request<ReportData>(`/reports/sales-tax?${params}`)
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Sales Tax" description="Tax liability and compliance report">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage title="Sales Tax Liability" description="This report shows sales tax liability for the selected period." :loading :error>
+    <template #filters>
+      <div class="bg-surface-card border border-border rounded-2xl p-4 mb-6">
+        <div class="flex items-end gap-3 flex-wrap">
+          <div class="flex-1 min-w-[220px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Date Range</label>
+            <DateRangePicker v-model="dateRange" />
+          </div>
+          <div class="w-[190px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Choose Currency</label>
+            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+          </div>
+          <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate Report</button>
+        </div>
+      </div>
+    </template>
+
+    <template v-if="data">
+      <!-- Summary -->
+      <div class="mb-4 text-[0.82rem] text-text-secondary space-y-1">
+        <p><span class="text-text-primary font-semibold">{{ data.totalInvoices }}</span> Invoices Found</p>
+        <p class="flex flex-wrap gap-4">
+          <span>Total Invoiced: <span class="text-text-primary font-medium">{{ fmt(data.totalInvoiced) }}</span></span>
+          <span>Tax Level 1 Liability: <span class="text-text-primary font-medium">{{ fmt(data.taxLevel1Liability) }}</span></span>
+          <span>Tax Level 2 Liability: <span class="text-text-primary font-medium">{{ fmt(data.taxLevel2Liability) }}</span></span>
+        </p>
+      </div>
+
+      <!-- Table -->
+      <div class="bg-surface-card border border-border rounded-2xl overflow-hidden">
+        <table class="w-full text-[0.82rem]">
+          <thead>
+            <tr class="border-b border-border bg-white/[0.02]">
+              <th class="px-4 py-3 text-left   text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Invoice ID</th>
+              <th class="px-4 py-3 text-left   text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Client Name</th>
+              <th class="px-4 py-3 text-center text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Invoice Date</th>
+              <th class="px-4 py-3 text-center text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Date Paid</th>
+              <th class="px-4 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Sub Total</th>
+              <th class="px-4 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Tax</th>
+              <th class="px-4 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Credit</th>
+              <th class="px-4 py-3 text-right  text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="data.rows.length === 0">
+              <td colspan="8" class="px-4 py-8 text-center text-text-secondary">No invoices found for this period.</td>
+            </tr>
+            <tr v-for="row in data.rows" :key="row.id"
+              class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-2.5 text-text-muted font-mono">{{ row.id }}</td>
+              <td class="px-4 py-2.5 text-text-primary">{{ row.clientName }}</td>
+              <td class="px-4 py-2.5 text-center text-text-secondary font-mono">{{ row.invoiceDate }}</td>
+              <td class="px-4 py-2.5 text-center font-mono" :class="row.datePaid ? 'text-text-secondary' : 'text-text-muted'">{{ row.datePaid ?? '—' }}</td>
+              <td class="px-4 py-2.5 text-right text-text-primary">{{ fmt(row.subTotal) }}</td>
+              <td class="px-4 py-2.5 text-right" :class="row.tax > 0 ? 'text-status-yellow font-medium' : 'text-text-muted'">{{ fmt(row.tax) }}</td>
+              <td class="px-4 py-2.5 text-right" :class="row.credit > 0 ? 'text-status-red' : 'text-text-muted'">{{ fmt(row.credit) }}</td>
+              <td class="px-4 py-2.5 text-right font-semibold text-status-green">{{ fmt(row.total) }}</td>
+            </tr>
+          </tbody>
+          <tfoot v-if="data.rows.length > 0">
+            <tr class="border-t-2 border-border bg-white/[0.03]">
+              <td colspan="4" class="px-4 py-3 text-[0.78rem] font-bold text-text-primary">Total</td>
+              <td class="px-4 py-3 text-right text-[0.88rem] font-bold text-text-primary">{{ fmt(data.rows.reduce((s, r) => s + r.subTotal, 0)) }}</td>
+              <td class="px-4 py-3 text-right text-[0.88rem] font-bold text-status-yellow">{{ fmt(data.taxLevel1Liability) }}</td>
+              <td class="px-4 py-3 text-right text-[0.88rem] font-bold text-status-red">{{ fmt(data.rows.reduce((s, r) => s + r.credit, 0)) }}</td>
+              <td class="px-4 py-3 text-right text-[0.88rem] font-bold text-status-green">{{ fmt(data.totalInvoiced) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <!-- Footer note -->
+      <p class="mt-4 text-[0.75rem] text-text-muted italic">
+        This report excludes invoices that affect a client's credit balance since this income will be counted and reported when it is applied to invoices for products/services.
+      </p>
+    </template>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/ServicesReportView.vue
+++ b/admin/src/modules/reports/views/ServicesReportView.vue
@@ -1,10 +1,207 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
+import FilterCard from '../../../components/FilterCard.vue'
+import AdvancedFilters, { type FilterRow, type FieldOption } from '../../../components/AdvancedFilters.vue'
+import FieldSelector from '../../../components/FieldSelector.vue'
+import DateRangePicker from '../../../components/DateRangePicker.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+interface ServiceRow {
+  id: number; clientId: number; clientName: string; productId: number; productName: string
+  domain: string | null; billingCycle: string; firstPaymentAmount: number; recurringAmount: number
+  paymentMethod: string | null; registrationDate: string; nextDueDate: string | null
+  terminatedAt: string | null; status: string; notes: string | null
+}
+const rows = ref<ServiceRow[]>([])
+const totalCount = ref(0)
+
+const filterFields: FieldOption[] = [
+  { value: 'clientName', label: 'Client Name' },
+  { value: 'productName', label: 'Product' },
+  { value: 'domain', label: 'Domain' },
+  { value: 'billingCycle', label: 'Billing Cycle' },
+  { value: 'paymentMethod', label: 'Payment Method' },
+  { value: 'status', label: 'Status' },
+]
+
+const activeFilters = ref<FilterRow[]>([])
+const createdRange = ref<[string, string] | null>(null)
+const nextDueRange = ref<[string, string] | null>(null)
+const terminatedRange = ref<[string, string] | null>(null)
+const completedRange = ref<[string, string] | null>(null)
+const page = ref(1); const pageSize = 50
+
+const allColumns = [
+  { key: 'id', label: 'ID' },
+  { key: 'clientId', label: 'User ID' },
+  { key: 'clientName', label: 'Client Name' },
+  { key: 'productId', label: 'Product ID' },
+  { key: 'productName', label: 'Product' },
+  { key: 'domain', label: 'Domain' },
+  { key: 'billingCycle', label: 'Billing Cycle' },
+  { key: 'firstPaymentAmount', label: 'First Payment Amount' },
+  { key: 'recurringAmount', label: 'Recurring Amount' },
+  { key: 'paymentMethod', label: 'Payment Method' },
+  { key: 'registrationDate', label: 'Registration Date' },
+  { key: 'nextDueDate', label: 'Next Due Date' },
+  { key: 'terminatedAt', label: 'Terminated At' },
+  { key: 'status', label: 'Status' },
+  { key: 'notes', label: 'Notes' },
+] as const
+
+type ColKey = typeof allColumns[number]['key']
+const visibleCols = ref<Set<ColKey>>(new Set())
+
+const activeCols = computed(() => allColumns.filter(c => visibleCols.value.has(c.key)))
+const totalPages = computed(() => Math.ceil(totalCount.value / pageSize))
+
+function toggleCol(key: string) {
+  const k = key as ColKey
+  if (visibleCols.value.has(k)) visibleCols.value.delete(k)
+  else visibleCols.value.add(k)
+}
+function selectAllCols() { allColumns.forEach(c => visibleCols.value.add(c.key)) }
+function clearAllCols() { visibleCols.value.clear() }
+
+function cellValue(row: ServiceRow, key: ColKey): string {
+  const v = row[key]
+  if (v == null || v === '') return '—'
+  if (['firstPaymentAmount', 'recurringAmount'].includes(key)) return `$${(v as number).toFixed(2)}`
+  return String(v)
+}
+
+const statusBg = (s: string) => ({
+  Active: 'bg-status-green/10 text-status-green',
+  Pending: 'bg-status-yellow/10 text-status-yellow',
+  Suspended: 'bg-status-red/10 text-status-red',
+  Terminated: 'bg-gray-500/10 text-gray-400',
+  Cancelled: 'bg-gray-500/10 text-gray-400',
+}[s] ?? 'text-text-secondary')
+
+function buildParams(): string {
+  const p = new URLSearchParams()
+  const statusF = activeFilters.value.find(f => f.field === 'status')
+  if (statusF) p.set('status', statusF.value)
+  const cycleF = activeFilters.value.find(f => f.field === 'billingCycle')
+  if (cycleF) p.set('billingCycle', cycleF.value)
+  if (createdRange.value) { p.set('createdFrom', createdRange.value[0]); p.set('createdTo', createdRange.value[1]) }
+  if (nextDueRange.value) { p.set('nextDueFrom', nextDueRange.value[0]); p.set('nextDueTo', nextDueRange.value[1]) }
+  if (terminatedRange.value) { p.set('terminatedFrom', terminatedRange.value[0]); p.set('terminatedTo', terminatedRange.value[1]) }
+  p.set('page', String(page.value))
+  p.set('pageSize', String(pageSize))
+  return p.toString()
+}
+
+function applyLocalFilters(items: ServiceRow[]): ServiceRow[] {
+  return items.filter(row => {
+    for (const f of activeFilters.value) {
+      if (['status', 'billingCycle'].includes(f.field)) continue
+      const rowVal = String(row[f.field as ColKey] ?? '').toLowerCase()
+      const search = f.value.toLowerCase()
+      if (f.condition === 'exact' && rowVal !== search) return false
+      if (f.condition === 'contains' && !rowVal.includes(search)) return false
+    }
+    return true
+  })
+}
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    const data = await request<{ items: ServiceRow[]; totalCount: number }>(`/reports/services?${buildParams()}`)
+    rows.value = applyLocalFilters(data.items)
+    totalCount.value = data.totalCount
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+function applyFilters() { page.value = 1; load() }
+function goPage(p: number) { page.value = p; load() }
+function printReport() { window.print() }
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Services" description="Active services and renewal status">
-    <ReportComingSoon />
-  </ReportPage>
+  <ReportPage title="Services" description="This report can be used to generate a custom export of services by applying up to 5 filters. CSV Export is available via the Tools menu to the right." :loading :error>
+    <template #filters>
+      <FilterCard>
+        <template #fields>
+          <div class="flex flex-col gap-3">
+            <!-- Fields selector full width -->
+            <div>
+              <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Fields to Include</label>
+              <FieldSelector :fields="allColumns" :selected="visibleCols" @toggle="toggleCol" @select-all="selectAllCols" @clear-all="clearAllCols" />
+            </div>
+            <!-- 4 date ranges in one row -->
+            <div class="grid grid-cols-4 gap-3">
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Registration Date</label>
+                <DateRangePicker v-model="createdRange" />
+              </div>
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Next Due Date</label>
+                <DateRangePicker v-model="nextDueRange" />
+              </div>
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Termination Date</label>
+                <DateRangePicker v-model="terminatedRange" />
+              </div>
+              <div>
+                <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Completed Date</label>
+                <DateRangePicker v-model="completedRange" />
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <AdvancedFilters :fields="filterFields" @update:filters="activeFilters = $event" />
+
+        <template #actions>
+          <div class="flex items-center justify-center gap-3 pt-3 border-t border-border/50">
+            <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="applyFilters">Generate</button>
+            <button class="px-4 py-2 bg-white/[0.04] border border-border text-text-secondary text-[0.78rem] font-medium rounded-[9px] hover:bg-white/[0.08] transition-colors" @click="printReport">Print</button>
+          </div>
+        </template>
+      </FilterCard>
+    </template>
+
+    <div class="text-[0.78rem] text-text-secondary mb-3">{{ totalCount }} service(s) found</div>
+
+    <div class="bg-surface-card border border-border rounded-2xl overflow-x-auto">
+      <table class="w-full text-[0.82rem]">
+        <thead>
+          <tr class="border-b border-border bg-white/[0.02]">
+            <th v-for="col in activeCols" :key="col.key" class="px-4 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted whitespace-nowrap">{{ col.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="rows.length === 0 && !loading">
+            <td :colspan="activeCols.length || 1" class="px-4 py-8 text-center text-text-secondary">No services found.</td>
+          </tr>
+          <tr v-for="row in rows" :key="row.id" class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+            <td v-for="col in activeCols" :key="col.key" class="px-4 py-3 whitespace-nowrap">
+              <span v-if="col.key === 'status'" :class="['text-[0.72rem] px-2 py-0.5 rounded-full font-medium', statusBg(row.status)]">{{ row.status }}</span>
+              <span v-else-if="col.key === 'id'" class="text-text-muted font-mono">#{{ row.id }}</span>
+              <span v-else-if="col.key === 'productName'" class="text-text-primary font-medium">{{ row.productName }}</span>
+              <span v-else class="text-text-secondary">{{ cellValue(row, col.key) }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 mt-4">
+      <button v-for="p in totalPages" :key="p"
+        class="px-3 py-1 rounded-lg text-[0.78rem] transition-colors"
+        :class="p === page ? 'bg-primary-500 text-white' : 'bg-white/[0.04] text-text-secondary hover:bg-white/[0.08]'"
+        @click="goPage(p)">{{ p }}</button>
+    </div>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/SupportTicketsReportView.vue
+++ b/admin/src/modules/reports/views/SupportTicketsReportView.vue
@@ -1,10 +1,104 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
-import ReportComingSoon from '../components/ReportComingSoon.vue'
+import AppSelect from '../../../components/AppSelect.vue'
+import { useApi } from '../../../composables/useApi'
+
+const { request } = useApi()
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const now = new Date()
+const selectedYear = ref(now.getFullYear())
+const selectedMonth = ref(now.getMonth() + 1)
+
+const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const monthOptions = monthNames.map((name, i) => ({ value: i + 1, label: name }))
+const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
+
+interface Row { adminName: string; dailyCounts: number[]; total: number }
+interface ReportData { month: number; year: number; daysInMonth: number; rows: Row[] }
+
+const data = ref<ReportData | null>(null)
+
+const reportTitle = computed(() => data.value
+  ? `Support Ticket Replies for ${monthNames[data.value.month - 1]} ${data.value.year}`
+  : 'Support Ticket Replies')
+
+const dayHeaders = computed(() =>
+  data.value ? Array.from({ length: data.value.daysInMonth }, (_, i) => i + 1) : []
+)
+
+async function load() {
+  loading.value = true; error.value = null
+  try {
+    data.value = await request<ReportData>(`/reports/support-ticket-replies?year=${selectedYear.value}&month=${selectedMonth.value}`)
+  } catch { error.value = 'Failed to load report.' } finally { loading.value = false }
+}
+
+onMounted(load)
 </script>
 
 <template>
-  <ReportPage title="Support Tickets" description="Ticket volume and response metrics">
-    <ReportComingSoon />
+  <ReportPage :title="reportTitle" description="This report shows a breakdown of support tickets dealt with per admin for a given month." :loading :error>
+    <template #filters>
+      <div class="bg-surface-card border border-border rounded-2xl p-4 mb-6">
+        <div class="flex items-end gap-3 flex-wrap">
+          <div class="w-[160px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Month</label>
+            <AppSelect v-model="selectedMonth" :options="monthOptions" />
+          </div>
+          <div class="w-[110px]">
+            <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Year</label>
+            <AppSelect v-model="selectedYear" :options="yearOptions" />
+          </div>
+          <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
+        </div>
+      </div>
+    </template>
+
+    <template v-if="data">
+      <div class="bg-surface-card border border-border rounded-2xl overflow-x-auto">
+        <table class="text-[0.78rem] w-full">
+          <thead>
+            <tr class="border-b border-border bg-white/[0.02]">
+              <th class="px-4 py-3 text-left text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted sticky left-0 bg-surface-card z-10 min-w-[140px]">Admin</th>
+              <th v-for="day in dayHeaders" :key="day"
+                class="px-2 py-3 text-center text-[0.68rem] font-semibold text-text-muted w-8">{{ day }}</th>
+              <th class="px-4 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="data.rows.length === 0">
+              <td :colspan="data.daysInMonth + 2" class="px-4 py-8 text-center text-text-secondary">
+                No Data Found For This Report
+              </td>
+            </tr>
+            <tr v-for="row in data.rows" :key="row.adminName"
+              class="border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-2.5 text-text-primary font-medium sticky left-0 bg-surface-card z-10">{{ row.adminName }}</td>
+              <td v-for="(count, i) in row.dailyCounts" :key="i"
+                class="px-2 py-2.5 text-center"
+                :class="count > 0 ? 'text-text-primary font-semibold' : 'text-text-muted'">
+                {{ count > 0 ? count : '' }}
+              </td>
+              <td class="px-4 py-2.5 text-right font-bold text-text-primary">{{ row.total }}</td>
+            </tr>
+          </tbody>
+          <tfoot v-if="data.rows.length > 0">
+            <tr class="border-t-2 border-border bg-white/[0.03]">
+              <td class="px-4 py-2.5 text-[0.75rem] font-bold text-text-primary sticky left-0 bg-surface-card z-10">Total</td>
+              <td v-for="(day, i) in dayHeaders" :key="day"
+                class="px-2 py-2.5 text-center text-[0.78rem] font-semibold text-text-primary">
+                {{ data.rows.reduce((s, r) => s + r.dailyCounts[i], 0) || '' }}
+              </td>
+              <td class="px-4 py-2.5 text-right text-[0.88rem] font-bold text-text-primary">
+                {{ data.rows.reduce((s, r) => s + r.total, 0) }}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </template>
   </ReportPage>
 </template>

--- a/admin/src/modules/reports/views/TopClientsView.vue
+++ b/admin/src/modules/reports/views/TopClientsView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { Pie } from 'vue-chartjs'
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import { useApi } from '../../../composables/useApi'
 
 ChartJS.register(ArcElement, Tooltip, Legend)
@@ -100,5 +101,6 @@ onMounted(load)
 
     <div class="text-[0.68rem] text-text-muted mt-4">* denotes converted to default currency</div>
     <div class="text-[0.68rem] text-text-muted mt-1 text-right">Report Generated at {{ new Date().toLocaleString() }}</div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/admin/src/modules/reports/views/TransactionsReportView.vue
+++ b/admin/src/modules/reports/views/TransactionsReportView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import ReportPage from '../components/ReportPage.vue'
+import ReportTimestamp from '../components/ReportTimestamp.vue'
 import FilterCard from '../../../components/FilterCard.vue'
 import AdvancedFilters, { type FilterRow, type FieldOption } from '../../../components/AdvancedFilters.vue'
 import FieldSelector from '../../../components/FieldSelector.vue'
@@ -179,5 +180,6 @@ onMounted(load)
     </div>
 
     <div class="text-[0.68rem] text-text-muted mt-4 text-right">Report Generated at {{ new Date().toLocaleString() }}</div>
-  </ReportPage>
+    <ReportTimestamp />
+</ReportPage>
 </template>

--- a/backend/src/Innovayse.API/Reports/ReportsController.cs
+++ b/backend/src/Innovayse.API/Reports/ReportsController.cs
@@ -227,6 +227,137 @@ public sealed class ReportsController(IMessageBus bus, IReportRepository reportR
         return Ok(result);
     }
 
+    /// <summary>Returns income by product grouped by product group for a given month.</summary>
+    [HttpGet("income-by-product-grouped")]
+    public async Task<ActionResult<IncomeByProductGroupedDto>> GetIncomeByProductGroupedAsync(
+        [FromQuery] int? year, [FromQuery] int? month,
+        CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var result = await reportRepo.GetIncomeByProductGroupedAsync(
+            year ?? now.Year, month ?? now.Month, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns monthly orders grouped by product group.</summary>
+    [HttpGet("monthly-orders")]
+    public async Task<ActionResult<MonthlyOrdersDto>> GetMonthlyOrdersAsync(
+        [FromQuery] int? year, [FromQuery] int? month,
+        CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var result = await reportRepo.GetMonthlyOrdersAsync(
+            year ?? now.Year, month ?? now.Month, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns a filtered, paginated list of services for reporting.</summary>
+    [HttpGet("services")]
+    public async Task<ActionResult<ServiceReportResultDto>> GetServicesReportAsync(
+        [FromQuery] string? status,
+        [FromQuery] string? billingCycle,
+        [FromQuery] string? createdFrom, [FromQuery] string? createdTo,
+        [FromQuery] string? nextDueFrom, [FromQuery] string? nextDueTo,
+        [FromQuery] string? terminatedFrom, [FromQuery] string? terminatedTo,
+        [FromQuery] int page = 1, [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var result = await reportRepo.GetServicesReportAsync(
+            status, billingCycle,
+            createdFrom is not null ? DateOnly.Parse(createdFrom) : null,
+            createdTo is not null ? DateOnly.Parse(createdTo) : null,
+            nextDueFrom is not null ? DateOnly.Parse(nextDueFrom) : null,
+            nextDueTo is not null ? DateOnly.Parse(nextDueTo) : null,
+            terminatedFrom is not null ? DateOnly.Parse(terminatedFrom) : null,
+            terminatedTo is not null ? DateOnly.Parse(terminatedTo) : null,
+            page, pageSize, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns a filtered, paginated list of domains for reporting.</summary>
+    [HttpGet("domains")]
+    public async Task<ActionResult<DomainReportResultDto>> GetDomainsReportAsync(
+        [FromQuery] string? status,
+        [FromQuery] string? registrar,
+        [FromQuery] string? registeredFrom, [FromQuery] string? registeredTo,
+        [FromQuery] string? expiresFrom, [FromQuery] string? expiresTo,
+        [FromQuery] string? nextDueFrom, [FromQuery] string? nextDueTo,
+        [FromQuery] int page = 1, [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var result = await reportRepo.GetDomainsReportAsync(
+            status, registrar,
+            registeredFrom is not null ? DateOnly.Parse(registeredFrom) : null,
+            registeredTo is not null ? DateOnly.Parse(registeredTo) : null,
+            expiresFrom is not null ? DateOnly.Parse(expiresFrom) : null,
+            expiresTo is not null ? DateOnly.Parse(expiresTo) : null,
+            nextDueFrom is not null ? DateOnly.Parse(nextDueFrom) : null,
+            nextDueTo is not null ? DateOnly.Parse(nextDueTo) : null,
+            page, pageSize, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns a filtered, paginated list of clients for reporting.</summary>
+    [HttpGet("clients")]
+    public async Task<ActionResult<ClientReportResultDto>> GetClientsReportAsync(
+        [FromQuery] string? status,
+        [FromQuery] string? country,
+        [FromQuery] string? createdFrom, [FromQuery] string? createdTo,
+        [FromQuery] int page = 1, [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var result = await reportRepo.GetClientsReportAsync(
+            status, country,
+            createdFrom is not null ? DateOnly.Parse(createdFrom) : null,
+            createdTo is not null ? DateOnly.Parse(createdTo) : null,
+            page, pageSize, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns all suspended services.</summary>
+    [HttpGet("product-suspensions")]
+    public async Task<ActionResult<IReadOnlyList<ProductSuspensionRowDto>>> GetProductSuspensionsAsync(CancellationToken ct)
+    {
+        var result = await reportRepo.GetProductSuspensionsAsync(ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns support ticket replies per admin per day for a given month.</summary>
+    [HttpGet("support-ticket-replies")]
+    public async Task<ActionResult<SupportTicketRepliesDto>> GetSupportTicketRepliesAsync(
+        [FromQuery] int? year, [FromQuery] int? month,
+        CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var result = await reportRepo.GetSupportTicketRepliesAsync(
+            year ?? now.Year, month ?? now.Month, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns sales tax liability for the given date range.</summary>
+    [HttpGet("sales-tax")]
+    public async Task<ActionResult<SalesTaxReportDto>> GetSalesTaxAsync(
+        [FromQuery] string? from, [FromQuery] string? to,
+        CancellationToken ct = default)
+    {
+        var result = await reportRepo.GetSalesTaxReportAsync(
+            from is not null ? DateOnly.Parse(from) : null,
+            to is not null ? DateOnly.Parse(to) : null, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Returns daily transaction aggregates for a given month.</summary>
+    [HttpGet("daily-transactions")]
+    public async Task<ActionResult<MonthlyTransactionsReportDto>> GetDailyTransactionsAsync(
+        [FromQuery] int? year, [FromQuery] int? month,
+        CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var result = await reportRepo.GetDailyTransactionsAsync(
+            year ?? now.Year, month ?? now.Month, ct);
+        return Ok(result);
+    }
+
     /// <summary>Returns a client account statement.</summary>
     [HttpGet("client-statement")]
     public async Task<ActionResult<ClientStatementDto>> GetClientStatementAsync(

--- a/backend/src/Innovayse.Application/Reports/DTOs/ClientReportDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/ClientReportDto.cs
@@ -1,0 +1,24 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One row in the Clients report.</summary>
+public record ClientReportDto(
+    int Id,
+    string FirstName,
+    string LastName,
+    string? CompanyName,
+    string Email,
+    string? Address1,
+    string? Address2,
+    string? City,
+    string? State,
+    string? PostCode,
+    string? Country,
+    string? Phone,
+    string? Currency,
+    decimal CreditBalance,
+    string Status,
+    string CreatedAt,
+    string? Notes);
+
+/// <summary>Paginated result wrapper for the Clients report.</summary>
+public record ClientReportResultDto(IReadOnlyList<ClientReportDto> Items, int TotalCount);

--- a/backend/src/Innovayse.Application/Reports/DTOs/DailyTransactionDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/DailyTransactionDto.cs
@@ -1,0 +1,18 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One day row in the Monthly Transactions report.</summary>
+public record DailyTransactionDto(
+    string Date,
+    decimal AmountIn,
+    decimal Fees,
+    decimal AmountOut,
+    decimal Balance);
+
+/// <summary>Full Monthly Transactions report result.</summary>
+public record MonthlyTransactionsReportDto(
+    int Month,
+    int Year,
+    IReadOnlyList<DailyTransactionDto> Rows,
+    decimal TotalAmountIn,
+    decimal TotalFees,
+    decimal TotalAmountOut);

--- a/backend/src/Innovayse.Application/Reports/DTOs/DomainReportDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/DomainReportDto.cs
@@ -1,0 +1,23 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One row in the Domains report.</summary>
+public record DomainReportDto(
+    int Id,
+    int ClientId,
+    string ClientName,
+    int? OrderId,
+    string OrderType,
+    string DomainName,
+    decimal FirstPaymentAmount,
+    decimal RecurringAmount,
+    int RegistrationPeriod,
+    string RegistrationDate,
+    string ExpiryDate,
+    string NextDueDate,
+    string? Registrar,
+    string? PaymentMethod,
+    string Status,
+    string? Notes);
+
+/// <summary>Paginated result for the Domains report.</summary>
+public record DomainReportResultDto(IReadOnlyList<DomainReportDto> Items, int TotalCount);

--- a/backend/src/Innovayse.Application/Reports/DTOs/IncomeByProductGroupedDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/IncomeByProductGroupedDto.cs
@@ -1,0 +1,23 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One product row in the grouped Income by Product report.</summary>
+public record IncomeByProductRowDto(
+    int ProductId,
+    string ProductName,
+    int UnitsSold,
+    decimal TotalIncome);
+
+/// <summary>One product group in the grouped Income by Product report.</summary>
+public record IncomeByProductGroupDto(
+    string GroupName,
+    IReadOnlyList<IncomeByProductRowDto> Products,
+    int GroupUnitsSold,
+    decimal GroupIncome);
+
+/// <summary>Full grouped Income by Product report result.</summary>
+public record IncomeByProductGroupedDto(
+    int Month,
+    int Year,
+    IReadOnlyList<IncomeByProductGroupDto> Groups,
+    int TotalUnitsSold,
+    decimal TotalIncome);

--- a/backend/src/Innovayse.Application/Reports/DTOs/MonthlyOrdersDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/MonthlyOrdersDto.cs
@@ -1,0 +1,23 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One product row in the Monthly Orders report.</summary>
+public record MonthlyOrderProductDto(
+    int ProductId,
+    string ProductName,
+    int UnitsSold,
+    decimal Value);
+
+/// <summary>One product group in the Monthly Orders report.</summary>
+public record MonthlyOrderGroupDto(
+    string GroupName,
+    IReadOnlyList<MonthlyOrderProductDto> Products,
+    int GroupUnitsSold,
+    decimal GroupValue);
+
+/// <summary>Full Monthly Orders report result.</summary>
+public record MonthlyOrdersDto(
+    int Month,
+    int Year,
+    IReadOnlyList<MonthlyOrderGroupDto> Groups,
+    int TotalUnitsSold,
+    decimal TotalValue);

--- a/backend/src/Innovayse.Application/Reports/DTOs/ProductSuspensionsDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/ProductSuspensionsDto.cs
@@ -1,0 +1,10 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One row in the Product Suspensions report.</summary>
+public record ProductSuspensionRowDto(
+    int ServiceId,
+    string ClientName,
+    string ProductName,
+    string? Domain,
+    string? NextDueDate,
+    string? SuspendReason);

--- a/backend/src/Innovayse.Application/Reports/DTOs/SalesTaxDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/SalesTaxDto.cs
@@ -1,0 +1,20 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One invoice row in the Sales Tax Liability report.</summary>
+public record SalesTaxRowDto(
+    int Id,
+    string ClientName,
+    string InvoiceDate,
+    string? DatePaid,
+    decimal SubTotal,
+    decimal Tax,
+    decimal Credit,
+    decimal Total);
+
+/// <summary>Full Sales Tax Liability report result.</summary>
+public record SalesTaxReportDto(
+    int TotalInvoices,
+    decimal TotalInvoiced,
+    decimal TaxLevel1Liability,
+    decimal TaxLevel2Liability,
+    IReadOnlyList<SalesTaxRowDto> Rows);

--- a/backend/src/Innovayse.Application/Reports/DTOs/ServiceReportDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/ServiceReportDto.cs
@@ -1,0 +1,22 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One row in the Services report.</summary>
+public record ServiceReportDto(
+    int Id,
+    int ClientId,
+    string ClientName,
+    int ProductId,
+    string ProductName,
+    string? Domain,
+    string BillingCycle,
+    decimal FirstPaymentAmount,
+    decimal RecurringAmount,
+    string? PaymentMethod,
+    string RegistrationDate,
+    string? NextDueDate,
+    string? TerminatedAt,
+    string Status,
+    string? Notes);
+
+/// <summary>Paginated result for the Services report.</summary>
+public record ServiceReportResultDto(IReadOnlyList<ServiceReportDto> Items, int TotalCount);

--- a/backend/src/Innovayse.Application/Reports/DTOs/SupportTicketRepliesDto.cs
+++ b/backend/src/Innovayse.Application/Reports/DTOs/SupportTicketRepliesDto.cs
@@ -1,0 +1,14 @@
+namespace Innovayse.Application.Reports.DTOs;
+
+/// <summary>One admin row in the Support Ticket Replies report.</summary>
+public record SupportTicketRepliesRowDto(
+    string AdminName,
+    IReadOnlyList<int> DailyCounts,
+    int Total);
+
+/// <summary>Full Support Ticket Replies report result.</summary>
+public record SupportTicketRepliesDto(
+    int Month,
+    int Year,
+    int DaysInMonth,
+    IReadOnlyList<SupportTicketRepliesRowDto> Rows);

--- a/backend/src/Innovayse.Application/Reports/Interfaces/IReportRepository.cs
+++ b/backend/src/Innovayse.Application/Reports/Interfaces/IReportRepository.cs
@@ -54,4 +54,43 @@ public interface IReportRepository
 
     /// <summary>Returns a client account statement for the given date range.</summary>
     Task<ClientStatementDto> GetClientStatementAsync(int clientId, DateOnly? from, DateOnly? to, CancellationToken ct);
+
+    /// <summary>Returns monthly orders grouped by product group.</summary>
+    Task<MonthlyOrdersDto> GetMonthlyOrdersAsync(int year, int month, CancellationToken ct);
+
+    /// <summary>Returns income by product grouped by product group for a given month.</summary>
+    Task<IncomeByProductGroupedDto> GetIncomeByProductGroupedAsync(int year, int month, CancellationToken ct);
+
+    /// <summary>Returns a filtered, paginated list of services for reporting.</summary>
+    Task<ServiceReportResultDto> GetServicesReportAsync(
+        string? status, string? billingCycle,
+        DateOnly? createdFrom, DateOnly? createdTo,
+        DateOnly? nextDueFrom, DateOnly? nextDueTo,
+        DateOnly? terminatedFrom, DateOnly? terminatedTo,
+        int page, int pageSize, CancellationToken ct);
+
+    /// <summary>Returns a filtered, paginated list of domains for reporting.</summary>
+    Task<DomainReportResultDto> GetDomainsReportAsync(
+        string? status, string? registrar,
+        DateOnly? registeredFrom, DateOnly? registeredTo,
+        DateOnly? expiresFrom, DateOnly? expiresTo,
+        DateOnly? nextDueFrom, DateOnly? nextDueTo,
+        int page, int pageSize, CancellationToken ct);
+
+    /// <summary>Returns a filtered, paginated list of clients for reporting.</summary>
+    Task<ClientReportResultDto> GetClientsReportAsync(
+        string? status, string? country, DateOnly? createdFrom, DateOnly? createdTo,
+        int page, int pageSize, CancellationToken ct);
+
+    /// <summary>Returns daily transaction aggregates for a given month.</summary>
+    Task<MonthlyTransactionsReportDto> GetDailyTransactionsAsync(int year, int month, CancellationToken ct);
+
+    /// <summary>Returns sales tax liability for the given date range.</summary>
+    Task<SalesTaxReportDto> GetSalesTaxReportAsync(DateOnly? from, DateOnly? to, CancellationToken ct);
+
+    /// <summary>Returns support ticket replies per admin per day for a given month.</summary>
+    Task<SupportTicketRepliesDto> GetSupportTicketRepliesAsync(int year, int month, CancellationToken ct);
+
+    /// <summary>Returns all suspended services with suspension details.</summary>
+    Task<IReadOnlyList<ProductSuspensionRowDto>> GetProductSuspensionsAsync(CancellationToken ct);
 }

--- a/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
@@ -3,6 +3,9 @@ namespace Innovayse.Infrastructure.Persistence;
 using Innovayse.Domain.Auth;
 using Innovayse.Domain.Billing;
 using Innovayse.Domain.Clients;
+using Innovayse.Domain.Orders;
+using Innovayse.Domain.Products;
+using Innovayse.Domain.Services;
 using Innovayse.Infrastructure.Auth;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -43,7 +46,12 @@ public sealed class DevDataSeeder(
                 await userManager.AddToRoleAsync(adminUser, Roles.Admin);
         }
 
-        if (await db.Clients.AnyAsync(ct) && await db.Invoices.AnyAsync(ct) && await db.Quotes.AnyAsync(ct))
+        var productNames = await db.Products.Select(p => p.Name).ToListAsync(ct);
+        var hasProductInvoices = productNames.Count > 0 && await db.InvoiceItems
+            .AnyAsync(ii => productNames.Contains(ii.Description), ct);
+
+        if (await db.Clients.AnyAsync(ct) && await db.Invoices.AnyAsync(ct) && await db.Quotes.AnyAsync(ct)
+            && await db.ProductGroups.AnyAsync(ct) && await db.Orders.AnyAsync(ct) && hasProductInvoices)
         {
             logger.LogInformation("Dev seed skipped — data already exists");
             return;
@@ -256,6 +264,127 @@ public sealed class DevDataSeeder(
 
             await db.SaveChangesAsync(ct);
             logger.LogInformation("Seeded billable items");
+        }
+
+        // ── Product Groups + Products ─────────────────────────────────────────
+        if (!await db.ProductGroups.AnyAsync(ct))
+        {
+            var groupDefs = new[]
+            {
+                ("Web Hosting",       ProductType.SharedHosting, new[] { ("Starter Hosting", 4.99m, 49.99m), ("Business Hosting", 9.99m, 99.99m), ("Pro Hosting", 19.99m, 199.99m) }),
+                ("VPS Servers",       ProductType.Vps,           new[] { ("VPS Basic", 29.99m, 299.99m), ("VPS Pro", 59.99m, 599.99m), ("VPS Enterprise", 99.99m, 999.99m) }),
+                ("Dedicated Servers", ProductType.Dedicated,     new[] { ("Dedicated Starter", 89.99m, 899.99m), ("Dedicated Pro", 149.99m, 1499.99m) }),
+                ("SSL Certificates",  ProductType.Ssl,           new[] { ("SSL Basic", 9.99m, 89.99m), ("SSL Wildcard", 29.99m, 279.99m) }),
+                ("Email Hosting",     ProductType.Other,         new[] { ("Email Basic", 2.99m, 29.99m), ("Email Pro", 7.99m, 79.99m) }),
+            };
+
+            foreach (var (groupName, productType, products) in groupDefs)
+            {
+                var group = ProductGroup.Create(groupName, null);
+                db.ProductGroups.Add(group);
+                await db.SaveChangesAsync(ct);
+
+                foreach (var (name, monthly, annual) in products)
+                {
+                    var product = Product.Create(group.Id, name, null, null, productType, monthly, annual);
+                    db.Products.Add(product);
+                }
+            }
+
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seeded product groups and products");
+        }
+
+        // ── Client Services ───────────────────────────────────────────────────
+        if (!await db.ClientServices.AnyAsync(ct))
+        {
+            var products = await db.Products.ToListAsync(ct);
+            var activeClients = await db.Clients.Where(c => c.Status == ClientStatus.Active).ToListAsync(ct);
+            var billingCycles = new[] { "monthly", "annual" };
+
+            foreach (var client in activeClients)
+            {
+                var numServices = Rng.Next(1, 4);
+                for (int i = 0; i < numServices; i++)
+                {
+                    var product = products[Rng.Next(products.Count)];
+                    var cycle = billingCycles[Rng.Next(2)];
+                    var svc = ClientService.Create(client.Id, product.Id, cycle);
+                    var monthsBack = Rng.Next(1, 12);
+                    db.Entry(svc).Property(nameof(ClientService.CreatedAt)).CurrentValue = MonthsAgo(monthsBack);
+                    svc.Activate("prov_" + Rng.Next(10000, 99999));
+                    db.ClientServices.Add(svc);
+                }
+            }
+
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seeded client services");
+        }
+
+        // ── Product-matched invoices (for Income by Product report) ──────────
+        // Seed paid invoices whose item descriptions match real product names,
+        // so GetIncomeByProductGroupedAsync can join them correctly.
+        if (!hasProductInvoices)
+        {
+            var products = await db.Products.ToListAsync(ct);
+            var activeClients = await db.Clients.Where(c => c.Status == ClientStatus.Active).ToListAsync(ct);
+
+            // Seed paid invoices for the last 3 months
+            for (int monthsBack = 2; monthsBack >= 0; monthsBack--)
+            {
+                var invoicesThisMonth = Rng.Next(5, 12);
+                for (int i = 0; i < invoicesThisMonth; i++)
+                {
+                    var client = activeClients[Rng.Next(activeClients.Count)];
+                    var product = products[Rng.Next(products.Count)];
+                    var invoiceDate = MonthsAgo(monthsBack, Rng.Next(1, 25));
+
+                    var invoice = Invoice.Create(client.Id, invoiceDate.AddDays(30));
+                    invoice.AddItem(product.Name, product.MonthlyPrice, 1);
+                    if (Rng.Next(3) == 0)
+                    {
+                        var p2 = products[Rng.Next(products.Count)];
+                        invoice.AddItem(p2.Name, p2.MonthlyPrice, 1);
+                    }
+                    invoice.MarkPaid("stripe_" + Rng.Next(100000, 999999));
+
+                    db.Invoices.Add(invoice);
+                    db.Entry(invoice).Property(nameof(Invoice.CreatedAt)).CurrentValue = invoiceDate;
+                }
+            }
+
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seeded product-matched invoices for Income by Product report");
+        }
+
+        // ── Orders ────────────────────────────────────────────────────────────
+        if (!await db.Orders.AnyAsync(ct))
+        {
+            var products = await db.Products.ToListAsync(ct);
+            var activeClients = await db.Clients.Where(c => c.Status == ClientStatus.Active).ToListAsync(ct);
+            var gateways = new[] { "Stripe", "PayPal", "Bank Transfer" };
+
+            for (int month = 11; month >= 0; month--)
+            {
+                var ordersThisMonth = Rng.Next(3, 8);
+                for (int o = 0; o < ordersThisMonth; o++)
+                {
+                    var client = activeClients[Rng.Next(activeClients.Count)];
+                    var product = products[Rng.Next(products.Count)];
+                    var gateway = gateways[Rng.Next(gateways.Length)];
+                    var orderDate = MonthsAgo(month, Rng.Next(1, 28));
+
+                    var order = Order.Create($"ORD-{Rng.Next(10000, 99999)}", client.Id, gateway, null);
+                    order.AddItem(product.Id, product.Name, "monthly", product.MonthlyPrice, product.MonthlyPrice, null, null);
+                    order.Accept();
+
+                    db.Orders.Add(order);
+                    db.Entry(order).Property(nameof(Order.CreatedAt)).CurrentValue = orderDate;
+                }
+            }
+
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Seeded orders across 12 months");
         }
 
         logger.LogInformation("Dev seed complete");

--- a/backend/src/Innovayse.Infrastructure/Reports/ReportRepository.cs
+++ b/backend/src/Innovayse.Infrastructure/Reports/ReportRepository.cs
@@ -485,4 +485,429 @@ public sealed class ReportRepository(AppDbContext db) : IReportRepository
 
         return new ClientStatementDto(clientId, clientName, previousBalance, result, running);
     }
+
+    /// <inheritdoc/>
+    public async Task<IncomeByProductGroupedDto> GetIncomeByProductGroupedAsync(int year, int month, CancellationToken ct)
+    {
+        var from = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = from.AddMonths(1);
+
+        // Income from paid invoices this month matched by product name
+        var paidItems = await db.InvoiceItems
+            .Join(db.Invoices.Where(i => i.Status == InvoiceStatus.Paid && i.CreatedAt >= from && i.CreatedAt < to),
+                item => item.InvoiceId, inv => inv.Id, (item, inv) => item)
+            .GroupBy(item => item.Description)
+            .Select(g => new { Name = g.Key, Units = g.Sum(x => x.Quantity), Income = g.Sum(x => x.UnitPrice * x.Quantity) })
+            .ToListAsync(ct);
+
+        var incomeMap = paidItems.ToDictionary(x => x.Name, x => new { x.Units, x.Income });
+
+        var groups = await db.ProductGroups
+            .Where(g => g.IsActive)
+            .Include(g => g.Products.Where(p => p.Status == Domain.Products.ProductStatus.Active))
+            .OrderBy(g => g.Name)
+            .ToListAsync(ct);
+
+        var result = groups.Select(g =>
+        {
+            var products = g.Products.Select(p =>
+            {
+                var sale = incomeMap.GetValueOrDefault(p.Name);
+                return new IncomeByProductRowDto(p.Id, p.Name, sale?.Units ?? 0, sale?.Income ?? 0m);
+            }).ToList();
+
+            return new IncomeByProductGroupDto(
+                g.Name,
+                products,
+                products.Sum(p => p.UnitsSold),
+                products.Sum(p => p.TotalIncome));
+        }).ToList();
+
+        return new IncomeByProductGroupedDto(
+            month, year, result,
+            result.Sum(g => g.GroupUnitsSold),
+            result.Sum(g => g.GroupIncome));
+    }
+
+    /// <inheritdoc/>
+    public async Task<MonthlyOrdersDto> GetMonthlyOrdersAsync(int year, int month, CancellationToken ct)
+    {
+        var from = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = from.AddMonths(1);
+
+        // Get all orders in this month with their items
+        var orderItems = await db.Orders
+            .Where(o => o.CreatedAt >= from && o.CreatedAt < to && o.Status == Domain.Orders.OrderStatus.Active)
+            .SelectMany(o => o.Items)
+            .GroupBy(i => i.ProductId)
+            .Select(g => new { ProductId = g.Key, Units = g.Count(), Value = g.Sum(i => i.FirstPaymentAmount) })
+            .ToListAsync(ct);
+
+        var salesMap = orderItems.ToDictionary(x => x.ProductId, x => new { x.Units, x.Value });
+
+        // Get all product groups with their products
+        var groups = await db.ProductGroups
+            .Where(g => g.IsActive)
+            .Include(g => g.Products.Where(p => p.Status == Domain.Products.ProductStatus.Active))
+            .OrderBy(g => g.Name)
+            .ToListAsync(ct);
+
+        var result = groups.Select(g =>
+        {
+            var products = g.Products.Select(p =>
+            {
+                var sale = salesMap.GetValueOrDefault(p.Id);
+                return new MonthlyOrderProductDto(p.Id, p.Name, sale?.Units ?? 0, sale?.Value ?? 0m);
+            }).ToList();
+
+            return new MonthlyOrderGroupDto(
+                g.Name,
+                products,
+                products.Sum(p => p.UnitsSold),
+                products.Sum(p => p.Value));
+        }).ToList();
+
+        return new MonthlyOrdersDto(
+            month, year, result,
+            result.Sum(g => g.GroupUnitsSold),
+            result.Sum(g => g.GroupValue));
+    }
+
+    /// <inheritdoc/>
+    public async Task<ServiceReportResultDto> GetServicesReportAsync(
+        string? status, string? billingCycle,
+        DateOnly? createdFrom, DateOnly? createdTo,
+        DateOnly? nextDueFrom, DateOnly? nextDueTo,
+        DateOnly? terminatedFrom, DateOnly? terminatedTo,
+        int page, int pageSize, CancellationToken ct)
+    {
+        var query = db.ClientServices.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(s => s.Status.ToString() == status);
+        if (!string.IsNullOrWhiteSpace(billingCycle))
+            query = query.Where(s => s.BillingCycle.ToLower() == billingCycle.ToLower());
+        if (createdFrom.HasValue)
+            query = query.Where(s => s.CreatedAt >= createdFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (createdTo.HasValue)
+            query = query.Where(s => s.CreatedAt <= createdTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+        if (nextDueFrom.HasValue)
+            query = query.Where(s => s.NextRenewalAt >= nextDueFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (nextDueTo.HasValue)
+            query = query.Where(s => s.NextRenewalAt <= nextDueTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+        if (terminatedFrom.HasValue)
+            query = query.Where(s => s.TerminatedAt >= terminatedFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (terminatedTo.HasValue)
+            query = query.Where(s => s.TerminatedAt <= terminatedTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+
+        var totalCount = await query.CountAsync(ct);
+
+        var clientIds = await query.Select(s => s.ClientId).Distinct().ToListAsync(ct);
+        var clientNames = await db.Clients
+            .Where(c => clientIds.Contains(c.Id))
+            .Select(c => new { c.Id, Name = c.FirstName + " " + c.LastName })
+            .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
+
+        var productIds = await query.Select(s => s.ProductId).Distinct().ToListAsync(ct);
+        var productNames = await db.Products
+            .Where(p => productIds.Contains(p.Id))
+            .Select(p => new { p.Id, p.Name })
+            .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
+
+        var items = await query
+            .OrderByDescending(s => s.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        var result = items.Select(s => new ServiceReportDto(
+            s.Id,
+            s.ClientId,
+            clientNames.GetValueOrDefault(s.ClientId, ""),
+            s.ProductId,
+            productNames.GetValueOrDefault(s.ProductId, ""),
+            s.Domain,
+            s.BillingCycle,
+            s.FirstPaymentAmount,
+            s.RecurringAmount,
+            s.PaymentMethod,
+            s.CreatedAt.ToString("yyyy-MM-dd"),
+            s.NextRenewalAt?.ToString("yyyy-MM-dd"),
+            s.TerminatedAt?.ToString("yyyy-MM-dd"),
+            s.Status.ToString(),
+            s.AdminNotes)).ToList();
+
+        return new ServiceReportResultDto(result, totalCount);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DomainReportResultDto> GetDomainsReportAsync(
+        string? status, string? registrar,
+        DateOnly? registeredFrom, DateOnly? registeredTo,
+        DateOnly? expiresFrom, DateOnly? expiresTo,
+        DateOnly? nextDueFrom, DateOnly? nextDueTo,
+        int page, int pageSize, CancellationToken ct)
+    {
+        var query = db.Domains.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(d => d.Status.ToString() == status);
+        if (!string.IsNullOrWhiteSpace(registrar))
+            query = query.Where(d => d.Registrar != null && d.Registrar.ToLower().Contains(registrar.ToLower()));
+        if (registeredFrom.HasValue)
+            query = query.Where(d => d.RegisteredAt >= registeredFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (registeredTo.HasValue)
+            query = query.Where(d => d.RegisteredAt <= registeredTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+        if (expiresFrom.HasValue)
+            query = query.Where(d => d.ExpiresAt >= expiresFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (expiresTo.HasValue)
+            query = query.Where(d => d.ExpiresAt <= expiresTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+        if (nextDueFrom.HasValue)
+            query = query.Where(d => d.NextDueDate >= nextDueFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+        if (nextDueTo.HasValue)
+            query = query.Where(d => d.NextDueDate <= nextDueTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+
+        var totalCount = await query.CountAsync(ct);
+
+        var clientIds = await query.Select(d => d.ClientId).Distinct().ToListAsync(ct);
+        var clientNames = await db.Clients
+            .Where(c => clientIds.Contains(c.Id))
+            .Join(db.Users, c => c.UserId, u => u.Id,
+                (c, u) => new { c.Id, Name = c.FirstName + " " + c.LastName })
+            .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
+
+        var items = await query
+            .OrderByDescending(d => d.RegisteredAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(d => new
+            {
+                d.Id, d.ClientId, d.OrderId, d.OrderType,
+                d.Name, d.Tld, d.FirstPaymentAmount, d.RecurringAmount,
+                d.RegistrationPeriod, d.RegisteredAt, d.ExpiresAt,
+                d.NextDueDate, d.Registrar, d.PaymentMethod,
+                d.Status, d.AdminNotes
+            })
+            .ToListAsync(ct);
+
+        var result = items.Select(d => new DomainReportDto(
+            d.Id,
+            d.ClientId,
+            clientNames.GetValueOrDefault(d.ClientId, ""),
+            d.OrderId,
+            d.OrderType,
+            $"{d.Name}.{d.Tld}",
+            d.FirstPaymentAmount,
+            d.RecurringAmount,
+            d.RegistrationPeriod,
+            d.RegisteredAt.ToString("yyyy-MM-dd"),
+            d.ExpiresAt.ToString("yyyy-MM-dd"),
+            d.NextDueDate.ToString("yyyy-MM-dd"),
+            d.Registrar,
+            d.PaymentMethod,
+            d.Status.ToString(),
+            d.AdminNotes)).ToList();
+
+        return new DomainReportResultDto(result, totalCount);
+    }
+
+    /// <inheritdoc/>
+    public async Task<ClientReportResultDto> GetClientsReportAsync(
+        string? status, string? country, DateOnly? createdFrom, DateOnly? createdTo,
+        int page, int pageSize, CancellationToken ct)
+    {
+        var query = db.Clients.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(c => c.Status.ToString() == status);
+
+        if (!string.IsNullOrWhiteSpace(country))
+            query = query.Where(c => c.Country != null && c.Country.ToLower().Contains(country.ToLower()));
+
+        if (createdFrom.HasValue)
+        {
+            var from = createdFrom.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            query = query.Where(c => c.CreatedAt >= from);
+        }
+
+        if (createdTo.HasValue)
+        {
+            var to = createdTo.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
+            query = query.Where(c => c.CreatedAt <= to);
+        }
+
+        var totalCount = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Join(db.Users,
+                c => c.UserId,
+                u => u.Id,
+                (c, u) => new ClientReportDto(
+                    c.Id,
+                    c.FirstName,
+                    c.LastName,
+                    c.CompanyName,
+                    u.Email ?? "",
+                    c.Street,
+                    c.Address2,
+                    c.City,
+                    c.State,
+                    c.PostCode,
+                    c.Country,
+                    c.Phone,
+                    c.Currency,
+                    c.CreditBalance,
+                    c.Status.ToString(),
+                    c.CreatedAt.ToString("yyyy-MM-dd"),
+                    c.AdminNotes))
+            .ToListAsync(ct);
+
+        return new ClientReportResultDto(items, totalCount);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ProductSuspensionRowDto>> GetProductSuspensionsAsync(CancellationToken ct)
+    {
+        var raw = await db.ClientServices
+            .Where(s => s.Status == Domain.Services.ServiceStatus.Suspended)
+            .Join(db.Clients, s => s.ClientId, c => c.Id, (s, c) => new { s, c })
+            .Join(db.Products, x => x.s.ProductId, p => p.Id, (x, p) => new
+            {
+                ServiceId    = x.s.Id,
+                ClientName   = x.c.FirstName + " " + x.c.LastName,
+                ProductName  = p.Name,
+                Domain       = x.s.Domain,
+                NextRenewalAt = x.s.NextRenewalAt,
+                AdminNotes   = x.s.AdminNotes,
+            })
+            .OrderBy(r => r.ClientName)
+            .ToListAsync(ct);
+
+        return raw.Select(r => new ProductSuspensionRowDto(
+            r.ServiceId,
+            r.ClientName,
+            r.ProductName,
+            r.Domain,
+            r.NextRenewalAt.HasValue ? r.NextRenewalAt.Value.ToString("yyyy-MM-dd") : null,
+            r.AdminNotes)).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<SupportTicketRepliesDto> GetSupportTicketRepliesAsync(int year, int month, CancellationToken ct)
+    {
+        var from = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = from.AddMonths(1);
+        int daysInMonth = DateTime.DaysInMonth(year, month);
+
+        // Get all staff replies for this month
+        var replies = await db.Tickets
+            .SelectMany(t => t.Replies)
+            .Where(r => r.IsStaffReply && r.CreatedAt >= from && r.CreatedAt < to)
+            .Select(r => new { r.AuthorName, Day = r.CreatedAt.Day })
+            .ToListAsync(ct);
+
+        // Group by admin name
+        var grouped = replies
+            .GroupBy(r => r.AuthorName)
+            .OrderBy(g => g.Key)
+            .Select(g =>
+            {
+                var byDay = g.GroupBy(r => r.Day).ToDictionary(x => x.Key, x => x.Count());
+                var dailyCounts = Enumerable.Range(1, daysInMonth)
+                    .Select(d => byDay.GetValueOrDefault(d, 0))
+                    .ToList();
+                return new SupportTicketRepliesRowDto(g.Key, dailyCounts, g.Count());
+            })
+            .ToList();
+
+        return new SupportTicketRepliesDto(month, year, daysInMonth, grouped);
+    }
+
+    /// <inheritdoc/>
+    public async Task<SalesTaxReportDto> GetSalesTaxReportAsync(DateOnly? from, DateOnly? to, CancellationToken ct)
+    {
+        var baseQuery = db.Invoices
+            .Where(i => i.Status == InvoiceStatus.Paid);
+
+        if (from.HasValue)
+        {
+            var fromDt = new DateTimeOffset(from.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+            baseQuery = baseQuery.Where(i => i.CreatedAt >= fromDt);
+        }
+        if (to.HasValue)
+        {
+            var toDt = new DateTimeOffset(to.Value.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc));
+            baseQuery = baseQuery.Where(i => i.CreatedAt <= toDt);
+        }
+
+        var rows = await baseQuery
+            .OrderBy(i => i.CreatedAt)
+            .Join(db.Clients, i => i.ClientId, c => c.Id, (i, c) => new SalesTaxRowDto(
+                i.Id,
+                c.FirstName + " " + c.LastName,
+                i.CreatedAt.ToString("dd/MM/yyyy"),
+                i.PaidAt != null ? i.PaidAt.Value.ToString("dd/MM/yyyy") : null,
+                i.SubTotal,
+                i.Tax,
+                i.Credit,
+                i.Total))
+            .ToListAsync(ct);
+
+        return new SalesTaxReportDto(
+            rows.Count,
+            rows.Sum(r => r.Total),
+            rows.Sum(r => r.Tax),   // Tax Level 1 — total tax
+            0m,                      // Tax Level 2 — not used in our system
+            rows);
+    }
+
+    /// <inheritdoc/>
+    public async Task<MonthlyTransactionsReportDto> GetDailyTransactionsAsync(int year, int month, CancellationToken ct)
+    {
+        var from = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = from.AddMonths(1);
+
+        // Aggregate transactions by day
+        var dailyRows = await db.Transactions
+            .Where(t => t.Date >= from && t.Date < to)
+            .GroupBy(t => t.Date.Date)
+            .Select(g => new
+            {
+                Date = g.Key,
+                AmountIn = g.Sum(t => t.AmountIn),
+                Fees = g.Sum(t => t.Fees),
+                AmountOut = g.Sum(t => t.AmountOut),
+            })
+            .OrderBy(r => r.Date)
+            .ToListAsync(ct);
+
+        // Map aggregated rows by date for quick lookup
+        var map = dailyRows.ToDictionary(r => r.Date.Date);
+
+        // Fill all days of the month — zeros for days without transactions
+        int daysInMonth = DateTime.DaysInMonth(year, month);
+        var rows = new List<DailyTransactionDto>();
+        for (int day = 1; day <= daysInMonth; day++)
+        {
+            var date = new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+            map.TryGetValue(date, out var r);
+            decimal amtIn  = r?.AmountIn  ?? 0m;
+            decimal fees   = r?.Fees      ?? 0m;
+            decimal amtOut = r?.AmountOut ?? 0m;
+            // Balance = daily net (same as WHMCS: AmountIn - Fees - AmountOut)
+            decimal balance = amtIn - fees - amtOut;
+            rows.Add(new DailyTransactionDto(
+                date.ToString("yyyy-MM-dd"),
+                amtIn, fees, amtOut, balance));
+        }
+
+        return new MonthlyTransactionsReportDto(
+            month, year, rows,
+            rows.Sum(r => r.AmountIn),
+            rows.Sum(r => r.Fees),
+            rows.Sum(r => r.AmountOut));
+    }
 }


### PR DESCRIPTION
Summary
Implemented 19 report views with real backend data.

Changes
Backend:

9 new DTOs: ClientReport, DomainReport, ServiceReport, MonthlyOrders, IncomeByProductGrouped, DailyTransaction, SalesTax, SupportTicketReplies, ProductSuspensions
Implemented all repository methods and API endpoints in ReportsController
DevDataSeeder: added product-matched invoice seed data for Income by Product report

Frontend:

Monthly Transactions — line chart (AmountIn/Fees/AmountOut) + daily table
Income by Product — grouped by product group + currency selector
Monthly Orders — grouped by product group + currency selector
Sales Tax Liability — paid invoices with tax breakdown + summary
Support Ticket Replies — admin × day of month matrix
Product Suspensions — suspended services table
ReportTimestamp added to all 19 report views
DateRangePicker: fixed positioning via Teleport to body
FieldSelector: added Apply button
Checklist
 Code follows the style rules (rules/ folder)
 dotnet format run (backend changes)
 XML docs added to all new C# members
 JSDoc added to all new exported TypeScript/Vue functions
 No hardcoded secrets or credentials
 Tested locally
