### PR TITLE
Add testmode toggle for Name.am integration with auto-activation

### DIFF
--- a/admin/src/modules/integrations/components/IntegrationConfigForm.vue
+++ b/admin/src/modules/integrations/components/IntegrationConfigForm.vue
@@ -107,6 +107,20 @@ function handleSave(): void {
             <option v-for="opt in field.options" :key="opt" :value="opt" class="bg-surface-elevated">{{ opt }}</option>
           </select>
 
+          <!-- Toggle for boolean fields — stores "true" / "false" as string -->
+          <div v-else-if="field.type === 'toggle'" class="flex items-center gap-2.5 pt-1">
+            <ToggleSwitch
+              :model-value="localConfig[field.key] === 'true'"
+              @update:model-value="localConfig[field.key] = $event ? 'true' : 'false'"
+            />
+            <span
+              class="text-[0.78rem] font-semibold"
+              :class="localConfig[field.key] === 'true' ? 'text-status-green' : 'text-text-muted'"
+            >
+              {{ localConfig[field.key] === 'true' ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+
           <input
             v-else
             v-model="localConfig[field.key]"

--- a/admin/src/modules/integrations/types/integration.meta.ts
+++ b/admin/src/modules/integrations/types/integration.meta.ts
@@ -78,6 +78,7 @@ export const INTEGRATION_META: Record<IntegrationSlug, IntegrationMeta> = {
       { key: 'email', label: 'Account Email', type: 'text' },
       { key: 'password', label: 'Account Password', type: 'password' },
       { key: 'apiUrl', label: 'API URL', type: 'text' },
+      { key: 'test_mode', label: 'Test Mode', type: 'toggle' },
     ],
   },
   resellerclub: {

--- a/admin/src/modules/integrations/types/integration.types.ts
+++ b/admin/src/modules/integrations/types/integration.types.ts
@@ -46,8 +46,8 @@ export interface FieldDefinitionDto {
   key: string
   /** Human-readable label shown above the input. */
   label: string
-  /** Input type — "text", "password", "select", or "textarea". */
-  type: 'text' | 'password' | 'select' | 'textarea'
+  /** Input type — "text", "password", "select", "textarea", or "toggle". */
+  type: 'text' | 'password' | 'select' | 'textarea' | 'toggle'
   /** Whether the field is required before the integration can be enabled. */
   required: boolean
   /** Allowed values for "select" type fields; absent for all others. */
@@ -111,8 +111,8 @@ export interface IntegrationField {
   key: string
   /** Human-readable label. */
   label: string
-  /** Input type — "text" for most, "password" for secrets, "select" for enums. */
-  type: 'text' | 'password' | 'select' | 'textarea'
+  /** Input type — "text" for most, "password" for secrets, "select" for enums, "toggle" for booleans. */
+  type: 'text' | 'password' | 'select' | 'textarea' | 'toggle'
   /** Options for "select" type fields. */
   options?: string[]
 }

--- a/backend/src/Innovayse.Application/Admin/Integrations/Queries/GetIntegration/GetIntegrationHandler.cs
+++ b/backend/src/Innovayse.Application/Admin/Integrations/Queries/GetIntegration/GetIntegrationHandler.cs
@@ -52,9 +52,10 @@ public sealed class GetIntegrationHandler(ISettingRepository settings, IPluginRe
         ]),
         ["nameam"] = ("Name.am", "Domain Registrars",
         [
-            new("email",    "Account Email",    "text",     Required: true),
-            new("password", "Account Password", "password", Required: true),
-            new("api_url",  "API URL",          "text",     Required: false),
+            new("email",     "Account Email",    "text",     Required: true),
+            new("password",  "Account Password", "password", Required: true),
+            new("api_url",   "API URL",          "text",     Required: false),
+            new("test_mode", "Test Mode",        "toggle",   Required: false),
         ]),
         ["resellerclub"] = ("ResellerClub", "Domain Registrars",
         [

--- a/backend/src/Innovayse.Application/Admin/Integrations/Queries/ListIntegrations/ListIntegrationsHandler.cs
+++ b/backend/src/Innovayse.Application/Admin/Integrations/Queries/ListIntegrations/ListIntegrationsHandler.cs
@@ -22,7 +22,7 @@ public sealed class ListIntegrationsHandler(ISettingRepository settings, IPlugin
         ["paypal"] = ("PayPal", "Payment Gateways", ["client_id", "client_secret"], ["client_id", "client_secret", "mode"]),
         ["bank-transfer"] = ("Bank Transfer", "Payment Gateways", [], ["account_name", "iban", "bank_name", "instructions"]),
         ["namecheap"] = ("Namecheap", "Domain Registrars", ["api_key", "api_username", "client_ip"], ["api_key", "api_username", "client_ip"]),
-        ["nameam"] = ("Name.am", "Domain Registrars", ["email", "password"], ["email", "password", "api_url"]),
+        ["nameam"] = ("Name.am", "Domain Registrars", ["email", "password"], ["email", "password", "api_url", "test_mode"]),
         ["resellerclub"] = ("ResellerClub", "Domain Registrars", ["reseller_id", "api_key"], ["reseller_id", "api_key"]),
         ["enom"] = ("ENOM", "Domain Registrars", ["account_id", "api_key"], ["account_id", "api_key"]),
         ["cpanel"] = ("cPanel WHM", "Hosting / Provisioning", ["host", "username", "api_token"], ["host", "port", "username", "api_token"]),

--- a/backend/src/Innovayse.Infrastructure/Domains/NameAm/NameAmClient.cs
+++ b/backend/src/Innovayse.Infrastructure/Domains/NameAm/NameAmClient.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Innovayse.Domain.Settings.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -19,11 +20,17 @@ public sealed class NameAmClient
     /// <summary>Resolved Name.am configuration settings.</summary>
     private readonly NameAmSettings _settings;
 
+    /// <summary>Setting repository for reading integration overrides from the database.</summary>
+    private readonly ISettingRepository _settingRepo;
+
     /// <summary>Logger for structured diagnostics.</summary>
     private readonly ILogger<NameAmClient> _logger;
 
     /// <summary>Cached JWT access token obtained from <c>/auth/login</c>.</summary>
     private string? _accessToken;
+
+    /// <summary>Cached test-mode override loaded from the database settings table.</summary>
+    private bool? _testModeOverride;
 
     /// <summary>Semaphore guarding concurrent login attempts to prevent token races.</summary>
     private readonly SemaphoreSlim _loginLock = new(1, 1);
@@ -40,11 +47,17 @@ public sealed class NameAmClient
     /// </summary>
     /// <param name="http">The <see cref="HttpClient"/> configured by <c>IHttpClientFactory</c>.</param>
     /// <param name="options">Bound <see cref="NameAmSettings"/> options.</param>
+    /// <param name="settingRepo">Setting repository for reading DB-stored integration config.</param>
     /// <param name="logger">Logger for structured diagnostics.</param>
-    public NameAmClient(HttpClient http, IOptions<NameAmSettings> options, ILogger<NameAmClient> logger)
+    public NameAmClient(
+        HttpClient http,
+        IOptions<NameAmSettings> options,
+        ISettingRepository settingRepo,
+        ILogger<NameAmClient> logger)
     {
         _http = http;
         _settings = options.Value;
+        _settingRepo = settingRepo;
         _logger = logger;
     }
 
@@ -63,6 +76,7 @@ public sealed class NameAmClient
     /// <exception cref="HttpRequestException">Thrown when the API returns a non-success status after retry.</exception>
     public async Task<JsonDocument> GetAsync(string path, CancellationToken ct)
     {
+        await LoadTestModeOverrideAsync(ct);
         await EnsureAuthenticatedAsync(ct);
 
         var url = BuildUrl(path);
@@ -99,6 +113,7 @@ public sealed class NameAmClient
     /// <exception cref="HttpRequestException">Thrown when the API returns a non-success status after retry.</exception>
     public async Task<JsonDocument> PostAsync(string path, object body, CancellationToken ct)
     {
+        await LoadTestModeOverrideAsync(ct);
         await EnsureAuthenticatedAsync(ct);
 
         var url = BuildUrl(path);
@@ -143,6 +158,7 @@ public sealed class NameAmClient
     /// <exception cref="HttpRequestException">Thrown when the API returns a non-success status after retry.</exception>
     public async Task<JsonDocument> PutAsync(string path, object body, CancellationToken ct)
     {
+        await LoadTestModeOverrideAsync(ct);
         await EnsureAuthenticatedAsync(ct);
 
         var url = BuildUrl(path);
@@ -256,8 +272,34 @@ public sealed class NameAmClient
     }
 
     /// <summary>
+    /// Loads the test-mode override from the database settings table.
+    /// The DB value (<c>integration:nameam:test_mode</c>) takes precedence over
+    /// <see cref="NameAmSettings.TestMode"/> from <c>appsettings.json</c>.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task LoadTestModeOverrideAsync(CancellationToken ct)
+    {
+        if (_testModeOverride is not null)
+        {
+            return;
+        }
+
+        var setting = await _settingRepo.FindByKeyAsync("integration:nameam:test_mode", ct);
+        _testModeOverride = setting is not null
+            && string.Equals(setting.Value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Gets whether test mode is active, checking the DB override first,
+    /// then falling back to <see cref="NameAmSettings.TestMode"/>.
+    /// Call <see cref="LoadTestModeOverrideAsync"/> before reading to ensure the DB value is loaded.
+    /// </summary>
+    public bool IsTestMode => _testModeOverride ?? _settings.TestMode;
+
+    /// <summary>
     /// Builds a full URL by combining the configured API base URL with the given path.
-    /// Appends <c>testmode=1</c> query parameter when <see cref="NameAmSettings.TestMode"/> is enabled.
+    /// Appends <c>testmode=1</c> query parameter when test mode is enabled
+    /// (either via DB setting or <c>appsettings.json</c>).
     /// </summary>
     /// <param name="path">Relative API path.</param>
     /// <returns>Absolute URL string.</returns>
@@ -265,7 +307,7 @@ public sealed class NameAmClient
     {
         var url = $"{_settings.ApiUrl.TrimEnd('/')}{path}";
 
-        if (_settings.TestMode)
+        if (IsTestMode)
         {
             url += url.Contains('?') ? "&testmode=1" : "?testmode=1";
         }

--- a/backend/src/Innovayse.Infrastructure/Domains/NameAm/NameAmRegistrarProvider.cs
+++ b/backend/src/Innovayse.Infrastructure/Domains/NameAm/NameAmRegistrarProvider.cs
@@ -61,9 +61,11 @@ public sealed class NameAmRegistrarProvider(NameAmClient client, ILogger<NameAmR
         var domainRef = request.DomainName;
         var expiresAt = DateTimeOffset.UtcNow.AddYears(request.Years);
 
-        // Name.am requires a pre-funded balance; the cart purchase is async —
-        // the domain becomes active only after Name.am processes the order.
-        return new RegistrarResult(true, domainRef, expiresAt, null, RequiresPolling: true);
+        // In test mode, Name.am never actually activates the domain, so skip polling
+        // and let the handler activate it immediately.
+        var requiresPolling = !client.IsTestMode;
+
+        return new RegistrarResult(true, domainRef, expiresAt, null, RequiresPolling: requiresPolling);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

- Add a **Test Mode** toggle to the Name.am integration settings page in the admin panel
- Introduce a reusable `toggle` field type for integration config forms
- Bridge DB setting to `NameAmClient` so testmode can be toggled without server restart
- Auto-activate domains immediately when testmode is ON (skip polling)

## Changes

**Backend (4 files):**
- `GetIntegrationHandler.cs` — added `test_mode` toggle field to nameam metadata
- `ListIntegrationsHandler.cs` — added `test_mode` to nameam AllFields array
- `NameAmClient.cs` — injects `ISettingRepository`, reads `integration:nameam:test_mode` from DB, caches per request lifetime, `IsTestMode` checks DB override then falls back to appsettings.json
- `NameAmRegistrarProvider.cs` — returns `RequiresPolling: false` when testmode is ON so domains activate immediately

**Frontend (3 files):**
- `IntegrationConfigForm.vue` — added `toggle` field type rendering using existing `ToggleSwitch` component
- `integration.meta.ts` — added `test_mode` toggle to nameam fields
- `integration.types.ts` — added `"toggle"` to field type unions

## Test plan

- [ ] Navigate to Admin > Integrations > Name.am — verify Test Mode toggle appears below API URL
- [ ] Toggle Test Mode ON, save — verify `integration:nameam:test_mode = true` persisted in Settings table
- [ ] Register a domain with testmode ON — verify `?testmode=1` appended to Name.am API calls in logs
- [ ] Verify domain goes straight to Active status (no PendingRegistration)
- [ ] Toggle Test Mode OFF, save — verify domains go back to PendingRegistration flow

Closes #48