### PR TITLE
feat(auth): add server-side token refresh with global 401 handling

### DIFF
--- a/client/composables/useApi.ts
+++ b/client/composables/useApi.ts
@@ -9,26 +9,43 @@
  *
  * - `apiFetch`  — wraps `$fetch` for one-shot calls (event handlers, Pinia stores).
  *                 Always runs client-side so relative URLs are fine.
- *                 Same headers + 401 handling.
+ *                 Same headers. On 401: delegates to the global auth guard plugin.
+ *
+ * 401 handling strategy:
+ * - The Nuxt server transparently refreshes expired tokens before the client
+ *   ever sees a 401. If a 401 reaches the client, it means the refresh token
+ *   is also expired — the session is truly dead.
+ * - `apiFetch` catches 401s and calls `$handleAuthExpired()` from the
+ *   auth-guard plugin to clear state and redirect to login.
+ * - `useApi` does NOT handle 401s — errors from useFetch are caught by
+ *   the calling component or by Vue's error boundaries.
  */
 import type { MaybeRefOrGetter } from 'vue'
 import type { UseFetchOptions } from 'nuxt/app'
 
+/** Options for the useApi composable, extending useFetch options. */
 export interface UseApiOptions<T> extends Omit<UseFetchOptions<T>, 'key' | 'query' | 'watch'> {
+  /** Query parameters — reactive or static. */
   query?: MaybeRefOrGetter<Record<string, unknown>>
+  /** Additional sources to watch for automatic re-fetch. */
   watch?: UseFetchOptions<T>['watch']
 }
 
+/**
+ * SSR-aware API composable wrapping `useFetch` with locale-aware caching.
+ *
+ * @param url - API endpoint URL (reactive or static)
+ * @param options - Fetch options
+ * @returns useFetch return value with reactive data, error, pending, etc.
+ */
 export function useApi<T = unknown>(url: MaybeRefOrGetter<string>, options: UseApiOptions<T> = {}) {
   const { locale } = useI18n()
 
-  // Destructure known overrides; spread the rest (server, lazy, transform, etc.) through to useFetch
   const { query, watch: watchOpts, default: defaultFn, headers: extraHeaders, ...restOptions } = options
 
   const resolvedUrl = computed(() => toValue(url))
   const resolvedQuery = computed(() => toValue(query) ?? {})
 
-  // Explicit key: locale + url + serialized query → unique SSR cache per locale
   const key = `api:${locale.value}:${toValue(url)}:${JSON.stringify(toValue(query) ?? {})}`
 
   return useFetch<T>(resolvedUrl, {
@@ -39,16 +56,21 @@ export function useApi<T = unknown>(url: MaybeRefOrGetter<string>, options: UseA
       ...(extraHeaders as Record<string, string> | undefined ?? {})
     })),
     default: defaultFn,
-    // re-run when locale or query changes
     watch: [locale, resolvedQuery, ...(watchOpts ?? [])],
-    onResponseError({ response }) {
-      if (response.status === 401) navigateTo('/client/login')
-    },
-    // Forward any remaining options (server, lazy, immediate, transform, …)
     ...restOptions
   } as UseFetchOptions<T>)
 }
 
