### PR TITLE
Admin SSO login, Namecheap email/contact/DNS APIs, ticket notifications

### DIFF
--- a/admin/src/composables/useApi.ts
+++ b/admin/src/composables/useApi.ts
@@ -1,31 +1,42 @@
 import router from '../router'
+import { refreshSsoToken } from '../modules/auth/useSso'
 
-/** In-memory JWT token — set after login, cleared on logout. */
+/** In-memory access token — set after SSO login, cleared on logout. */
 let _token: string | null = localStorage.getItem('admin_token')
+
+/** Refresh token from the SSO token response, persisted so a page reload can silently re-auth. */
+let _refreshToken: string | null = localStorage.getItem('admin_refresh_token')
 
 /** Prevents multiple concurrent refresh attempts. */
 let _refreshPromise: Promise<boolean> | null = null
 
 /**
- * Stores the JWT token in memory and localStorage for session persistence.
+ * Stores the access token (and optionally a refresh token) for session persistence.
  *
- * @param token - JWT access token from the login response.
+ * @param token - Access token from the SSO token response.
+ * @param refreshToken - Refresh token from the SSO token response, if issued.
  */
-export function setToken(token: string): void {
+export function setToken(token: string, refreshToken?: string): void {
   _token = token
   localStorage.setItem('admin_token', token)
+  if (refreshToken) {
+    _refreshToken = refreshToken
+    localStorage.setItem('admin_refresh_token', refreshToken)
+  }
 }
 
 /**
- * Clears the stored JWT token from memory and localStorage.
+ * Clears the stored tokens from memory and localStorage.
  */
 export function clearToken(): void {
   _token = null
+  _refreshToken = null
   localStorage.removeItem('admin_token')
+  localStorage.removeItem('admin_refresh_token')
 }
 
 /**
- * Attempts to get a new access token via the httpOnly refresh cookie.
+ * Attempts to get a new access token from SSO using the stored refresh token.
  * Concurrent calls share the same in-flight request.
  *
  * @returns True if a new token was obtained, false otherwise.
@@ -34,15 +45,11 @@ async function tryRefresh(): Promise<boolean> {
   if (_refreshPromise) return _refreshPromise
 
   _refreshPromise = (async () => {
+    if (!_refreshToken) return false
     try {
-      const res = await fetch('/api/auth/refresh', { method: 'POST' })
-      if (!res.ok) return false
-      const data = await res.json()
-      if (data.accessToken) {
-        setToken(data.accessToken)
-        return true
-      }
-      return false
+      const data = await refreshSsoToken(_refreshToken)
+      setToken(data.access_token, data.refresh_token)
+      return true
     } catch {
       return false
     } finally {

--- a/admin/src/modules/auth/stores/authStore.ts
+++ b/admin/src/modules/auth/stores/authStore.ts
@@ -1,51 +1,25 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { useApi, setToken, clearToken } from '../../../composables/useApi'
+import { useApi, clearToken } from '../../../composables/useApi'
+import { startSsoLogin, ssoLogoutRedirect } from '../useSso'
 
-/**
- * Decodes the payload of a JWT token without verifying the signature.
- *
- * @param token - JWT string with three base64url segments.
- * @returns Parsed payload object or null if decoding fails.
- */
-function decodeJwt(token: string): Record<string, unknown> | null {
-  try {
-    const payload = token.split('.')[1] ?? ''
-    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
-    return JSON.parse(json)
-  } catch {
-    return null
-  }
-}
-
-/**
- * Extracts email and role from a JWT payload.
- *
- * @param token - JWT access token string.
- * @returns User object with email and role, or null.
- */
-function userFromToken(token: string): { email: string; role: string } | null {
-  const payload = decodeJwt(token)
-  if (!payload) return null
-  const email = payload['email'] as string | undefined
-  // ASP.NET Identity writes role as the long-form claim URI
-  const role = (
-    payload['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'] ??
-    payload['role']
-  ) as string | undefined
-  if (!email || !role) return null
-  return { email, role }
+interface MeResponse {
+  email: string
+  roles: string[]
+  emailVerified: boolean
 }
 
 /**
  * Pinia store managing admin authentication state.
  *
- * Handles login, logout, session restoration, and email verification status.
- * Decodes user info from the token — no extra API call needed.
+ * All authentication happens against Innovayse SSO (see useSso.ts) — this
+ * store only tracks the resulting session (who's logged in, their roles,
+ * email verification status) by calling the Hostpanel API's /auth/me, since
+ * roles are assigned locally in Hostpanel and can't be read off the SSO token.
  */
 export const useAuthStore = defineStore('auth', () => {
   /** Currently authenticated admin user, null when unauthenticated. */
-  const user = ref<{ email: string; role: string } | null>(null)
+  const user = ref<{ email: string; roles: string[] } | null>(null)
 
   /** Whether the current user's email has been verified. Null means not yet checked. */
   const emailVerified = ref<boolean | null>(null)
@@ -56,91 +30,33 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => user.value !== null)
 
   /**
-   * Logs in with email and password credentials.
-   *
-   * Stores the returned JWT, decodes user info, and checks email verification status.
-   *
-   * @param email - Admin email address.
-   * @param password - Admin password.
-   * @returns Promise that resolves after login completes.
+   * Redirects the browser to Innovayse SSO to start the login flow.
+   * On success, SSO redirects back to /auth/callback, which exchanges the
+   * code for tokens and calls fetchMe() to populate this store.
    */
-  async function login(email: string, password: string): Promise<void> {
-    const data = await request<{ accessToken: string; role: string }>('/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ email, password }),
-    })
-    setToken(data.accessToken)
-    user.value = userFromToken(data.accessToken)
-    await checkEmailVerified()
+  async function login(): Promise<void> {
+    await startSsoLogin()
   }
 
   /**
-   * Checks whether the current user's email has been verified.
+   * Loads the current user from the API using the stored access token.
+   * Called after the SSO callback exchange, and on page load to restore
+   * an existing session.
    *
-   * @returns Promise that resolves when the check completes.
-   */
-  async function checkEmailVerified(): Promise<void> {
-    try {
-      const data = await request<{ verified: boolean }>('/auth/email-verified')
-      emailVerified.value = data.verified
-    } catch {
-      emailVerified.value = null
-    }
-  }
-
-  /**
-   * Restores session from a stored JWT token (page refresh).
-   *
-   * Sets user to null if no valid token is found.
-   * Also checks email verification status if session is valid.
-   *
-   * @returns Promise that resolves when session is restored.
+   * @returns Promise that resolves when the fetch completes; clears session on failure.
    */
   async function fetchMe(): Promise<void> {
-    const stored = localStorage.getItem('admin_token')
-    if (!stored) {
+    if (!localStorage.getItem('admin_token')) {
       user.value = null
       emailVerified.value = null
       return
     }
 
-    // Check if the token is expired locally before making a network call
-    const payload = decodeJwt(stored)
-    const exp = payload?.['exp'] as number | undefined
-    if (exp && exp * 1000 < Date.now()) {
-      // Token expired — try silent refresh before hitting the API
-      try {
-        const res = await fetch('/api/auth/refresh', { method: 'POST' })
-        if (!res.ok) throw new Error('refresh failed')
-        const data = await res.json()
-        if (data.accessToken) {
-          setToken(data.accessToken)
-        } else {
-          throw new Error('no token')
-        }
-      } catch {
-        clearToken()
-        user.value = null
-        emailVerified.value = null
-        return
-      }
-    }
-
-    const parsed = userFromToken(localStorage.getItem('admin_token') ?? '')
-    if (!parsed) {
-      clearToken()
-      user.value = null
-      emailVerified.value = null
-      return
-    }
-
-    // Token is valid — fetch email verification status
     try {
-      const data = await request<{ verified: boolean }>('/auth/email-verified')
-      user.value = parsed
-      emailVerified.value = data.verified
+      const data = await request<MeResponse>('/auth/me')
+      user.value = { email: data.email, roles: data.roles }
+      emailVerified.value = data.emailVerified
     } catch {
-      // Token was rejected (revoked, expired, etc.) — clear session
       clearToken()
       user.value = null
       emailVerified.value = null
@@ -148,19 +64,15 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   /**
-   * Logs out the current user and clears session state.
-   *
-   * @returns Promise that resolves after logout completes.
+   * Ends the local session and redirects to SSO's end-session endpoint so
+   * the SSO-wide session is cleared too (not just this app's token).
    */
-  async function logout(): Promise<void> {
-    try {
-      await request('/auth/logout', { method: 'POST' })
-    } finally {
-      clearToken()
-      user.value = null
-      emailVerified.value = null
-    }
+  function logout(): void {
+    clearToken()
+    user.value = null
+    emailVerified.value = null
+    ssoLogoutRedirect()
   }
 
-  return { user, emailVerified, isAuthenticated, login, logout, fetchMe, checkEmailVerified }
+  return { user, emailVerified, isAuthenticated, login, logout, fetchMe }
 })

--- a/admin/src/modules/auth/useSso.ts
+++ b/admin/src/modules/auth/useSso.ts
@@ -1,0 +1,147 @@
+/**
+ * Browser-side OIDC Authorization Code + PKCE flow against Innovayse SSO.
+ *
+ * The admin panel is a pure Vite SPA with no server component, so — unlike
+ * the client portal's Nuxt BFF — it cannot hold a client secret or an
+ * httpOnly cookie for the PKCE verifier. It registers as a *public* OIDC
+ * client instead (see hostpanel-admin in innovayse-sso's SsoSeeder) and runs
+ * the whole code+PKCE exchange directly in the browser, which is the
+ * standard pattern for SPA-only public clients.
+ */
+
+const SSO_URL = (import.meta.env.VITE_SSO_URL as string | undefined) ?? 'http://accounts.local'
+const CLIENT_ID = (import.meta.env.VITE_SSO_CLIENT_ID as string | undefined) ?? 'hostpanel-admin'
+
+const VERIFIER_KEY = 'admin_sso_pkce_verifier'
+const STATE_KEY = 'admin_sso_state'
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = ''
+  for (const b of bytes) str += String.fromCharCode(b)
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(new Uint8Array(digest))
+}
+
+function randomToken(byteLength: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength))
+  return base64UrlEncode(bytes)
+}
+
+/** Builds the redirect_uri used for both the authorize request and the token exchange. */
+function callbackUrl(): string {
+  return `${window.location.origin}/auth/callback`
+}
+
+/**
+ * Starts the login flow: generates a fresh PKCE pair + state, stashes the
+ * verifier in sessionStorage (survives the redirect, cleared on tab close),
+ * and navigates the browser to the SSO authorize endpoint.
+ */
+export async function startSsoLogin(): Promise<void> {
+  const verifier = randomToken(32)
+  const challenge = await sha256Base64Url(verifier)
+  const state = randomToken(16)
+
+  sessionStorage.setItem(VERIFIER_KEY, verifier)
+  sessionStorage.setItem(STATE_KEY, state)
+
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: callbackUrl(),
+    scope: 'openid profile email offline_access',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state,
+  })
+
+  window.location.href = `${SSO_URL}/connect/authorize?${params}`
+}
+
+export interface SsoTokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+  token_type: string
+}
+
+/**
+ * Completes the flow after the SSO redirect back to /auth/callback: validates
+ * `state`, exchanges `code` + the stashed verifier for tokens directly
+ * against the SSO token endpoint (no secret needed — public client).
+ *
+ * @param query - The callback URL's query params (code, state, error).
+ * @throws Error if state doesn't match, the verifier is missing, or the token exchange fails.
+ */
+export async function completeSsoLogin(query: URLSearchParams): Promise<SsoTokenResponse> {
+  const error = query.get('error')
+  if (error) throw new Error(query.get('error_description') ?? error)
+
+  const code = query.get('code')
+  const returnedState = query.get('state')
+  const expectedState = sessionStorage.getItem(STATE_KEY)
+  const verifier = sessionStorage.getItem(VERIFIER_KEY)
+
+  sessionStorage.removeItem(STATE_KEY)
+  sessionStorage.removeItem(VERIFIER_KEY)
+
+  if (!code) throw new Error('Missing authorization code.')
+  if (!expectedState || returnedState !== expectedState) throw new Error('Invalid OAuth state.')
+  if (!verifier) throw new Error('Missing PKCE verifier — login likely started in another tab.')
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    code,
+    redirect_uri: callbackUrl(),
+    code_verifier: verifier,
+  })
+
+  const res = await fetch(`${SSO_URL}/connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`SSO token exchange failed: ${res.status} ${text}`)
+  }
+
+  return res.json() as Promise<SsoTokenResponse>
+}
+
+/**
+ * Exchanges a refresh token for a new access token. Used for silent renewal
+ * when the stored access token is close to expiry.
+ *
+ * @param refreshToken - The refresh token previously issued alongside the access token.
+ */
+export async function refreshSsoToken(refreshToken: string): Promise<SsoTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: CLIENT_ID,
+    refresh_token: refreshToken,
+  })
+
+  const res = await fetch(`${SSO_URL}/connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  if (!res.ok) throw new Error(`SSO token refresh failed: ${res.status}`)
+  return res.json() as Promise<SsoTokenResponse>
+}
+
+/** Redirects the browser to SSO's end-session endpoint, ending the SSO session too. */
+export function ssoLogoutRedirect(idTokenHint?: string): void {
+  const params = new URLSearchParams({ post_logout_redirect_uri: window.location.origin })
+  if (idTokenHint) params.set('id_token_hint', idTokenHint)
+  window.location.href = `${SSO_URL}/connect/logout?${params}`
+}

