### PR TITLE
feat: show 2FA status in admin clients list and summary, fix reports …

### DIFF
--- a/admin/src/components/layout/AppTopbar.vue
+++ b/admin/src/components/layout/AppTopbar.vue
@@ -28,6 +28,8 @@ const titles: Record<string, string> = {
   '/servers':     'Servers',
   '/integrations':'Integrations',
   '/settings':    'Settings',
+  '/reports':     'Reports',
+  '/orders':      'Orders',
 }
 
 /** Current page title derived from the active route. */

--- a/admin/src/modules/clients/views/ClientSummaryView.vue
+++ b/admin/src/modules/clients/views/ClientSummaryView.vue
@@ -213,6 +213,10 @@ onMounted(() => {
             <span class="text-[0.82rem] font-medium" :class="client.lateFees ? 'text-status-green' : 'text-status-red'">
               {{ client.lateFees ? 'Yes' : 'No' }}
             </span>
+            <span class="text-[0.75rem] text-text-muted">Two-Factor Auth</span>
+            <span class="text-[0.82rem] font-medium" :class="client.twoFactorEnabled ? 'text-status-green' : 'text-status-red'">
+              {{ client.twoFactorEnabled ? 'Enabled' : 'Disabled' }}
+            </span>
           </div>
         </div>
 

--- a/admin/src/modules/clients/views/ClientsListView.vue
+++ b/admin/src/modules/clients/views/ClientsListView.vue
@@ -193,12 +193,13 @@ onMounted(() => store.fetchAll())
     <div v-else-if="store.clients.length > 0" class="bg-surface-card border border-border rounded-2xl overflow-hidden">
 
       <!-- Header row -->
-      <div class="hidden sm:grid grid-cols-[0.5fr_2fr_2fr_1.5fr_1fr_1fr] gap-4 px-5 py-3 border-b border-border bg-white/[0.02]">
+      <div class="hidden sm:grid grid-cols-[0.5fr_2fr_2fr_1.5fr_1fr_0.7fr_1fr] gap-4 px-5 py-3 border-b border-border bg-white/[0.02]">
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">ID</span>
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Name</span>
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Email</span>
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Company</span>
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Status</span>
+        <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">2FA</span>
         <span class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Joined</span>
       </div>
 
@@ -207,7 +208,7 @@ onMounted(() => store.fetchAll())
         v-for="client in store.clients"
         :key="client.id"
         :to="`/clients/${client.id}`"
-        class="grid grid-cols-1 sm:grid-cols-[0.5fr_2fr_2fr_1.5fr_1fr_1fr] gap-2 sm:gap-4 px-5 py-3.5 border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors no-underline"
+        class="grid grid-cols-1 sm:grid-cols-[0.5fr_2fr_2fr_1.5fr_1fr_0.7fr_1fr] gap-2 sm:gap-4 px-5 py-3.5 border-b border-border last:border-0 hover:bg-white/[0.02] transition-colors no-underline"
       >
         <span class="text-[0.82rem] text-text-muted font-mono hidden sm:block">{{ client.id }}</span>
 
@@ -237,6 +238,27 @@ onMounted(() => store.fetchAll())
             :class="statusStyles[client.status] ?? statusStyles.Inactive"
           >
             {{ client.status }}
+          </span>
+        </div>
+
+        <!-- 2FA badge -->
+        <div class="hidden sm:flex items-center">
+          <span
+            v-if="client.twoFactorEnabled"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[0.68rem] font-semibold text-status-green bg-status-green/10 border border-status-green/20"
+            title="Two-Factor Authentication enabled"
+          >
+            <svg class="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+            </svg>
+            On
+          </span>
+          <span
+            v-else
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[0.68rem] font-semibold text-text-muted bg-white/[0.04] border border-border"
+            title="Two-Factor Authentication disabled"
+          >
+            Off
           </span>
         </div>
 

--- a/admin/src/types/models.ts
+++ b/admin/src/types/models.ts
@@ -32,6 +32,8 @@ export interface ClientListItem {
   status: string
   /** True if the linked Identity user has been deleted. */
   isUserDeleted: boolean
+  /** True if the user has TOTP 2FA enabled. */
+  twoFactorEnabled: boolean
   /** ISO 8601 creation timestamp. */
   createdAt: string
 }
@@ -88,6 +90,8 @@ export interface ClientDetail extends ClientListItem {
   statusUpdate: boolean
   /** Whether the client may use single sign-on. */
   allowSso: boolean
+  /** True if the user has TOTP 2FA enabled. */
+  twoFactorEnabled: boolean
   /** Associated contacts. */
   contacts: Contact[]
 }

--- a/backend/src/Innovayse.Application/Clients/DTOs/ClientDto.cs
+++ b/backend/src/Innovayse.Application/Clients/DTOs/ClientDto.cs
@@ -35,6 +35,7 @@ using Innovayse.Domain.Clients;
 /// <param name="MarketingOptIn">Marketing emails opt-in.</param>
 /// <param name="StatusUpdate">Status update emails sent.</param>
 /// <param name="AllowSso">Single sign-on allowed.</param>
+/// <param name="TwoFactorEnabled">True if the user has TOTP 2FA enabled.</param>
 /// <param name="CreatedAt">Account creation timestamp.</param>
 /// <param name="Contacts">Additional contacts linked to this client.</param>
 public record ClientDto(
@@ -70,5 +71,6 @@ public record ClientDto(
     bool MarketingOptIn,
     bool StatusUpdate,
     bool AllowSso,
+    bool TwoFactorEnabled,
     DateTimeOffset CreatedAt,
     IReadOnlyList<ContactDto> Contacts);

--- a/backend/src/Innovayse.Application/Clients/DTOs/ClientListItemDto.cs
+++ b/backend/src/Innovayse.Application/Clients/DTOs/ClientListItemDto.cs
@@ -11,6 +11,7 @@ using Innovayse.Domain.Clients;
 /// <param name="CompanyName">Company name (null for individuals).</param>
 /// <param name="Status">Current account status.</param>
 /// <param name="IsUserDeleted">True if the linked Identity user no longer exists.</param>
+/// <param name="TwoFactorEnabled">True if the user has TOTP 2FA enabled.</param>
 /// <param name="CreatedAt">Account creation timestamp.</param>
 public record ClientListItemDto(
     int Id,
@@ -21,4 +22,5 @@ public record ClientListItemDto(
     string? CompanyName,
     ClientStatus Status,
     bool IsUserDeleted,
+    bool TwoFactorEnabled,
     DateTimeOffset CreatedAt);

--- a/backend/src/Innovayse.Application/Clients/Queries/GetClient/GetClientHandler.cs
+++ b/backend/src/Innovayse.Application/Clients/Queries/GetClient/GetClientHandler.cs
@@ -27,15 +27,17 @@ public sealed class GetClientHandler(IClientRepository clientRepo, IUserService 
 
         var user = await userService.FindByIdAsync(client.UserId, ct);
         var email = user?.Email ?? "";
+        var twoFactorEnabled = await userService.IsTwoFactorEnabledAsync(client.UserId, ct);
 
-        return MapToDto(client, email);
+        return MapToDto(client, email, twoFactorEnabled);
     }
 
     /// <summary>Maps a <see cref="Client"/> aggregate to <see cref="ClientDto"/>.</summary>
     /// <param name="client">The client aggregate to map.</param>
     /// <param name="email">The email from the Identity user.</param>
+    /// <param name="twoFactorEnabled">Whether TOTP 2FA is enabled for the user.</param>
     /// <returns>The mapped DTO.</returns>
-    private static ClientDto MapToDto(Client client, string email) =>
+    private static ClientDto MapToDto(Client client, string email, bool twoFactorEnabled) =>
         new(
             client.Id,
             client.UserId,
@@ -69,6 +71,7 @@ public sealed class GetClientHandler(IClientRepository clientRepo, IUserService 
             client.MarketingOptIn,
             client.StatusUpdate,
             client.AllowSso,
+            twoFactorEnabled,
             client.CreatedAt,
             client.Contacts.Select(c => new ContactDto(
                 c.Id, c.FirstName, c.LastName, c.CompanyName,

--- a/backend/src/Innovayse.Application/Clients/Queries/GetMyProfile/GetMyProfileHandler.cs
+++ b/backend/src/Innovayse.Application/Clients/Queries/GetMyProfile/GetMyProfileHandler.cs
@@ -27,15 +27,17 @@ public sealed class GetMyProfileHandler(IClientRepository clientRepo, IUserServi
 
         var user = await userService.FindByIdAsync(client.UserId, ct);
         var email = user?.Email ?? "";
+        var twoFactorEnabled = await userService.IsTwoFactorEnabledAsync(client.UserId, ct);
 
-        return MapToDto(client, email);
+        return MapToDto(client, email, twoFactorEnabled);
     }
 
     /// <summary>Maps a <see cref="Client"/> aggregate to <see cref="ClientDto"/>.</summary>
     /// <param name="client">The client aggregate to map.</param>
     /// <param name="email">The email from the Identity user.</param>
+    /// <param name="twoFactorEnabled">True if the user has TOTP 2FA enabled.</param>
     /// <returns>The mapped DTO.</returns>
-    private static ClientDto MapToDto(Client client, string email) =>
+    private static ClientDto MapToDto(Client client, string email, bool twoFactorEnabled) =>
         new(
             client.Id,
             client.UserId,
@@ -69,6 +71,7 @@ public sealed class GetMyProfileHandler(IClientRepository clientRepo, IUserServi
             client.MarketingOptIn,
             client.StatusUpdate,
             client.AllowSso,
+            twoFactorEnabled,
             client.CreatedAt,
             client.Contacts.Select(c => new ContactDto(
                 c.Id, c.FirstName, c.LastName, c.CompanyName,

--- a/backend/src/Innovayse.Application/Clients/Queries/ListClients/ListClientsHandler.cs
+++ b/backend/src/Innovayse.Application/Clients/Queries/ListClients/ListClientsHandler.cs
@@ -46,10 +46,18 @@ public sealed class ListClientsHandler(IClientRepository clientRepo, IUserServic
             query.Phone, statusFilter, emailUserIds, ct);
 
         // Batch-fetch emails for the returned page
-        var userIds = items.Select(c => c.UserId).Distinct();
+        var userIds = items.Select(c => c.UserId).Distinct().ToList();
         var emails = await userService.GetEmailsByIdsAsync(userIds, ct);
 
-        var dtos = items.Select(c => MapToListItem(c, emails)).ToList();
+        // Batch-fetch 2FA status
+        var twoFactorStatuses = new Dictionary<string, bool>();
+        await Task.WhenAll(userIds.Select(async uid =>
+        {
+            var enabled = await userService.IsTwoFactorEnabledAsync(uid, ct);
+            lock (twoFactorStatuses) twoFactorStatuses[uid] = enabled;
+        }));
+
+        var dtos = items.Select(c => MapToListItem(c, emails, twoFactorStatuses)).ToList();
 
         return new PagedResult<ClientListItemDto>(dtos, totalCount, page, pageSize);
     }
@@ -57,9 +65,10 @@ public sealed class ListClientsHandler(IClientRepository clientRepo, IUserServic
     /// <summary>Maps a <see cref="Client"/> to <see cref="ClientListItemDto"/>.</summary>
     /// <param name="client">The client to map.</param>
     /// <param name="emails">User ID to email lookup.</param>
+    /// <param name="twoFactorStatuses">User ID to 2FA enabled status lookup.</param>
     /// <returns>The list item DTO.</returns>
-    private static ClientListItemDto MapToListItem(Client client, Dictionary<string, string> emails) =>
+    private static ClientListItemDto MapToListItem(Client client, Dictionary<string, string> emails, Dictionary<string, bool> twoFactorStatuses) =>
         new(client.Id, client.UserId, emails.GetValueOrDefault(client.UserId, ""),
             client.FirstName, client.LastName, client.CompanyName, client.Status,
-            !emails.ContainsKey(client.UserId), client.CreatedAt);
+            !emails.ContainsKey(client.UserId), twoFactorStatuses.GetValueOrDefault(client.UserId, false), client.CreatedAt);
 }


### PR DESCRIPTION
Summary
Add 2FA status visibility to the admin panel — clients list table and client summary page now show whether a client has Two-Factor Authentication enabled. Also fixes the topbar page title showing "Admin" instead of "Reports" on report pages.

Related Issue
Closes #31

Changes
Add twoFactorEnabled to ClientListItemDto and ClientDto records
Batch-fetch 2FA status in ListClientsHandler via Task.WhenAll for all clients
Pass twoFactorEnabled through GetClientHandler and GetMyProfileHandler
Add 2FA On/Off badge column to clients table (grid updated to 7 columns)
Add Two-Factor Auth Enabled/Disabled row in Other Information section of client summary
Add /reports and /orders entries to AppTopbar page title map
Checklist
 Code follows the style rules (rules/ folder)
 dotnet format run (backend changes)
 XML docs added to all new C# members
 JSDoc added to all new exported TypeScript/Vue functions
 No hardcoded secrets or credentials
 Tested locally