### PR TITLE
feat: integrate Innovayse header widget into panel.local

### DIFF
--- a/client/components/layout/Header.vue
+++ b/client/components/layout/Header.vue
@@ -64,6 +64,9 @@
 
         <!-- Language Switcher & CTA (Desktop 1280px+) -->
         <div class="hidden xl:flex items-center gap-3">
+          <!-- Global App Launcher widget mount point -->
+          <div id="inno-launcher-mount"></div>
+
           <LayoutLanguageSwitcher />
 
           <!-- Cart icon with badge -->
@@ -84,88 +87,8 @@
             </ClientOnly>
           </button>
 
-          <!-- Client area button — user dropdown if logged in, login link otherwise -->
-          <!-- Logged in: user dropdown -->
-          <div v-if="isLoggedIn" class="relative group">
-            <button
-              type="button"
-              class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-gray-300 hover:text-white border border-white/10 hover:border-white/20 transition-all duration-200"
-            >
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary-500/20 text-primary-400 text-xs font-bold">
-                {{ user?.firstname?.charAt(0)?.toUpperCase() ?? 'U' }}
-              </span>
-              <span>{{ user?.firstname ?? $t('nav.clientArea') }}</span>
-              <Icon name="lucide:chevron-down" size="14" class="transition-transform duration-200 group-hover:rotate-180" />
-            </button>
-
-            <div class="absolute right-0 top-full pt-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-              <div class="w-52 rounded-xl bg-gray-900/95 border border-white/10 shadow-2xl backdrop-blur-lg overflow-hidden">
-                <div class="px-4 py-3 border-b border-white/10">
-                  <p class="text-xs text-gray-500">{{ $t('client.nav.welcomeBack') }}</p>
-                  <p class="text-sm font-medium text-white truncate">{{ user?.firstname }} {{ user?.lastname }}</p>
-                </div>
-                <NuxtLink :to="localePath('/client/dashboard')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:layout-dashboard" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.dashboard') }}
-                </NuxtLink>
-                <NuxtLink :to="localePath('/client/services')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:server" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.services') }}
-                </NuxtLink>
-                <NuxtLink :to="localePath('/client/domains')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:globe" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.domains') }}
-                </NuxtLink>
-                <NuxtLink :to="localePath('/client/invoices')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:file-text" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.invoices') }}
-                </NuxtLink>
-                <NuxtLink :to="localePath('/client/tickets')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:message-square" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.support') }}
-                </NuxtLink>
-                <NuxtLink :to="localePath('/client/account')" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors">
-                  <Icon name="lucide:settings" size="15" class="text-primary-400 flex-shrink-0" />
-                  {{ $t('client.nav.account') }}
-                </NuxtLink>
-                <div v-if="activeHostingServices.length > 0" class="border-t border-white/10">
-                  <div class="px-4 py-2 text-[10px] font-bold text-gray-500 uppercase tracking-widest">{{ $t('client.services.actionLoginCpanel') }}</div>
-                  <button
-                    v-for="service in activeHostingServices.slice(0, 3)"
-                    :key="service.id"
-                    type="button"
-                    class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:text-white hover:bg-white/8 transition-colors disabled:opacity-50"
-                    :disabled="ssoLoading === service.id"
-                    @click="loginToCpanel(service)"
-                  >
-                    <Icon v-if="ssoLoading === service.id" name="lucide:loader" size="15" class="animate-spin text-primary-400" />
-                    <Icon v-else name="lucide:monitor" size="15" class="text-primary-400 flex-shrink-0" />
-                    <span class="truncate">{{ service.name }}</span>
-                  </button>
-                </div>
-                <div class="border-t border-white/10">
-                  <button
-                    type="button"
-                    class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-400 hover:text-red-300 hover:bg-white/8 transition-colors"
-                    @click="handleLogout"
-                  >
-                    <Icon name="lucide:log-out" size="15" class="flex-shrink-0" />
-                    {{ $t('client.nav.signOut') }}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Not logged in: simple link (SSO mode goes directly to SSO, local mode goes to login page) -->
-          <a
-            v-else
-            :href="clientAreaHref"
-            class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium text-gray-300 hover:text-white border border-white/10 hover:border-white/20 transition-all duration-200"
-          >
-            <Icon name="lucide:user" size="15" />
-            {{ $t('nav.clientArea') }}
-          </a>
+          <!-- Global Account widget mount point (App Launcher widget injects here) -->
+          <div id="inno-account-mount"></div>
 
         </div>
 

--- a/client/layouts/client.vue
+++ b/client/layouts/client.vue
@@ -21,7 +21,7 @@
            Mobile: fixed overlay (slides in/out)
            Desktop: normal flex child, fills height, internal scroll -->
       <aside
-        class="fixed inset-y-0 left-0 z-20 w-64 flex flex-col bg-white dark:bg-[#0d0d12] border-r border-gray-200 dark:border-white/10 transition-transform duration-300 lg:relative lg:z-auto lg:translate-x-0 lg:flex-shrink-0"
+        class="fixed inset-y-0 left-0 z-20 w-64 flex flex-col bg-white dark:bg-[#0d0d12] border-r border-gray-200 dark:border-white/10 transition-transform duration-300 lg:relative lg:z-auto lg:inset-y-auto lg:translate-x-0 lg:flex-shrink-0"
         :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full'"
       >
         <!-- Logo -->

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen flex flex-col bg-[#0a0a0f]">
-    <!-- Header -->
+    <!-- Header with embedded App Launcher + Account widget mount points -->
     <LayoutHeader />
 
     <!-- Main content -->

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -192,6 +192,9 @@ export default defineNuxtConfig({
         { name: 'format-detection', content: 'telephone=no' },
         { name: 'theme-color', content: '#0ea5e9' }
       ],
+      script: [
+        { src: 'http://app.local/widget/header.js', defer: true }
+      ],
       link: [
         // Performance: preconnect to third-party origins used on all pages
         { rel: 'preconnect', href: 'https://www.googletagmanager.com' },


### PR DESCRIPTION
Summary

Adds the Innovayse global header widget to all apps (panel.local, email.local, docs.local, sheets.local). The widget is a lightweight vanilla JS component served from app.local/widget/header.js that mounts an App Launcher and Account dropdown into dedicated DOM mount points in each app's existing header.

Changes

Add widget/header.js to innovayse-main — App Launcher + Account dropdown, loads user profile from SSO, mounts via #inno-launcher-mount / #inno-account-mount
panel.local (hostpanel): add mount points in Header, restore LayoutHeader, remove old full-bar widget approach
email.local: add mount points in TopBar, load widget via nuxt.config script
docs.local: add mount points in index and document page headers
sheets.local: add mount points in sheet page header
SSO: update FrontendUrl, CORS origins and hostpanel client seed from localhost to .local domains