--- a/admin/src/modules/auth/views/CallbackView.vue
+++ b/admin/src/modules/auth/views/CallbackView.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+/**
+ * SSO callback landing page — /auth/callback.
+ *
+ * SSO redirects here with `code` + `state` in the query string after the
+ * user authenticates. Exchanges them for tokens, loads the session, and
+ * forwards to /dashboard (or back to /login with an error on failure).
+ */
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { setToken } from '../../../composables/useApi'
+import { completeSsoLogin } from '../useSso'
+import { useAuthStore } from '../stores/authStore'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    const query = new URLSearchParams(window.location.search)
+    const tokens = await completeSsoLogin(query)
+    setToken(tokens.access_token, tokens.refresh_token)
+    await authStore.fetchMe()
+    await router.replace('/dashboard')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Sign-in failed.'
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-surface-base flex items-center justify-center">
+    <div v-if="error" class="text-center max-w-sm px-6">
+      <p class="text-sm text-status-red mb-4">{{ error }}</p>
+      <router-link to="/login" class="text-sm text-primary-500 hover:underline">Back to sign in</router-link>
+    </div>
+    <div v-else class="flex items-center gap-2 text-text-secondary text-sm">
+      <span class="w-1.5 h-1.5 bg-primary-500 rounded-full animate-bounce" style="animation-delay:0s"/>
+      <span class="w-1.5 h-1.5 bg-primary-500 rounded-full animate-bounce" style="animation-delay:0.15s"/>
+      <span class="w-1.5 h-1.5 bg-primary-500 rounded-full animate-bounce" style="animation-delay:0.3s"/>
+      <span class="ml-2">Signing in…</span>
+    </div>
+  </div>
+</template>

--- a/admin/src/modules/auth/views/LoginView.vue
+++ b/admin/src/modules/auth/views/LoginView.vue
@@ -2,41 +2,31 @@
 /**
  * Admin login page — full-screen dark with brand gradient accents.
  *
- * Redirects to /dashboard on successful authentication.
+ * Authentication is delegated entirely to Innovayse SSO: this page just
+ * kicks off the redirect. The actual token exchange happens on
+ * /auth/callback once SSO sends the browser back.
  */
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/authStore'
 
-const router = useRouter()
 const authStore = useAuthStore()
 
-/** Email field value. */
-const email = ref('')
-
-/** Password field value. */
-const password = ref('')
-
-/** True while the login request is in flight. */
+/** True while the SSO redirect is being prepared (PKCE pair generation). */
 const loading = ref(false)
 
-/** Error message shown when login fails. */
+/** Error message shown if starting the SSO flow itself fails. */
 const error = ref<string | null>(null)
 
 /**
- * Submits the login form.
- *
- * @returns Promise that resolves after login attempt.
+ * Starts the SSO login flow — navigates the browser away from this app.
  */
 async function handleLogin(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    await authStore.login(email.value, password.value)
-    await router.push('/dashboard')
+    await authStore.login()
   } catch {
-    error.value = 'Invalid email or password.'
-  } finally {
+    error.value = 'Could not start sign-in. Please try again.'
     loading.value = false
   }
 }
