### PR TITLE
fix(auth): remove manual JSON.stringify in $fetch calls

### DIFF
--- a/client/server/api/portal/auth/accept-invite.post.ts
+++ b/client/server/api/portal/auth/accept-invite.post.ts
@@ -25,8 +25,7 @@ export default defineEventHandler(async (event) => {
       `${apiUrl}/api/auth/accept-invite`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, password }),
+        body: { token, password },
       }
     )
 

--- a/client/server/api/portal/auth/login.post.ts
+++ b/client/server/api/portal/auth/login.post.ts
@@ -25,8 +25,7 @@ export default defineEventHandler(async (event) => {
       `${apiUrl}/api/auth/login`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
+        body: { email, password },
       }
     )
 

--- a/client/server/utils/api.ts
+++ b/client/server/utils/api.ts
@@ -76,7 +76,6 @@ export async function tryRefreshToken(event: H3Event): Promise<string | null> {
         {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
             Cookie: `refreshToken=${refreshToken}`,
           },
         }
@@ -149,7 +148,7 @@ export async function internalApiCall<T>(
     $fetch<T>(`${apiUrl}/api${endpoint}`, {
       method: options.method ?? 'GET',
       headers: buildHeaders(bearerToken),
-      body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+      body: options.body,
     })
 
   try {


### PR DESCRIPTION
$fetch/ofetch auto-serializes objects to JSON. Passing pre-stringified JSON caused double-encoding, resulting in 401 on login.