### PR TITLE
fix: address widget MR review comments

### DIFF
--- a/client/components/layout/Header.vue
+++ b/client/components/layout/Header.vue
@@ -306,7 +306,6 @@ const navLinks = computed(() => [
 
 /** Authentication state for the Client Area button */
 const { isLoggedIn, user, fetchUser, logout } = useClientAuth()
-const store = useClientStore()
 const runtimeConfig = useRuntimeConfig()
 
 /** In SSO mode, link directly to SSO authorize (skips "Continue with Innovayse" page) */
@@ -319,30 +318,8 @@ const clientAreaHref = computed(() =>
 onMounted(async () => {
   if (isLoggedIn.value) {
     await fetchUser()
-    await store.fetchServices()
   }
 })
-
-/** Quick SSO from Header */
-const ssoLoading = ref<number | null>(null)
-const activeHostingServices = computed(() =>
-  store.services.filter(s => s.status === 'Active' && s.serverhostname)
-)
-
-async function loginToCpanel(service: any) {
-  if (ssoLoading.value) return
-  ssoLoading.value = service.id
-  try {
-    const { url } = await apiFetch<{ url: string }>(`/api/portal/client/services/${service.id}/cpanel-sso`)
-    window.open(url, '_blank', 'noopener')
-  } catch (err: any) {
-    if (service.serverhostname) {
-      window.open(`https://${service.serverhostname}:2083`, '_blank', 'noopener')
-    }
-  } finally {
-    ssoLoading.value = null
-  }
-}
 
 async function handleLogout() {
   await logout()

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -80,6 +80,7 @@ export default defineNuxtConfig({
       ssoPublicUrl: process.env.SSO_PUBLIC_URL || 'http://sso.local',
       whmcsUrl: (process.env.WHMCS_URL || '').replace(/\/+$/, ''),
       stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || '',
+      widgetUrl: process.env.NUXT_PUBLIC_WIDGET_URL || '',
     }
   },
 
@@ -193,7 +194,9 @@ export default defineNuxtConfig({
         { name: 'theme-color', content: '#0ea5e9' }
       ],
       script: [
-        { src: 'http://app.local/widget/header.js', defer: true }
+        ...(process.env.NUXT_PUBLIC_WIDGET_URL
+          ? [{ src: `${process.env.NUXT_PUBLIC_WIDGET_URL}/widget/header.js`, defer: true }]
+          : []),
       ],
       link: [
         // Performance: preconnect to third-party origins used on all pages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
       # between them, randomly routing requests to the wrong app's backend.
       API_URL: http://hostpanel-api-1:5148
       NUXT_PUBLIC_BASE_URL: http://panel.local
+      NUXT_PUBLIC_WIDGET_URL: http://app.local
       SSO_URL: http://innovayse-sso-sso-api-1:8080
       SSO_PUBLIC_URL: http://accounts.local
       SSO_CLIENT_ID: hostpanel


### PR DESCRIPTION
Summary

Addresses review comments on the Innovayse header widget PR. Removes dead code left over from the old desktop account dropdown, and gates the widget script URL behind an environment variable so it doesn't break staging or production builds.

Changes

Remove unused ssoLoading, activeHostingServices, loginToCpanel, useClientStore and store.fetchServices() from Header.vue — desktop cPanel SSO is now handled by the Account widget; isLoggedIn, user, handleLogout are kept as they drive the mobile menu
Replace hardcoded http://app.local/widget/header.js in nuxt.config.ts with NUXT_PUBLIC_WIDGET_URL env var — script tag is omitted entirely when the var is unset (safe on staging/production)
Add NUXT_PUBLIC_WIDGET_URL: http://app.local to docker-compose.yml for local dev