+/**
+ * One-shot API fetch for event handlers and Pinia stores.
+ *
+ * On 401 (session truly expired — server-side refresh already failed),
+ * delegates to the global auth guard plugin to clear state and redirect.
+ *
+ * @param url - API endpoint URL
+ * @param opts - $fetch options
+ * @returns Parsed response data
+ */
 export async function apiFetch<T = unknown>(
   url: string,
   opts: Parameters<typeof $fetch>[1] = {}
@@ -58,16 +80,26 @@ export async function apiFetch<T = unknown>(
     locale = (useNuxtApp().$i18n as { locale: { value: string } }).locale.value
   } catch {}
 
-  return $fetch<T>(url, {
-    ...opts,
-    headers: {
-      'x-locale': locale,
-      ...(opts.headers as Record<string, string> | undefined ?? {})
-    },
-    onResponseError({ response }) {
-      if (response.status === 401) {
-        useNuxtApp().runWithContext(() => navigateTo('/client/login'))
+  try {
+    return await $fetch<T>(url, {
+      ...opts,
+      headers: {
+        'x-locale': locale,
+        ...(opts.headers as Record<string, string> | undefined ?? {})
+      }
+    })
+  } catch (err: unknown) {
+    const statusCode = (err as { statusCode?: number })?.statusCode
+      ?? (err as { status?: number })?.status
+
+    if (statusCode === 401) {
+      const nuxtApp = useNuxtApp()
+      const handleAuthExpired = nuxtApp.$handleAuthExpired as (() => Promise<void>) | undefined
+      if (handleAuthExpired) {
+        await nuxtApp.runWithContext(() => handleAuthExpired())
       }
     }
-  })
+
+    throw err
+  }
 }

--- a/client/plugins/auth-guard.ts
+++ b/client/plugins/auth-guard.ts
@@ -1,0 +1,37 @@
+/**
+ * Global auth guard plugin — runs on CLIENT SIDE ONLY
+ *
+ * Provides a global `$handleAuthExpired()` function that clears all
+ * client-side auth state and redirects to the login page.
+ *
+ * Called from `apiFetch` when a 401 reaches the client (meaning the
+ * server-side token refresh also failed — the session is truly expired).
+ *
+ * Uses a `provide` pattern rather than `app:error` or `vue:error` hooks
+ * because those hooks don't reliably catch `$fetch` errors from Pinia stores.
+ * Instead, `apiFetch` (the single gateway for all client API calls) checks
+ * for 401 and calls `$handleAuthExpired()` directly.
+ */
+import { useClientStore } from '~/stores/client'
+
+export default defineNuxtPlugin(() => {
+  if (!import.meta.client) return
+
+  return {
+    provide: {
+      handleAuthExpired: () => {
+        try {
+          const store = useClientStore()
+          store.reset()
+        } catch {
+          // Store may not be initialized
+        }
+
+        const authedCookie = useCookie('authed')
+        authedCookie.value = null
+
+        return navigateTo('/client/login')
+      },
+    },
+  }
+})

--- a/client/server/api/portal/auth/accept-invite.post.ts
+++ b/client/server/api/portal/auth/accept-invite.post.ts
@@ -1,8 +1,12 @@
 /**
  * POST /api/portal/auth/accept-invite
- * Accepts a user invitation by setting the password, then returns an authenticated session.
- * Sets the JWT auth cookie so the user is logged in immediately after accepting.
+ *
+ * Accepts a user invitation by setting the password, then returns an
+ * authenticated session. Captures both access and refresh tokens from
+ * the backend response.
  */
+import { setAuthCookie, setRefreshCookie } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { token, password } = body ?? {}
@@ -11,20 +15,56 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Token and password are required' })
   }
 
-  const response = await internalApiCall<{ accessToken: string; expiresAt: string; role: string }>(
-    event,
-    '/auth/accept-invite',
-    { method: 'POST', body: { token, password } }
-  )
-
-  setAuthCookie(event, response.accessToken)
-
-  // Fetch full user profile with the new token
   const config = useRuntimeConfig()
   const apiUrl = (config.apiUrl as string) || 'http://localhost:5000'
+
+  let accessToken: string
+
+  try {
+    const response = await $fetch.raw<{ accessToken: string; expiresAt: string; role: string }>(
+      `${apiUrl}/api/auth/accept-invite`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      }
+    )
+
+    accessToken = response._data?.accessToken ?? ''
+    if (!accessToken) {
+      throw createError({ statusCode: 502, statusMessage: 'Backend returned no access token' })
+    }
+
+    setAuthCookie(event, accessToken)
+
+    // Extract refresh token from backend's Set-Cookie header
+    const setCookieHeaders = response.headers.getSetCookie()
+    for (const cookie of setCookieHeaders) {
+      if (cookie.startsWith('refreshToken=')) {
+        const value = cookie.split(';')[0]?.substring('refreshToken='.length)
+        if (value) {
+          setRefreshCookie(event, value)
+        }
+        break
+      }
+    }
+  } catch (err: unknown) {
+    if ((err as { statusCode?: number })?.statusCode === 400 || (err as { statusCode?: number })?.statusCode === 502) {
+      throw err
+    }
+    const fetchErr = err as { status?: number; statusCode?: number; data?: unknown; message?: string }
+    const status = fetchErr?.status ?? fetchErr?.statusCode ?? 400
+    const data = fetchErr?.data as { error?: string; message?: string } | undefined
+    throw createError({
+      statusCode: status,
+      statusMessage: data?.error ?? data?.message ?? 'Failed to accept invitation',
+    })
+  }
+
+  // Fetch full user profile with the new token
   try {
     const user = await $fetch(`${apiUrl}/api/clients/me`, {
-      headers: { Authorization: `Bearer ${response.accessToken}` }
+      headers: { Authorization: `Bearer ${accessToken}` },
     })
     return user
   } catch {

--- a/client/server/api/portal/auth/login.post.ts
+++ b/client/server/api/portal/auth/login.post.ts
@@ -1,7 +1,12 @@
 /**
  * POST /api/portal/auth/login
- * Authenticates a client against the C# backend and sets a JWT auth cookie.
+ *
+ * Authenticates a client against the C# backend.
+ * Captures the access token from the response body and the refresh token
+ * from the Set-Cookie header, then sets both as httpOnly cookies.
  */
+import { setAuthCookie, setRefreshCookie } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { email, password } = body ?? {}
@@ -10,17 +15,55 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Email and password are required' })
   }
 