@@ -93,74 +83,32 @@ async function handleLogin(): Promise<void> {
       <!-- Heading -->
       <div class="mb-7">
         <h1 class="font-display text-[1.6rem] font-bold text-text-primary tracking-tight leading-none mb-1.5">Admin Panel</h1>
-        <p class="text-sm text-text-secondary">Sign in to manage your platform</p>
+        <p class="text-sm text-text-secondary">Sign in with your Innovayse account</p>
       </div>
 
-      <!-- Form -->
-      <form @submit.prevent="handleLogin" class="flex flex-col gap-4">
+      <!-- Error -->
+      <div v-if="error" class="mb-4 flex items-center gap-2 text-[0.8rem] text-status-red bg-status-red/8 border border-status-red/20 rounded-lg px-3 py-2.5">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+        </svg>
+        {{ error }}
+      </div>
 
-        <!-- Email -->
-        <div class="flex flex-col gap-1.5">
-          <label class="text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Email address</label>
-          <div class="relative">
-            <svg class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
-              <polyline points="22,6 12,13 2,6"/>
-            </svg>
-            <input
-              v-model="email"
-              type="email"
-              required
-              placeholder="admin@innovayse.com"
-              autocomplete="email"
-              class="w-full bg-white/[0.04] border border-white/[0.08] rounded-[10px] pl-9 pr-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none transition-all duration-200 focus:border-primary-500/50 focus:bg-primary-500/[0.04] focus:ring-2 focus:ring-primary-500/10"
-            />
-          </div>
-        </div>
-
-        <!-- Password -->
-        <div class="flex flex-col gap-1.5">
-          <label class="text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-text-muted">Password</label>
-          <div class="relative">
-            <svg class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-            </svg>
-            <input
-              v-model="password"
-              type="password"
-              required
-              placeholder="••••••••••"
-              autocomplete="current-password"
-              class="w-full bg-white/[0.04] border border-white/[0.08] rounded-[10px] pl-9 pr-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none transition-all duration-200 focus:border-primary-500/50 focus:bg-primary-500/[0.04] focus:ring-2 focus:ring-primary-500/10"
-            />
-          </div>
-        </div>
-
-        <!-- Error -->
-        <div v-if="error" class="flex items-center gap-2 text-[0.8rem] text-status-red bg-status-red/8 border border-status-red/20 rounded-lg px-3 py-2.5">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
-          </svg>
-          {{ error }}
-        </div>
-
-        <!-- Submit -->
-        <button
-          type="submit"
-          :disabled="loading"
-          class="mt-1 w-full py-3 rounded-[10px] font-display font-semibold text-[0.95rem] text-white gradient-brand border-none cursor-pointer transition-all duration-200 hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0"
-          style="box-shadow: 0 4px 20px rgba(14,165,233,0.25);"
-        >
-          <span v-if="!loading">Sign in</span>
-          <span v-else class="flex items-center justify-center gap-1.5">
-            <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0s"/>
-            <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0.15s"/>
-            <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0.3s"/>
-          </span>
-        </button>
-
-      </form>
+      <!-- SSO sign-in -->
+      <button
+        type="button"
+        :disabled="loading"
+        @click="handleLogin"
+        class="w-full py-3 rounded-[10px] font-display font-semibold text-[0.95rem] text-white gradient-brand border-none cursor-pointer transition-all duration-200 hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0"
+        style="box-shadow: 0 4px 20px rgba(14,165,233,0.25);"
+      >
+        <span v-if="!loading">Sign in with Innovayse SSO</span>
+        <span v-else class="flex items-center justify-center gap-1.5">
+          <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0s"/>
+          <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0.15s"/>
+          <span class="w-1.5 h-1.5 bg-white rounded-full animate-bounce" style="animation-delay:0.3s"/>
+        </span>
+      </button>
     </div>
   </div>
 </template>

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -22,6 +22,11 @@ const router = createRouter({
       meta: { public: true },
     },
     {
+      path: '/auth/callback',
+      component: () => import('../modules/auth/views/CallbackView.vue'),
+      meta: { public: true },
+    },
+    {
       path: '/',
       component: () => import('../components/layout/AppLayout.vue'),
       meta: { requiresAuth: true },

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.1" />
   </ItemGroup>
   <!-- Wolverine -->
   <ItemGroup>

--- a/backend/Innovayse.Backend.sln
+++ b/backend/Innovayse.Backend.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Innovayse.CWP.Tests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Innovayse.Providers.CWP7", "src\Innovayse.Providers.CWP7\Innovayse.Providers.CWP7.csproj", "{8F88FA95-1915-4E49-9600-A99F7DE6B7CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Innovayse.Infrastructure.Tests", "tests\Innovayse.Infrastructure.Tests\Innovayse.Infrastructure.Tests.csproj", "{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +173,18 @@ Global
 		{8F88FA95-1915-4E49-9600-A99F7DE6B7CA}.Release|x64.Build.0 = Release|Any CPU
 		{8F88FA95-1915-4E49-9600-A99F7DE6B7CA}.Release|x86.ActiveCfg = Release|Any CPU
 		{8F88FA95-1915-4E49-9600-A99F7DE6B7CA}.Release|x86.Build.0 = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|x64.Build.0 = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Debug|x86.Build.0 = Debug|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|x64.ActiveCfg = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|x64.Build.0 = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|x86.ActiveCfg = Release|Any CPU
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,5 +201,6 @@ Global
 		{BC8913D2-43AE-4C19-B49D-4111DBC565F5} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{AAE4ABA6-E64F-47B6-A2DB-53C2463883AB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{8F88FA95-1915-4E49-9600-A99F7DE6B7CA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{AF83E7EB-C9A1-40DC-B2AB-09BFCE88D35D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/Innovayse.API/Admin/AdminUsersController.cs
+++ b/backend/src/Innovayse.API/Admin/AdminUsersController.cs
@@ -5,8 +5,8 @@ using Innovayse.Application.Admin.DTOs;
 using Innovayse.Application.Auth.Interfaces;
 using Innovayse.Application.Common;
 using Innovayse.Application.Notifications.Commands.SendEmail;
+using Innovayse.Application.Notifications.Services;
 using Innovayse.Domain.Auth;
-using Innovayse.Domain.Notifications;
 using Innovayse.Domain.Notifications.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -106,57 +106,7 @@ public sealed class AdminUsersController(
         var user = await userService.FindByIdAsync(id, ct)
             ?? throw new InvalidOperationException($"User {id} not found.");
 
-        // Seed the password reset template on first use
-        const string slug = "user-password-reset";
-        var existing = await templateRepo.FindBySlugAsync(slug, ct);
-        if (existing is null)
-        {
-            var body = """
-                <!DOCTYPE html>
-                <html>
-                <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
-                <body style="margin:0;padding:0;background-color:#0a0a0f;font-family:'Inter',system-ui,-apple-system,sans-serif;">
-                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0a0a0f;padding:40px 20px;">
-                    <tr><td align="center">
-                      <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;">
-                        <tr><td align="center" style="padding-bottom:32px;">
-                          <table role="presentation" cellpadding="0" cellspacing="0"><tr>
-                            <td style="background:linear-gradient(135deg,rgba(14,165,233,0.1),rgba(168,85,247,0.1));border:1px solid rgba(14,165,233,0.2);border-radius:10px;padding:8px 16px;">
-                              <span style="font-size:16px;font-weight:700;background:linear-gradient(135deg,#0ea5e9,#a855f7);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;">Innovayse</span>
-                            </td>
-                          </tr></table>
-                        </td></tr>
-                        <tr><td style="background-color:#1a1a1f;border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:40px 36px;">
-                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                            <tr><td align="center" style="padding-bottom:24px;">
-                              <h1 style="margin:0;font-size:22px;font-weight:700;color:#f0f0f5;">Reset Your Password</h1>
-                            </td></tr>
-                            <tr><td align="center" style="padding-bottom:28px;">
-                              <p style="margin:0;font-size:14px;color:#8a8a9a;line-height:1.6;">Click the button below to reset your password. This link will expire in 24 hours.</p>
-                            </td></tr>
-                            <tr><td align="center" style="padding-bottom:28px;">
-                              <a href="{{ reset_link }}" style="display:inline-block;padding:14px 32px;background:linear-gradient(135deg,#0ea5e9,#0284c7);color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;border-radius:10px;box-shadow:0 4px 20px rgba(14,165,233,0.25);">Reset Password</a>
-                            </td></tr>
-                            <tr><td style="border-top:1px solid rgba(255,255,255,0.06);padding-top:20px;">
-                              <p style="margin:0;font-size:12px;color:#5a5a6a;line-height:1.6;">If you didn't request this, you can safely ignore this email.</p>
-                              <p style="margin:8px 0 0;font-size:12px;color:#0ea5e9;word-break:break-all;">{{ reset_link }}</p>
-                            </td></tr>
-                          </table>
-                        </td></tr>
-                        <tr><td align="center" style="padding-top:24px;">
-                          <p style="margin:0;font-size:11px;color:#3a3a4a;">© Innovayse. All rights reserved.</p>
-                        </td></tr>
-                      </table>
-                    </td></tr>
-                  </table>
-                </body>
-                </html>
-                """;
-            var template = EmailTemplate.Create(slug, "Reset your password — Innovayse", body,
-                "Sent when an admin initiates a password reset for a user.");
-            templateRepo.Add(template);
-            await uow.SaveChangesAsync(ct);
-        }
+        await PasswordResetTemplateSeeder.EnsureSeededAsync(templateRepo, uow, ct);
 
         var token = await userService.GeneratePasswordResetTokenAsync(id, ct);
         var clientBaseUrl = configuration["ClientBaseUrl"] ?? "http://localhost:3000";
@@ -164,7 +114,7 @@ public sealed class AdminUsersController(
 
         await bus.InvokeAsync(new SendEmailCommand(
             user.Email,
-            slug,
+            PasswordResetTemplateSeeder.Slug,
             new { reset_link = resetLink }), ct);
 
         return NoContent();

--- a/backend/src/Innovayse.API/Auth/AuthController.cs
+++ b/backend/src/Innovayse.API/Auth/AuthController.cs
@@ -62,6 +62,28 @@ public sealed class AuthController(IMessageBus bus, IUserService userService) : 
     }
 
     /// <summary>
+    /// Returns the current SSO-authenticated user's email and local roles.
+    /// Used by SPA clients (the admin panel) that cannot decode roles from the
+    /// SSO-issued token itself, since roles are assigned locally in Hostpanel,
+    /// not by the SSO service.
+    /// </summary>
+    [HttpGet("me")]
+    [Authorize]
+    public async Task<IActionResult> MeAsync(CancellationToken ct)
+    {
+        var sub = User.FindFirst("sub")?.Value;
+        if (sub is null) return Unauthorized();
+
+        var found = await userService.FindBySsoSubjectAsync(sub, ct);
+        if (found is null) return Unauthorized();
+
+        var roles = await userService.GetRolesAsync(found.Value.Id, ct);
+        var verified = User.FindFirst("email_verified")?.Value is "true" or "True";
+
+        return Ok(new { email = found.Value.Email, roles, emailVerified = verified });
+    }
+
+    /// <summary>
     /// Accepts an invitation. The invitation token is validated and the
     /// current SSO user is assigned the role defined in the invitation.
     /// The caller must be authenticated via SSO.

--- a/backend/src/Innovayse.API/Auth/LocalAuthController.cs
+++ b/backend/src/Innovayse.API/Auth/LocalAuthController.cs
@@ -2,8 +2,13 @@ namespace Innovayse.API.Auth;
 
 using Innovayse.API.Auth.Requests;
 using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Common;
+using Innovayse.Application.Notifications.Commands.SendEmail;
+using Innovayse.Application.Notifications.Services;
+using Innovayse.Domain.Notifications.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Wolverine;
 
 /// <summary>
 /// Local authentication endpoints — only active when Auth:Mode=local.
@@ -14,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 public sealed class LocalAuthController(
     IUserService userService,
     JwtTokenService tokenService,
+    IMessageBus bus,
     IConfiguration config) : ControllerBase
 {
     private bool IsLocalMode => (config["Auth:Mode"] ?? "sso") == "local";
@@ -118,7 +124,11 @@ public sealed class LocalAuthController(
     /// </summary>
     [HttpPost("forgot-password")]
     [AllowAnonymous]
-    public async Task<IActionResult> ForgotPasswordAsync([FromBody] ForgotPasswordRequest request, CancellationToken ct)
+    public async Task<IActionResult> ForgotPasswordAsync(
+        [FromBody] ForgotPasswordRequest request,
+        [FromServices] IEmailTemplateRepository templateRepo,
+        [FromServices] IUnitOfWork uow,
+        CancellationToken ct)
     {
         if (!IsLocalMode) return NotFound();
 
@@ -126,8 +136,17 @@ public sealed class LocalAuthController(
         if (user is null) return Ok(); // Silent — no enumeration
 
         var token = await userService.GeneratePasswordResetTokenAsync(user.Value.Id, ct);
-        // TODO: send email with reset link — for now just return OK
-        // In a real setup, inject IEmailService and send the reset link
+
+        await PasswordResetTemplateSeeder.EnsureSeededAsync(templateRepo, uow, ct);
+
+        var clientBaseUrl = config["ClientBaseUrl"] ?? "http://localhost:3000";
+        var resetLink = $"{clientBaseUrl}/client/reset-password?token={Uri.EscapeDataString(token)}&email={Uri.EscapeDataString(user.Value.Email)}";
+
+        await bus.InvokeAsync(new SendEmailCommand(
+            user.Value.Email,
+            PasswordResetTemplateSeeder.Slug,
+            new { reset_link = resetLink }), ct);
+
         return Ok();
     }
 

--- a/backend/src/Innovayse.Application/Notifications/Services/PasswordResetTemplateSeeder.cs
+++ b/backend/src/Innovayse.Application/Notifications/Services/PasswordResetTemplateSeeder.cs
@@ -1,0 +1,83 @@
+namespace Innovayse.Application.Notifications.Services;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Notifications;
+using Innovayse.Domain.Notifications.Interfaces;
+
+/// <summary>
+/// Lazily seeds the shared "user-password-reset" email template on first use.
+/// Used by both the admin-initiated reset (<c>AdminUsersController</c>) and the
+/// client/local self-service "forgot password" flow (<c>LocalAuthController</c>)
+/// so the two entry points send an identical email instead of drifting apart.
+/// </summary>
+public static class PasswordResetTemplateSeeder
+{
+    /// <summary>The shared template slug used by both reset entry points.</summary>
+    public const string Slug = "user-password-reset";
+
+    /// <summary>
+    /// Ensures the password reset template exists, creating it with the default
+    /// design if this is the first reset ever requested.
+    /// </summary>
+    /// <param name="templateRepo">Email template repository.</param>
+    /// <param name="uow">Unit of work for persisting the template if newly created.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task EnsureSeededAsync(
+        IEmailTemplateRepository templateRepo,
+        IUnitOfWork uow,
+        CancellationToken ct)
+    {
+        var existing = await templateRepo.FindBySlugAsync(Slug, ct);
+        if (existing is not null)
+        {
+            return;
+        }
+
+        var body = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+            <body style="margin:0;padding:0;background-color:#0a0a0f;font-family:'Inter',system-ui,-apple-system,sans-serif;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0a0a0f;padding:40px 20px;">
+                <tr><td align="center">
+                  <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;">
+                    <tr><td align="center" style="padding-bottom:32px;">
+                      <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+                        <td style="background:linear-gradient(135deg,rgba(14,165,233,0.1),rgba(168,85,247,0.1));border:1px solid rgba(14,165,233,0.2);border-radius:10px;padding:8px 16px;">
+                          <span style="font-size:16px;font-weight:700;background:linear-gradient(135deg,#0ea5e9,#a855f7);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;">Innovayse</span>
+                        </td>
+                      </tr></table>
+                    </td></tr>
+                    <tr><td style="background-color:#1a1a1f;border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:40px 36px;">
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                        <tr><td align="center" style="padding-bottom:24px;">
+                          <h1 style="margin:0;font-size:22px;font-weight:700;color:#f0f0f5;">Reset Your Password</h1>
+                        </td></tr>
+                        <tr><td align="center" style="padding-bottom:28px;">
+                          <p style="margin:0;font-size:14px;color:#8a8a9a;line-height:1.6;">Click the button below to reset your password. This link will expire in 24 hours.</p>
+                        </td></tr>
+                        <tr><td align="center" style="padding-bottom:28px;">
+                          <a href="{{ reset_link }}" style="display:inline-block;padding:14px 32px;background:linear-gradient(135deg,#0ea5e9,#0284c7);color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;border-radius:10px;box-shadow:0 4px 20px rgba(14,165,233,0.25);">Reset Password</a>
+                        </td></tr>
+                        <tr><td style="border-top:1px solid rgba(255,255,255,0.06);padding-top:20px;">
+                          <p style="margin:0;font-size:12px;color:#5a5a6a;line-height:1.6;">If you didn't request this, you can safely ignore this email.</p>
+                          <p style="margin:8px 0 0;font-size:12px;color:#0ea5e9;word-break:break-all;">{{ reset_link }}</p>
+                        </td></tr>
+                      </table>
+                    </td></tr>
+                    <tr><td align="center" style="padding-top:24px;">
+                      <p style="margin:0;font-size:11px;color:#3a3a4a;">© Innovayse. All rights reserved.</p>
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            """;
+
+        var template = EmailTemplate.Create(Slug, "Reset your password — Innovayse", body,
+            "Sent when a password reset is requested, whether by the user or an admin.");
+        templateRepo.Add(template);
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Events/TicketClosedHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Events/TicketClosedHandler.cs
@@ -1,0 +1,40 @@
+namespace Innovayse.Application.Support.Events;
+
+using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Notifications.Commands.SendEmail;
+using Innovayse.Domain.Clients.Interfaces;
+using Innovayse.Domain.Support.Events;
+using Innovayse.Domain.Support.Interfaces;
+using Wolverine;
+
+/// <summary>
+/// Handles <see cref="TicketClosedEvent"/> raised when a support ticket is closed.
+/// Notifies the client so they know the ticket is resolved and can leave feedback.
+/// </summary>
+public sealed class TicketClosedHandler(
+    IMessageBus bus,
+    ITicketRepository ticketRepo,
+    IClientRepository clientRepo,
+    IUserService userService)
+{
+    /// <summary>
+    /// Resolves the client's email and sends a ticket-closed notification email.
+    /// </summary>
+    /// <param name="evt">The ticket closed domain event.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task HandleAsync(TicketClosedEvent evt, CancellationToken ct)
+    {
+        var client = await clientRepo.FindByIdAsync(evt.ClientId, ct);
+        if (client is null) return;
+
+        var user = await userService.FindByIdAsync(client.UserId, ct);
+        if (user is null) return;
+
+        var ticket = await ticketRepo.FindByIdAsync(evt.TicketId, ct);
+        var subject = ticket?.Subject ?? string.Empty;
+
+        var data = new { ticket = new { id = evt.TicketId, subject } };
+
+        await bus.InvokeAsync(new SendEmailCommand(user.Value.Email, "ticket-closed", data), ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Events/TicketCreatedHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Events/TicketCreatedHandler.cs
@@ -1,24 +1,41 @@
 namespace Innovayse.Application.Support.Events;
 
+using Innovayse.Application.Notifications.Commands.SendEmail;
 using Innovayse.Domain.Support.Events;
+using Innovayse.Domain.Support.Interfaces;
 using Wolverine;
 
 /// <summary>
 /// Handles <see cref="TicketCreatedEvent"/> raised when a new support ticket is opened.
-/// Currently a placeholder — will dispatch email notifications when the Notifications module is ready.
+/// Notifies the department the ticket was routed to, if the department has an email set.
 /// </summary>
-public sealed class TicketCreatedHandler(IMessageBus bus)
+public sealed class TicketCreatedHandler(
+    IMessageBus bus,
+    ITicketRepository ticketRepo,
+    IDepartmentRepository departmentRepo)
 {
     /// <summary>
-    /// Processes the ticket created event.
+    /// Resolves the ticket and its department, then sends a ticket-created notification email
+    /// to the department if one is configured.
     /// </summary>
     /// <param name="evt">The ticket created domain event.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>A completed task (placeholder until notifications are implemented).</returns>
     public async Task HandleAsync(TicketCreatedEvent evt, CancellationToken ct)
     {
-        // TODO: dispatch SendEmailCommand to department when notifications module is ready
-        _ = bus;
-        await Task.CompletedTask;
+        var department = await departmentRepo.FindByIdAsync(evt.DepartmentId, ct);
+        if (department is null || string.IsNullOrWhiteSpace(department.Email))
+        {
+            return;
+        }
+
+        var ticket = await ticketRepo.FindByIdAsync(evt.TicketId, ct);
+        if (ticket is null)
+        {
+            return;
+        }
+
+        var data = new { ticket = new { id = evt.TicketId, subject = ticket.Subject } };
+
+        await bus.InvokeAsync(new SendEmailCommand(department.Email, "ticket-created", data), ct);
     }
 }

--- a/backend/src/Innovayse.Application/Support/Events/TicketRepliedHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Events/TicketRepliedHandler.cs
@@ -1,0 +1,55 @@
+namespace Innovayse.Application.Support.Events;
+
+using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Notifications.Commands.SendEmail;
+using Innovayse.Domain.Clients.Interfaces;
+using Innovayse.Domain.Support.Events;
+using Innovayse.Domain.Support.Interfaces;
+using Wolverine;
+
+/// <summary>
+/// Handles <see cref="TicketRepliedEvent"/> raised when a reply is added to a ticket.
+/// A staff reply notifies the client; a client reply notifies the assigned department.
+/// </summary>
+public sealed class TicketRepliedHandler(
+    IMessageBus bus,
+    ITicketRepository ticketRepo,
+    IDepartmentRepository departmentRepo,
+    IClientRepository clientRepo,
+    IUserService userService)
+{
+    /// <summary>
+    /// Resolves the recipient (client or department, depending on the reply's author) and
+    /// sends a ticket-replied notification email.
+    /// </summary>
+    /// <param name="evt">The ticket replied domain event.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task HandleAsync(TicketRepliedEvent evt, CancellationToken ct)
+    {
+        var ticket = await ticketRepo.FindByIdAsync(evt.TicketId, ct);
+        if (ticket is null)
+        {
+            return;
+        }
+
+        var data = new { ticket = new { id = evt.TicketId, subject = ticket.Subject } };
+
+        if (evt.IsStaffReply)
+        {
+            var client = await clientRepo.FindByIdAsync(ticket.ClientId, ct);
+            if (client is null) return;
+
+            var user = await userService.FindByIdAsync(client.UserId, ct);
+            if (user is null) return;
+
+            await bus.InvokeAsync(new SendEmailCommand(user.Value.Email, "ticket-replied", data), ct);
+        }
+        else if (ticket.DepartmentId is int departmentId)
+        {
+            var department = await departmentRepo.FindByIdAsync(departmentId, ct);
+            if (department is null || string.IsNullOrWhiteSpace(department.Email)) return;
+
+            await bus.InvokeAsync(new SendEmailCommand(department.Email, "ticket-replied", data), ct);
+        }
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Domains/Namecheap/NamecheapRegistrarProvider.cs
+++ b/backend/src/Innovayse.Infrastructure/Domains/Namecheap/NamecheapRegistrarProvider.cs
@@ -418,65 +418,140 @@ public sealed class NamecheapRegistrarProvider(NamecheapClient client) : IRegist
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> ModifyContactDetailsAsync(
+    public async Task<RegistrarResult> ModifyContactDetailsAsync(
         string domainName,
         DomainContact contact,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap contacts.setCustom API call.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        if (!client.IsConfigured)
+        {
+            return _notConfiguredResult;
+        }
+
+        var (sld, tld) = SplitDomain(domainName);
+
+        var parameters = new Dictionary<string, string>
+        {
+            ["SLD"] = sld,
+            ["TLD"] = tld,
+        };
+
+        // Namecheap's setContacts applies to all four contact roles in one call.
+        // We have no per-role data, so the same contact is used for every role —
+        // this matches how NameAm's ModifyContactDetailsAsync treats the same input.
+        foreach (var role in new[] { "Registrant", "Tech", "Admin", "AuxBilling" })
+        {
+            parameters[$"{role}FirstName"] = contact.FirstName;
+            parameters[$"{role}LastName"] = contact.LastName;
+            parameters[$"{role}OrganizationName"] = contact.Organization ?? string.Empty;
+            parameters[$"{role}EmailAddress"] = contact.Email;
+            parameters[$"{role}Phone"] = contact.Phone;
+            parameters[$"{role}Address1"] = contact.Address1;
+            parameters[$"{role}Address2"] = contact.Address2 ?? string.Empty;
+            parameters[$"{role}City"] = contact.City;
+            parameters[$"{role}StateProvince"] = contact.State;
+            parameters[$"{role}PostalCode"] = contact.PostalCode;
+            parameters[$"{role}Country"] = contact.Country;
+        }
+
+        await client.ExecuteAsync("namecheap.domains.setContacts", parameters, ct);
+        return new RegistrarResult(true, null, null, null);
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> SetEmailForwardingAsync(
+    public async Task<RegistrarResult> SetEmailForwardingAsync(
         string domainName,
         bool enabled,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap email forwarding toggle.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        if (!client.IsConfigured)
+        {
+            return _notConfiguredResult;
+        }
+
+        // Namecheap has no dedicated on/off switch — email forwarding is implicit
+        // in whether any forwarding rules exist. Disabling clears every rule;
+        // enabling with none configured yet is a no-op until rules are added.
+        if (!enabled)
+        {
+            return await SetAllEmailForwardsAsync(domainName, [], ct);
+        }
+
+        return new RegistrarResult(true, null, null, null);
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> AddEmailForwardingRuleAsync(
+    public async Task<RegistrarResult> AddEmailForwardingRuleAsync(
         string domainName,
         string source,
         string destination,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap email forwarding rule creation.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        var existing = await GetEmailForwardsAsync(domainName, ct);
+        var updated = existing
+            .Where(r => !string.Equals(r.Mailbox, source, StringComparison.OrdinalIgnoreCase))
+            .Append((Mailbox: source, ForwardTo: destination))
+            .ToList();
+
+        return await SetAllEmailForwardsAsync(domainName, updated, ct);
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> UpdateEmailForwardingRuleAsync(
+    public async Task<RegistrarResult> UpdateEmailForwardingRuleAsync(
         string domainName,
         string source,
         string destination,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap email forwarding rule update.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        var existing = await GetEmailForwardsAsync(domainName, ct);
+        var updated = existing
+            .Select(r => string.Equals(r.Mailbox, source, StringComparison.OrdinalIgnoreCase)
+                ? (Mailbox: source, ForwardTo: destination)
+                : r)
+            .ToList();
+
+        return await SetAllEmailForwardsAsync(domainName, updated, ct);
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> DeleteEmailForwardingRuleAsync(
+    public async Task<RegistrarResult> DeleteEmailForwardingRuleAsync(
         string domainName,
         string source,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap email forwarding rule deletion.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        var existing = await GetEmailForwardsAsync(domainName, ct);
+        var updated = existing
+            .Where(r => !string.Equals(r.Mailbox, source, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return await SetAllEmailForwardsAsync(domainName, updated, ct);
     }
 
     /// <inheritdoc/>
-    public Task<RegistrarResult> SetDnsManagementAsync(
+    public async Task<RegistrarResult> SetDnsManagementAsync(
         string domainName,
         bool enabled,
         CancellationToken ct)
     {
-        // TODO: Implement Namecheap DNS management toggle.
-        return Task.FromResult(new RegistrarResult(true, null, null, null));
+        if (!client.IsConfigured)
+        {
+            return _notConfiguredResult;
+        }
+
+        // "DNS management" here means "let Namecheap host the DNS" — enabling it
+        // repoints the domain at Namecheap's own nameservers. Disabling has no
+        // corresponding API call; the caller is expected to point nameservers
+        // elsewhere via SetNameserversAsync instead.
+        if (!enabled)
+        {
+            return new RegistrarResult(true, null, null, null);
+        }
+
+        var (sld, tld) = SplitDomain(domainName);
+        var parameters = new Dictionary<string, string> { ["SLD"] = sld, ["TLD"] = tld };
+
+        await client.ExecuteAsync("namecheap.domains.dns.setDefault", parameters, ct);
+        return new RegistrarResult(true, null, null, null);
     }
 
     /// <inheritdoc/>
@@ -604,6 +679,77 @@ public sealed class NamecheapRegistrarProvider(NamecheapClient client) : IRegist
 
         await client.ExecuteAsync("namecheap.domains.dns.setHosts", parameters, ct);
         return new RegistrarResult(true, registrarRef, null, null);
+    }
+
+    /// <summary>
+    /// Reads the current email forwarding rules via <c>namecheap.domains.dns.getEmailForwarding</c>.
+    /// </summary>
+    /// <param name="domainName">The fully-qualified domain name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The mailbox → forward-to pairs currently configured.</returns>
+    private async Task<List<(string Mailbox, string ForwardTo)>> GetEmailForwardsAsync(
+        string domainName,
+        CancellationToken ct)
+    {
+        if (!client.IsConfigured)
+        {
+            return [];
+        }
+
+        var parameters = new Dictionary<string, string> { ["DomainName"] = domainName };
+        var doc = await client.ExecuteAsync("namecheap.domains.dns.getEmailForwarding", parameters, ct);
+
+        var ns = GetNamespace(doc);
+        var forwardNodes = doc.Root
+            ?.Element(XName.Get("CommandResponse", ns))
+            ?.Element(XName.Get("DomainDNSGetEmailForwardingResult", ns))
+            ?.Elements(XName.Get("Forward", ns))
+            ?? [];
+
+        var forwards = new List<(string Mailbox, string ForwardTo)>();
+        foreach (var node in forwardNodes)
+        {
+            var mailbox = node.Attribute("mailbox")?.Value;
+            var forwardTo = node.Value;
+            if (!string.IsNullOrEmpty(mailbox) && !string.IsNullOrEmpty(forwardTo))
+            {
+                forwards.Add((mailbox, forwardTo));
+            }
+        }
+
+        return forwards;
+    }
+
+    /// <summary>
+    /// Pushes the complete set of email forwarding rules to Namecheap using
+    /// <c>namecheap.domains.dns.setEmailForwarding</c>. As with DNS hosts, Namecheap
+    /// requires the full rule set on every write — there is no add/remove-single-rule call.
+    /// </summary>
+    /// <param name="domainName">The fully-qualified domain name.</param>
+    /// <param name="forwards">The complete list of mailbox → forward-to pairs to persist.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating whether the operation succeeded.</returns>
+    private async Task<RegistrarResult> SetAllEmailForwardsAsync(
+        string domainName,
+        IReadOnlyList<(string Mailbox, string ForwardTo)> forwards,
+        CancellationToken ct)
+    {
+        if (!client.IsConfigured)
+        {
+            return _notConfiguredResult;
+        }
+
+        var parameters = new Dictionary<string, string> { ["DomainName"] = domainName };
+
+        for (var i = 0; i < forwards.Count; i++)
+        {
+            var n = i + 1;
+            parameters[$"MailBox{n}"] = forwards[i].Mailbox;
+            parameters[$"ForwardTo{n}"] = forwards[i].ForwardTo;
+        }
+
+        await client.ExecuteAsync("namecheap.domains.dns.setEmailForwarding", parameters, ct);
+        return new RegistrarResult(true, null, null, null);
     }
 
     /// <summary>

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260727195405_AddTicketRepliedClosedEmailTemplates.Designer.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260727195405_AddTicketRepliedClosedEmailTemplates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Innovayse.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Innovayse.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727195405_AddTicketRepliedClosedEmailTemplates")]
+    partial class AddTicketRepliedClosedEmailTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Innovayse.Infrastructure/Migrations/20260727195405_AddTicketRepliedClosedEmailTemplates.cs
+++ b/backend/src/Innovayse.Infrastructure/Migrations/20260727195405_AddTicketRepliedClosedEmailTemplates.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Innovayse.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTicketRepliedClosedEmailTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "email_templates",
+                columns: new[] { "Id", "Body", "Description", "IsActive", "Slug", "Subject" },
+                values: new object[,]
+                {
+                    { 6, "<p>There's a new reply on your support ticket.</p>", "Sent when a reply is added to a ticket", true, "ticket-replied", "New Reply on Ticket #{{ticket.id}}: {{ticket.subject}}" },
+                    { 7, "<p>Your support ticket \"{{ticket.subject}}\" has been closed. We'd love your feedback.</p>", "Sent when a ticket is closed", true, "ticket-closed", "Support Ticket #{{ticket.id}} Closed" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "email_templates",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "email_templates",
+                keyColumn: "Id",
+                keyValue: 7);
+        }
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Notifications/Configurations/EmailTemplateConfiguration.cs
+++ b/backend/src/Innovayse.Infrastructure/Notifications/Configurations/EmailTemplateConfiguration.cs
@@ -67,6 +67,24 @@ public sealed class EmailTemplateConfiguration : IEntityTypeConfiguration<EmailT
                 Body = "<p>We received your support request.</p>",
                 IsActive = true,
                 Description = "Sent when ticket created",
+            },
+            new
+            {
+                Id = 6,
+                Slug = "ticket-replied",
+                Subject = "New Reply on Ticket #{{ticket.id}}: {{ticket.subject}}",
+                Body = "<p>There's a new reply on your support ticket.</p>",
+                IsActive = true,
+                Description = "Sent when a reply is added to a ticket",
+            },
+            new
+            {
+                Id = 7,
+                Slug = "ticket-closed",
+                Subject = "Support Ticket #{{ticket.id}} Closed",
+                Body = "<p>Your support ticket \"{{ticket.subject}}\" has been closed. We'd love your feedback.</p>",
+                IsActive = true,
+                Description = "Sent when a ticket is closed",
             });
     }
 }

--- a/backend/tests/Innovayse.Application.Tests/Support/TicketNotificationHandlersTests.cs
+++ b/backend/tests/Innovayse.Application.Tests/Support/TicketNotificationHandlersTests.cs
@@ -1,0 +1,172 @@
+namespace Innovayse.Application.Tests.Support;
+
+using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Notifications.Commands.SendEmail;
+using Innovayse.Application.Support.Events;
+using Innovayse.Domain.Clients;
+using Innovayse.Domain.Clients.Interfaces;
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Events;
+using Innovayse.Domain.Support.Interfaces;
+using Moq;
+using Wolverine;
+using Xunit;
+
+/// <summary>
+/// Unit tests for the Support module's notification handlers
+/// (<see cref="TicketCreatedHandler"/>, <see cref="TicketRepliedHandler"/>, <see cref="TicketClosedHandler"/>).
+/// </summary>
+public sealed class TicketNotificationHandlersTests
+{
+    private static Client MakeClient(string userId = "user-1") =>
+        Client.Create(userId, "Jane", "Doe", "jane@example.com");
+
+    public sealed class TicketCreatedHandlerTests
+    {
+        [Fact]
+        public async Task HandleAsync_WhenDepartmentHasEmail_SendsTicketCreatedEmailAsync()
+        {
+            var ticket = Ticket.Create(clientId: 1, "Help", "Something's broken", departmentId: 5, TicketPriority.Medium);
+            var department = Department.Create("Support", "support@example.com");
+
+            var ticketRepo = new Mock<ITicketRepository>();
+            ticketRepo.Setup(r => r.FindByIdAsync(ticket.Id, It.IsAny<CancellationToken>())).ReturnsAsync(ticket);
+
+            var departmentRepo = new Mock<IDepartmentRepository>();
+            departmentRepo.Setup(r => r.FindByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(department);
+
+            var bus = new Mock<IMessageBus>();
+
+            var handler = new TicketCreatedHandler(bus.Object, ticketRepo.Object, departmentRepo.Object);
+
+            await handler.HandleAsync(new TicketCreatedEvent(ticket.Id, 1, 5), CancellationToken.None);
+
+            bus.Verify(b => b.InvokeAsync(
+                It.Is<SendEmailCommand>(c => c.To == "support@example.com" && c.TemplateSlug == "ticket-created"),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<TimeSpan?>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenDepartmentNotFound_DoesNotSendAsync()
+        {
+            var ticketRepo = new Mock<ITicketRepository>();
+            var departmentRepo = new Mock<IDepartmentRepository>();
+            departmentRepo.Setup(r => r.FindByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync((Department?)null);
+
+            var bus = new Mock<IMessageBus>();
+            var handler = new TicketCreatedHandler(bus.Object, ticketRepo.Object, departmentRepo.Object);
+
+            await handler.HandleAsync(new TicketCreatedEvent(1, 1, 5), CancellationToken.None);
+
+            bus.VerifyNoOtherCalls();
+            ticketRepo.VerifyNoOtherCalls();
+        }
+    }
+
+    public sealed class TicketRepliedHandlerTests
+    {
+        [Fact]
+        public async Task HandleAsync_WhenStaffReplies_NotifiesClientAsync()
+        {
+            var ticket = Ticket.Create(1, "Help", "Something's broken", departmentId: 5, TicketPriority.Medium);
+            var client = MakeClient();
+
+            var ticketRepo = new Mock<ITicketRepository>();
+            ticketRepo.Setup(r => r.FindByIdAsync(ticket.Id, It.IsAny<CancellationToken>())).ReturnsAsync(ticket);
+
+            var clientRepo = new Mock<IClientRepository>();
+            clientRepo.Setup(r => r.FindByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(client);
+
+            var userService = new Mock<IUserService>();
+            userService.Setup(s => s.FindByIdAsync(client.UserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((client.UserId, "jane@example.com"));
+
+            var departmentRepo = new Mock<IDepartmentRepository>();
+            var bus = new Mock<IMessageBus>();
+
+            var handler = new TicketRepliedHandler(bus.Object, ticketRepo.Object, departmentRepo.Object, clientRepo.Object, userService.Object);
+
+            await handler.HandleAsync(new TicketRepliedEvent(ticket.Id, IsStaffReply: true), CancellationToken.None);
+
+            bus.Verify(b => b.InvokeAsync(
+                It.Is<SendEmailCommand>(c => c.To == "jane@example.com" && c.TemplateSlug == "ticket-replied"),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<TimeSpan?>()), Times.Once);
+            departmentRepo.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenClientReplies_NotifiesDepartmentAsync()
+        {
+            var ticket = Ticket.Create(1, "Help", "Something's broken", departmentId: 5, TicketPriority.Medium);
+            var department = Department.Create("Support", "support@example.com");
+
+            var ticketRepo = new Mock<ITicketRepository>();
+            ticketRepo.Setup(r => r.FindByIdAsync(ticket.Id, It.IsAny<CancellationToken>())).ReturnsAsync(ticket);
+
+            var departmentRepo = new Mock<IDepartmentRepository>();
+            departmentRepo.Setup(r => r.FindByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(department);
+
+            var clientRepo = new Mock<IClientRepository>();
+            var userService = new Mock<IUserService>();
+            var bus = new Mock<IMessageBus>();
+
+            var handler = new TicketRepliedHandler(bus.Object, ticketRepo.Object, departmentRepo.Object, clientRepo.Object, userService.Object);
+
+            await handler.HandleAsync(new TicketRepliedEvent(ticket.Id, IsStaffReply: false), CancellationToken.None);
+
+            bus.Verify(b => b.InvokeAsync(
+                It.Is<SendEmailCommand>(c => c.To == "support@example.com" && c.TemplateSlug == "ticket-replied"),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<TimeSpan?>()), Times.Once);
+            clientRepo.VerifyNoOtherCalls();
+        }
+    }
+
+    public sealed class TicketClosedHandlerTests
+    {
+        [Fact]
+        public async Task HandleAsync_SendsTicketClosedEmailToClientAsync()
+        {
+            var ticket = Ticket.Create(1, "Help", "Something's broken", departmentId: 5, TicketPriority.Medium);
+            var client = MakeClient();
+
+            var ticketRepo = new Mock<ITicketRepository>();
+            ticketRepo.Setup(r => r.FindByIdAsync(ticket.Id, It.IsAny<CancellationToken>())).ReturnsAsync(ticket);
+
+            var clientRepo = new Mock<IClientRepository>();
+            clientRepo.Setup(r => r.FindByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(client);
+
+            var userService = new Mock<IUserService>();
+            userService.Setup(s => s.FindByIdAsync(client.UserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((client.UserId, "jane@example.com"));
+
+            var bus = new Mock<IMessageBus>();
+            var handler = new TicketClosedHandler(bus.Object, ticketRepo.Object, clientRepo.Object, userService.Object);
+
+            await handler.HandleAsync(new TicketClosedEvent(ticket.Id, 1), CancellationToken.None);
+
+            bus.Verify(b => b.InvokeAsync(
+                It.Is<SendEmailCommand>(c => c.To == "jane@example.com" && c.TemplateSlug == "ticket-closed"),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<TimeSpan?>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenClientNotFound_DoesNotSendAsync()
+        {
+            var ticketRepo = new Mock<ITicketRepository>();
+            var clientRepo = new Mock<IClientRepository>();
+            clientRepo.Setup(r => r.FindByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((Client?)null);
+
+            var userService = new Mock<IUserService>();
+            var bus = new Mock<IMessageBus>();
+            var handler = new TicketClosedHandler(bus.Object, ticketRepo.Object, clientRepo.Object, userService.Object);
+
+            await handler.HandleAsync(new TicketClosedEvent(1, 1), CancellationToken.None);
+
+            bus.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/backend/tests/Innovayse.Infrastructure.Tests/Domains/Namecheap/NamecheapRegistrarProviderTests.cs
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Domains/Namecheap/NamecheapRegistrarProviderTests.cs
@@ -1,0 +1,184 @@
+namespace Innovayse.Infrastructure.Tests.Domains.Namecheap;
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Innovayse.Domain.Domains;
+using Innovayse.Infrastructure.Domains.Namecheap;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="NamecheapRegistrarProvider"/>'s previously-stubbed operations —
+/// contact updates, email forwarding, and the DNS-management toggle — verifying both the
+/// XML response parsing and the exact query parameters sent to the Namecheap API.
+/// </summary>
+public sealed class NamecheapRegistrarProviderTests
+{
+    private static NamecheapSettings Settings => new()
+    {
+        ApiUser = "testuser",
+        ApiKey = "testkey",
+        ClientIp = "127.0.0.1",
+        ApiUrl = "https://api.sandbox.namecheap.com/xml.response",
+    };
+
+    /// <summary>
+    /// Builds a provider wired to a mock HTTP handler that always returns <paramref name="responseXml"/>,
+    /// and captures the last request URL sent so tests can assert on the query parameters.
+    /// </summary>
+    private static (NamecheapRegistrarProvider Provider, Func<string> LastRequestUrl) BuildProvider(string responseXml)
+    {
+        string? lastUrl = null;
+
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => lastUrl = req.RequestUri!.ToString())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseXml, Encoding.UTF8, "text/xml"),
+            });
+
+        var http = new HttpClient(mockHandler.Object);
+        var client = new NamecheapClient(http, Options.Create(Settings));
+        return (new NamecheapRegistrarProvider(client), () => lastUrl ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Extracts a single query parameter's decoded value from a request URL.
+    /// Avoids depending on System.Web/AspNetCore query-parsing helpers just for tests.
+    /// </summary>
+    private static string QueryParam(string url, string name)
+    {
+        var query = new Uri(url).Query.TrimStart('?');
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length == 2 && Uri.UnescapeDataString(parts[0]) == name)
+            {
+                return Uri.UnescapeDataString(parts[1]);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    [Fact]
+    public async Task ModifyContactDetailsAsync_SendsSetContactsCommand_ForAllFourRolesAsync()
+    {
+        const string response = """<?xml version="1.0"?><ApiResponse Status="OK"><CommandResponse><DomainSetContactResult Domain="example.com" IsSuccess="true" /></CommandResponse></ApiResponse>""";
+        var (provider, lastUrl) = BuildProvider(response);
+
+        var contact = new DomainContact(
+            "Jane", "Doe", "Acme Inc", "jane@example.com", "+1.5551234567",
+            "123 Main St", null, "Springfield", "IL", "62701", "US");
+
+        var result = await provider.ModifyContactDetailsAsync("example.com", contact, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var url = lastUrl();
+        QueryParam(url, "Command").Should().Be("namecheap.domains.setContacts");
+        QueryParam(url, "RegistrantFirstName").Should().Be("Jane");
+        QueryParam(url, "TechEmailAddress").Should().Be("jane@example.com");
+        QueryParam(url, "AdminCountry").Should().Be("US");
+        QueryParam(url, "AuxBillingLastName").Should().Be("Doe");
+    }
+
+    [Fact]
+    public async Task SetEmailForwardingAsync_WhenDisabling_ClearsAllForwardsAsync()
+    {
+        const string response = """<?xml version="1.0"?><ApiResponse Status="OK"><CommandResponse /></ApiResponse>""";
+        var (provider, lastUrl) = BuildProvider(response);
+
+        var result = await provider.SetEmailForwardingAsync("example.com", enabled: false, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        QueryParam(lastUrl(), "Command").Should().Be("namecheap.domains.dns.setEmailForwarding");
+        QueryParam(lastUrl(), "MailBox1").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddEmailForwardingRuleAsync_MergesWithExistingForwardsAsync()
+    {
+        // First call (GetEmailForwardsAsync inside AddEmailForwardingRuleAsync) returns one
+        // existing forward; the provider must resend it alongside the newly added rule.
+        const string getResponse = """
+            <?xml version="1.0"?>
+            <ApiResponse Status="OK">
+              <CommandResponse>
+                <DomainDNSGetEmailForwardingResult>
+                  <Forward mailbox="sales">sales@destination.com</Forward>
+                </DomainDNSGetEmailForwardingResult>
+              </CommandResponse>
+            </ApiResponse>
+            """;
+
+        var mockHandler = new Mock<HttpMessageHandler>();
+        var capturedUrls = new List<string>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedUrls.Add(req.RequestUri!.ToString()))
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(getResponse, Encoding.UTF8, "text/xml"),
+            });
+
+        var http = new HttpClient(mockHandler.Object);
+        var provider = new NamecheapRegistrarProvider(new NamecheapClient(http, Options.Create(Settings)));
+
+        var result = await provider.AddEmailForwardingRuleAsync(
+            "example.com", "support", "support@destination.com", CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        capturedUrls.Should().HaveCount(2);
+
+        var setUrl = capturedUrls[1];
+        QueryParam(setUrl, "Command").Should().Be("namecheap.domains.dns.setEmailForwarding");
+
+        var mailboxes = new[] { QueryParam(setUrl, "MailBox1"), QueryParam(setUrl, "MailBox2") };
+        mailboxes.Should().Contain("sales").And.Contain("support");
+    }
+
+    [Fact]
+    public async Task SetDnsManagementAsync_WhenEnabling_CallsSetDefaultAsync()
+    {
+        const string response = """<?xml version="1.0"?><ApiResponse Status="OK"><CommandResponse /></ApiResponse>""";
+        var (provider, lastUrl) = BuildProvider(response);
+
+        var result = await provider.SetDnsManagementAsync("example.com", enabled: true, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        QueryParam(lastUrl(), "Command").Should().Be("namecheap.domains.dns.setDefault");
+    }
+
+    [Fact]
+    public async Task SetDnsManagementAsync_WhenDisabling_MakesNoApiCallAsync()
+    {
+        var callCount = 0;
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback(() => callCount++)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("<ApiResponse Status=\"OK\"/>") });
+
+        var http = new HttpClient(mockHandler.Object);
+        var provider = new NamecheapRegistrarProvider(new NamecheapClient(http, Options.Create(Settings)));
+
+        var result = await provider.SetDnsManagementAsync("example.com", enabled: false, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        callCount.Should().Be(0);
+    }
+}

--- a/backend/tests/Innovayse.Infrastructure.Tests/Innovayse.Infrastructure.Tests.csproj
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Innovayse.Infrastructure.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Settings inherited from Directory.Build.props -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Options" /><!-- version pinned centrally in Directory.Packages.props -->
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Innovayse.Infrastructure\Innovayse.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Innovayse.Domain\Innovayse.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,9 @@ services:
       context: .
       dockerfile: docker/admin.Dockerfile
       target: prod
+      args:
+        VITE_SSO_URL: ${SSO_PUBLIC_URL:-https://accounts.innovayse.com}
+        VITE_SSO_CLIENT_ID: ${ADMIN_SSO_CLIENT_ID:-hostpanel-admin}
     depends_on:
       - api
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
     environment:
       VITE_API_BASE: /api
       API_PROXY_TARGET: http://api:5148
+      VITE_SSO_URL: http://accounts.local
+      VITE_SSO_CLIENT_ID: hostpanel-admin
       CHOKIDAR_USEPOLLING: "true"
     depends_on:
       - api

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -15,6 +15,13 @@ FROM node:22-alpine AS build
 
 WORKDIR /app
 
+# Vite inlines VITE_* vars at build time, so the SSO endpoint must be baked in
+# here rather than read at container start like the other services' env vars.
+ARG VITE_SSO_URL=https://accounts.innovayse.com
+ARG VITE_SSO_CLIENT_ID=hostpanel-admin
+ENV VITE_SSO_URL=$VITE_SSO_URL
+ENV VITE_SSO_CLIENT_ID=$VITE_SSO_CLIENT_ID
+
 COPY admin/package.json admin/package-lock.json ./
 RUN npm install
 


### PR DESCRIPTION
## Summary
- Admin panel now authenticates via Innovayse SSO (new public PKCE client `hostpanel-admin`) instead of the old local-JWT login form — the admin panel is a pure Vite SPA with no BFF, so a local password login didn't actually work once `Auth:Mode` defaulted to `sso`. Adds `GET /api/auth/me` for reading the SSO-authenticated user's local roles.
- Implements the 6 previously-stubbed Namecheap registrar operations: `setContacts`, email forwarding (get/set/add/update/delete), and the DNS-management toggle.
- Wires up ticket notification emails: `TicketCreatedHandler` now actually emails the department; adds `TicketRepliedHandler` and `TicketClosedHandler`. Local-mode forgot-password now sends a real reset email (reusing the same template as the admin-initiated reset).
- Adds a new `Innovayse.Infrastructure.Tests` project plus unit tests for the new handlers and Namecheap API calls.

Companion change in `innovayse-sso` registers the `hostpanel-admin` client (already applied/verified against the local SSO instance).

## Test plan
- [x] `dotnet build` on the full solution
- [x] `dotnet test` — new tests pass (6 ticket-handler tests, 5 Namecheap tests); pre-existing Integration.Tests failures confirmed present on `main` too (unrelated to this branch)
- [x] `vue-tsc --build` on admin — no new type errors in touched files
- [x] `vite build` on admin — succeeds
- [x] Live-verified against local SSO: `hostpanel-admin` client registered as public/PKCE, `/connect/authorize` accepts it and redirects correctly
- [x] EF migration applied locally, new email templates seeded