-  const response = await internalApiCall<{ accessToken: string; expiresAt: string; role: string }>(
-    event,
-    '/auth/login',
-    { method: 'POST', body: { email, password } }
-  )
+  const config = useRuntimeConfig()
+  const apiUrl = (config.apiUrl as string) || 'http://localhost:5000'
 
-  setAuthCookie(event, response.accessToken)
+  let accessToken: string
+
+  try {
+    const response = await $fetch.raw<{ accessToken: string; expiresAt: string; role: string }>(
+      `${apiUrl}/api/auth/login`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      }
+    )
+
+    accessToken = response._data?.accessToken ?? ''
+    if (!accessToken) {
+      throw createError({ statusCode: 502, statusMessage: 'Backend returned no access token' })
+    }
+
+    setAuthCookie(event, accessToken)
+
+    // Extract refresh token from backend's Set-Cookie header
+    const setCookieHeaders = response.headers.getSetCookie()
+    for (const cookie of setCookieHeaders) {
+      if (cookie.startsWith('refreshToken=')) {
+        const value = cookie.split(';')[0]?.substring('refreshToken='.length)
+        if (value) {
+          setRefreshCookie(event, value)
+        }
+        break
+      }
+    }
+  } catch (err: unknown) {
+    if ((err as { statusCode?: number })?.statusCode === 400 || (err as { statusCode?: number })?.statusCode === 502) {
+      throw err
+    }
+    const fetchErr = err as { status?: number; statusCode?: number; data?: unknown; message?: string }
+    const status = fetchErr?.status ?? fetchErr?.statusCode ?? 401
+    const data = fetchErr?.data as { error?: string; message?: string } | undefined
+    throw createError({
+      statusCode: status,
+      statusMessage: data?.error ?? data?.message ?? 'Login failed',
+    })
+  }
 
   // Fetch full user profile with the new token
   const user = await $fetch(`${(useRuntimeConfig().apiUrl as string) || 'http://localhost:5000'}/api/clients/me`, {
-    headers: { Authorization: `Bearer ${response.accessToken}` }
+    headers: { Authorization: `Bearer ${accessToken}` },
   })
 
   return user

--- a/client/server/api/portal/auth/logout.post.ts
+++ b/client/server/api/portal/auth/logout.post.ts
@@ -1,14 +1,30 @@
 /**
  * POST /api/portal/auth/logout
- * Calls the backend logout endpoint and clears the JWT auth cookies.
+ *
+ * Revokes the refresh token on the backend and clears all auth cookies.
+ * Forwards the refresh token as a Cookie header since the backend reads
+ * it from `Request.Cookies["refreshToken"]`.
  */
+import { clearAllAuthCookies } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
+  const refreshToken = getCookie(event, 'refresh_token')
+
   try {
-    await internalApiCall(event, '/auth/logout', { method: 'POST' })
+    const config = useRuntimeConfig()
+    const apiUrl = (config.apiUrl as string) || 'http://localhost:5000'
+
+    await $fetch(`${apiUrl}/api/auth/logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(refreshToken ? { Cookie: `refreshToken=${refreshToken}` } : {}),
+      },
+    })
   } catch {
     // Ignore backend errors on logout — clear cookies regardless
   }
 
-  clearAuthCookie(event)
+  clearAllAuthCookies(event)
   return { ok: true }
 })

--- a/client/server/utils/api.ts
+++ b/client/server/utils/api.ts
@@ -1,21 +1,120 @@
 /**
- * C# backend API utility — server-side only
+ * C# backend API utility -- server-side only
  *
  * All backend API calls go through `internalApiCall`. It:
  * - Reads `apiUrl` from runtimeConfig (set via API_URL env var)
- * - Attaches the JWT token from the `auth_token` httpOnly cookie
+ * - Attaches the JWT access token from the `auth_token` httpOnly cookie
+ * - On 401: silently refreshes the token using the `refresh_token` cookie
+ *   and retries the request once
  * - Throws appropriate H3 errors on failure
- *
- * Usage:
- * ```ts
- * const data = await internalApiCall<ClientDto>(event, '/clients/me')
- * ```
  */
 
 import type { H3Event } from 'h3'
 
+/** Module-level lock to prevent concurrent refresh calls. */
+let refreshPromise: Promise<string | null> | null = null
+
+/**
+ * Resolve the C# backend base URL from runtime config.
+ *
+ * @returns The backend API base URL, e.g. `http://localhost:5000`.
+ */
+function getApiUrl(): string {
+  const config = useRuntimeConfig()
+  return (config.apiUrl as string) || 'http://localhost:5000'
+}
+
+/**
+ * Parse a refresh token value from the backend's Set-Cookie headers.
+ *
+ * The C# backend sets: `refreshToken=<value>; HttpOnly; Secure; SameSite=Strict; Expires=...`
+ * We extract just the token value.
+ *
+ * @param headers - Response headers from $fetch.raw()
+ * @returns The raw refresh token string, or null if not found.
+ */
+function extractRefreshTokenFromHeaders(headers: Headers): string | null {
+  const setCookieHeaders = headers.getSetCookie()
+  for (const cookie of setCookieHeaders) {
+    if (cookie.startsWith('refreshToken=')) {
+      const value = cookie.split(';')[0]?.substring('refreshToken='.length)
+      return value || null
+    }
+  }
+  return null
+}
+
+/**
+ * Attempt to refresh the access token using the stored refresh token.
+ *
+ * Calls the C# backend's `POST /api/auth/refresh` endpoint, forwarding the
+ * refresh token as a Cookie header. On success, updates all auth cookies and
+ * returns the new access token. On failure, clears all cookies and returns null.
+ *
+ * Uses a module-level promise lock so concurrent 401s share a single refresh call.
+ *
+ * @param event - H3 event (needed to read/write cookies on the browser response)
+ * @returns The new access token string, or null if refresh failed.
+ */
+export async function tryRefreshToken(event: H3Event): Promise<string | null> {
+  // If a refresh is already in progress, wait for it
+  if (refreshPromise) {
+    return refreshPromise
+  }
+
+  const refreshToken = getCookie(event, 'refresh_token')
+  if (!refreshToken) {
+    clearAllAuthCookies(event)
+    return null
+  }
+
+  refreshPromise = (async () => {
+    try {
+      const apiUrl = getApiUrl()
+      const response = await $fetch.raw<{ accessToken: string; expiresAt: string; role: string }>(
+        `${apiUrl}/api/auth/refresh`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Cookie: `refreshToken=${refreshToken}`,
+          },
+        }
+      )
+
+      const newAccessToken = response._data?.accessToken
+      if (!newAccessToken) {
+        clearAllAuthCookies(event)
+        return null
+      }
+
+      // Extract the rotated refresh token from Set-Cookie header
+      const newRefreshToken = extractRefreshTokenFromHeaders(response.headers)
+
+      setAuthCookie(event, newAccessToken)
+      if (newRefreshToken) {
+        setRefreshCookie(event, newRefreshToken)
+      }
+
+      return newAccessToken
+    } catch {
+      clearAllAuthCookies(event)
+      return null
+    }
+  })()
+
+  try {
+    return await refreshPromise
+  } finally {
+    refreshPromise = null
+  }
+}
+
 /**
  * Make an authenticated request to the internal C# backend API.
+ *
+ * On 401 responses, automatically attempts a token refresh and retries
+ * the request once. If refresh fails, throws 401 to the client.
  *
  * @param event - H3 event from the Nuxt server route handler
  * @param endpoint - API path after `/api`, e.g. `/clients/me`
@@ -32,28 +131,54 @@ export async function internalApiCall<T>(
     headers?: Record<string, string>
   } = {}
 ): Promise<T> {
-  const config = useRuntimeConfig()
-  const apiUrl = (config.apiUrl as string) || 'http://localhost:5000'
+  const apiUrl = getApiUrl()
   const token = getCookie(event, 'auth_token')
 
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...options.headers,
+  const buildHeaders = (bearerToken: string | undefined): Record<string, string> => {
+    const h: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    }
+    if (bearerToken) {
+      h['Authorization'] = `Bearer ${bearerToken}`
+    }
+    return h
   }
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-
-  try {
-    return await $fetch<T>(`${apiUrl}/api${endpoint}`, {
+  const makeRequest = (bearerToken: string | undefined): Promise<T> =>
+    $fetch<T>(`${apiUrl}/api${endpoint}`, {
       method: options.method ?? 'GET',
-      headers,
+      headers: buildHeaders(bearerToken),
       body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
     })
+
+  try {
+    return await makeRequest(token)
   } catch (err: unknown) {
     const fetchErr = err as { status?: number; statusCode?: number; data?: unknown; message?: string }
     const status = fetchErr?.status ?? fetchErr?.statusCode ?? 502
+
+    // On 401: attempt token refresh and retry (skip for auth endpoints to avoid loops)
+    const isAuthEndpoint = endpoint.startsWith('/auth/')
+    if (status === 401 && !isAuthEndpoint) {
+      const newToken = await tryRefreshToken(event)
+      if (newToken) {
+        try {
+          return await makeRequest(newToken)
+        } catch (retryErr: unknown) {
+          const retryFetchErr = retryErr as { status?: number; statusCode?: number; data?: unknown; message?: string }
+          const retryStatus = retryFetchErr?.status ?? retryFetchErr?.statusCode ?? 502
+          const retryData = retryFetchErr?.data as { error?: string; message?: string } | undefined
+          const retryMessage = retryData?.error
+            ?? retryData?.message
+            ?? retryFetchErr?.message
+            ?? `Backend API error for ${endpoint}`
+
+          throw createError({ statusCode: retryStatus, statusMessage: retryMessage })
+        }
+      }
+    }
+
     const data = fetchErr?.data as { error?: string; message?: string } | undefined
     const message = data?.error
       ?? data?.message
@@ -65,7 +190,11 @@ export async function internalApiCall<T>(
 }
 
 /**
- * Set the JWT auth cookie on the response.
+ * Set the JWT access token cookie on the response.
+ *
+ * MaxAge is 15 minutes to match the backend JWT lifetime.
+ * Also sets the `authed` flag cookie (7 days, non-httpOnly) so client-side
+ * middleware can check login status without reading the token.
  *
  * @param event - H3 event
  * @param token - JWT access token from the C# API
@@ -75,26 +204,45 @@ export function setAuthCookie(event: H3Event, token: string): void {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
-    maxAge: 60 * 60 * 24 * 7, // 7 days
+    maxAge: 60 * 15, // 15 minutes -- matches JWT expiry
     path: '/',
   })
 
-  // Readable flag cookie — lets client-side JS and middleware know user is logged in
   setCookie(event, 'authed', '1', {
     httpOnly: false,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
-    maxAge: 60 * 60 * 24 * 7,
+    maxAge: 60 * 60 * 24 * 7, // 7 days -- matches refresh token lifetime
     path: '/',
   })
 }
 
 /**
- * Clear the JWT auth cookie and the readable auth flag cookie.
+ * Set the refresh token cookie on the response.
+ *
+ * httpOnly and Secure in production. 7-day lifetime to match the
+ * backend's refresh token expiry.
+ *
+ * @param event - H3 event
+ * @param token - Opaque refresh token from the C# API
+ */
+export function setRefreshCookie(event: H3Event, token: string): void {
+  setCookie(event, 'refresh_token', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 7, // 7 days
+    path: '/',
+  })
+}
+
+/**
+ * Clear all auth-related cookies (access token, refresh token, and flag).
  *
  * @param event - H3 event
  */
-export function clearAuthCookie(event: H3Event): void {
+export function clearAllAuthCookies(event: H3Event): void {
   deleteCookie(event, 'auth_token', { path: '/' })
+  deleteCookie(event, 'refresh_token', { path: '/' })
   deleteCookie(event, 'authed', { path: '/' })
 }


### PR DESCRIPTION
- Add transparent JWT refresh in internalApiCall() — on 401, silently refreshes using refresh_token cookie and retries the request once
- Add concurrency lock to prevent parallel refresh storms
- Capture refresh token from backend Set-Cookie on login/accept-invite
- Forward refresh token to backend on logout for revocation
- Fix auth_token cookie maxAge from 7 days to 15 minutes (matches JWT)
- Add global auth-guard plugin for session expiry redirect
- Remove scattered 401 handling from useApi/apiFetch composables