### PR TITLE
feat(panel): widget integration, SSO switch-account, mobile UX

### DIFF
--- a/client/components/layout/Header.vue
+++ b/client/components/layout/Header.vue
@@ -319,6 +319,10 @@ onMounted(async () => {
   if (isLoggedIn.value) {
     await fetchUser()
   }
+
+  // Reinit the widget so it picks up any accounts saved by the callback flow
+  const w = window as unknown as { InnoWidget?: { reinit: () => void } }
+  w.InnoWidget?.reinit?.()
 })
 
 async function handleLogout() {

--- a/client/layouts/client.vue
+++ b/client/layouts/client.vue
@@ -2,12 +2,33 @@
   <!-- Full viewport, pinned to viewport — prevents any browser-level scroll -->
   <div class="fixed inset-0 overflow-hidden bg-gray-50 dark:bg-[#0a0a0f] flex flex-col">
 
-    <!-- Mobile top bar — fixed at top, shrinks flex column -->
-    <header class="lg:hidden flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-white/10 bg-white dark:bg-[#0d0d12] z-30">
-      <NuxtLink to="/" class="text-gray-900 dark:text-white font-bold text-lg">Innovayse</NuxtLink>
-      <div class="flex items-center gap-3">
-        <span class="text-sm text-gray-500 dark:text-gray-400 truncate max-w-[120px]">{{ store.fullName }}</span>
-        <button class="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white" @click="sidebarOpen = !sidebarOpen">
+    <!-- Unified top bar (mobile + desktop) — one header, no duplicate mount IDs -->
+    <header class="flex-shrink-0 flex items-center justify-between px-4 lg:px-8 py-3 lg:py-4 border-b border-gray-200 dark:border-white/10 bg-white dark:bg-[#0d0d12] z-30">
+
+      <!-- Left: logo on mobile / welcome text on desktop -->
+      <div class="min-w-0 mr-3">
+        <NuxtLink to="/" class="lg:hidden text-gray-900 dark:text-white font-bold text-lg">Innovayse</NuxtLink>
+        <div class="hidden lg:block text-gray-500 dark:text-gray-400 text-sm truncate">
+          {{ $t('client.nav.welcomeBack') }}
+          <span class="text-gray-900 dark:text-white font-medium">{{ store.fullName }}</span>
+        </div>
+      </div>
+
+      <!-- Right: controls -->
+      <div class="flex items-center gap-2 lg:gap-3 flex-shrink-0">
+        <!-- Desktop-only: theme toggle, language switcher, app launcher -->
+        <div class="hidden lg:flex items-center gap-3">
+          <UiThemeToggle />
+          <UiLanguageSwitcher />
+          <div id="inno-launcher-mount"></div>
+        </div>
+        <!-- Account popup: always visible (mobile needs account switching too) -->
+        <div id="inno-account-mount"></div>
+        <!-- Hamburger: mobile only -->
+        <button
+          class="lg:hidden p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+          @click="sidebarOpen = !sidebarOpen"
+        >
           <Menu v-if="!sidebarOpen" :size="22" :stroke-width="2" />
           <X v-else :size="22" :stroke-width="2" />
         </button>
@@ -32,19 +53,6 @@
           <button class="lg:hidden text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white" @click="sidebarOpen = false">
             <X :size="18" :stroke-width="2" />
           </button>
-        </div>
-
-        <!-- User info -->
-        <div class="px-6 py-4 border-b border-gray-200 dark:border-white/10 flex-shrink-0">
-          <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-full bg-gradient-to-br from-cyan-500/30 to-primary-500/20 flex items-center justify-center text-cyan-700 dark:text-white font-bold text-sm border border-cyan-500/30">
-              {{ store.userInitial }}
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="text-gray-900 dark:text-white font-medium text-sm truncate">{{ store.fullName || $t('client.nav.dashboard') }}</div>
-              <div class="text-gray-500 text-xs truncate">{{ store.user?.email }}</div>
-            </div>
-          </div>
         </div>
 
         <!-- Navigation — scrollable if nav items overflow -->
@@ -92,26 +100,6 @@
 
       <!-- Main — only this scrolls -->
       <main class="flex-1 min-w-0 overflow-y-auto flex flex-col">
-
-        <!-- Desktop top bar — sticky inside the scrollable main -->
-        <div class="hidden lg:flex flex-shrink-0 items-center justify-between px-8 py-4 border-b border-gray-200 dark:border-white/10 bg-white dark:bg-[#0d0d12] sticky top-0 z-10">
-          <div class="text-gray-500 dark:text-gray-400 text-sm">
-            {{ $t('client.nav.welcomeBack') }} <span class="text-gray-900 dark:text-white font-medium">{{ store.fullName }}</span>
-          </div>
-          <div class="flex items-center gap-3">
-            <UiThemeToggle />
-            <UiLanguageSwitcher />
-            <button
-              class="flex items-center gap-2 px-4 py-2 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-all duration-200 border border-gray-200 dark:border-white/10 hover:border-red-200 dark:hover:border-red-500/20"
-              @click="handleLogout"
-            >
-              <LogOut :size="16" :stroke-width="2" />
-              {{ $t('client.nav.signOut') }}
-            </button>
-          </div>
-        </div>
-
-        <!-- Page content -->
         <div class="p-6 lg:p-8">
           <Suspense>
             <template #default>
@@ -153,14 +141,41 @@ const { logout } = useClientAuth()
 const { hasPermission } = usePermissions()
 const store = useClientStore()
 const { init } = useAppColorMode()
+const config = useRuntimeConfig()
 
 const sidebarOpen = ref(false)
 
-// Apply saved color preference when entering client area; restore dark on leave
+function widgetReinit() {
+  const w = window as unknown as { InnoWidget?: { reinit: () => void } }
+  if (w.InnoWidget?.reinit) w.InnoWidget.reinit()
+}
+
 onMounted(async () => {
   init()
   if (!store.userLoaded) await store.fetchUser()
+  // Reinit widget after Vue renders the mount points.
+  // Poll until InnoWidget is available (script may still be loading with async).
+  await nextTick()
+  let attempts = 0
+  const tryReinit = () => {
+    const w = window as unknown as { InnoWidget?: { reinit: () => void } }
+    if (w.InnoWidget?.reinit) {
+      w.InnoWidget.reinit()
+    } else if (attempts++ < 50) {
+      setTimeout(tryReinit, 200)
+    }
+  }
+  setTimeout(tryReinit, 50)
 })
+
+// Vue may re-render the layout after reactive state changes, replacing mount point divs.
+// Reinit the widget if the account button was wiped.
+onUpdated(() => {
+  if (!document.getElementById('inno-account-btn')) {
+    widgetReinit()
+  }
+})
+
 onUnmounted(() => {
   document.documentElement.classList.add('dark')
   document.documentElement.classList.remove('light')
@@ -187,11 +202,34 @@ function isActive(path: string) {
 }
 
 async function handleLogout() {
-  await logout()
-  store.reset()
-  navigateTo('/client/login')
+  const authMode = config.public.authMode as string
+
+  if (authMode === 'sso') {
+    // Clear cookies + fire backchannel logout (fire-and-forget is fine)
+    try {
+      await $fetch('/api/portal/auth/logout', { method: 'POST', credentials: 'include' })
+    } catch { /* ignore — clear session regardless */ }
+    store.reset()
+    // Navigate browser to SSO endsession (required to clear SSO session cookie at accounts.local)
+    const ssoPublicUrl = (config.public.ssoPublicUrl as string) || 'http://accounts.local'
+    window.location.href = `${ssoPublicUrl}/connect/endsession?post_logout_redirect_uri=${encodeURIComponent(window.location.origin)}`
+  } else {
+    await logout()
+    store.reset()
+    navigateTo('/client/login')
+  }
 }
 </script>
+
+<style>
+/* Account panel responsive width on small screens */
+@media (max-width: 640px) {
+  #inno-account-panel {
+    width: calc(100vw - 16px);
+    right: -4px;
+  }
+}
+</style>
 
 <style scoped>
 .fade-enter-active,

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -72,6 +72,8 @@ export default defineNuxtConfig({
     whmcsAccessKey: process.env.WHMCS_ACCESS_KEY,
     // WHM root API token for cPanel SSO (create_user_session)
     whmApiToken: process.env.WHM_API_TOKEN,
+    // Internal URL of innovayse-main (app.local) — used for backchannel logout delegation
+    mainApiUrl: process.env.NUXT_MAIN_API_URL || 'http://innovayse-main-client-1:3000',
 
     // Public runtime config (exposed to client)
     public: {
@@ -85,7 +87,7 @@ export default defineNuxtConfig({
       nextcloudUrl: process.env.NUXT_PUBLIC_NEXTCLOUD_URL || 'http://cloud.local',
       whmcsUrl: (process.env.WHMCS_URL || '').replace(/\/+$/, ''),
       stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || '',
-      widgetUrl: process.env.NUXT_PUBLIC_WIDGET_URL || '',
+      mainUrl: process.env.NUXT_PUBLIC_MAIN_URL || 'http://app.local',
     }
   },
 
@@ -147,6 +149,9 @@ export default defineNuxtConfig({
   },
 
   vite: {
+    server: {
+      allowedHosts: ['panel.local', 'panel-admin.local']
+    },
     ssr: {
       // Force lucide-vue-next to be bundled into the SSR output (not treated as external)
       // This prevents named export resolution issues (e.g. "Server is not defined")
@@ -199,8 +204,8 @@ export default defineNuxtConfig({
         { name: 'theme-color', content: '#0ea5e9' }
       ],
       script: [
-        ...(process.env.NUXT_PUBLIC_WIDGET_URL
-          ? [{ src: `${process.env.NUXT_PUBLIC_WIDGET_URL}/widget/header.js`, defer: true }]
+        ...(process.env.NUXT_PUBLIC_MAIN_URL
+          ? [{ src: `${process.env.NUXT_PUBLIC_MAIN_URL}/widget/header.js`, async: true }]
           : []),
       ],
       link: [

--- a/client/server/api/portal/auth/logout.post.ts
+++ b/client/server/api/portal/auth/logout.post.ts
@@ -1,19 +1,22 @@
 /**
  * POST /api/portal/auth/logout
  *
- * Revokes the refresh token on the backend and clears all auth cookies.
- * Forwards the refresh token as a Cookie header since the backend reads
- * it from `Request.Cookies["refreshToken"]`.
+ * Called by the shared header widget when the user clicks Sign out.
+ * 1. Revokes the refresh token on the hostpanel backend.
+ * 2. Fires backchannel logout to all platform services via app.local
+ *    (app.local already knows all internal service URLs and keys).
+ * 3. Clears all auth cookies.
  */
 import { clearAllAuthCookies } from '~/server/utils/api'
 
 export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
   const refreshToken = getCookie(event, 'refresh_token')
+  const authToken = getCookie(event, 'auth_token')
 
+  // 1. Revoke refresh token on hostpanel backend
   try {
-    const config = useRuntimeConfig()
     const apiUrl = (config.apiUrl as string) || 'http://localhost:5000'
-
     await $fetch(`${apiUrl}/api/auth/logout`, {
       method: 'POST',
       headers: {
@@ -22,9 +25,29 @@ export default defineEventHandler(async (event) => {
       },
     })
   } catch {
-    // Ignore backend errors on logout — clear cookies regardless
+    // Ignore — clear cookies regardless
   }
 
+  // 2. Fire backchannel logout to all platform services via app.local.
+  // The widget goes to SSO endsession after this returns, but backchannel
+  // calls are fire-and-forget so we don't block the response on them.
+  if (authToken) {
+    try {
+      const payload = authToken.split('.')[1] ?? ''
+      const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+      const email: string = decoded.email || decoded.sub || ''
+      const mainApiUrl = (config.mainApiUrl as string) || 'http://innovayse-main-client-1:3000'
+      if (email) {
+        fetch(`${mainApiUrl}/api/portal/auth/sso/logout-redirect?redirect_uri=${encodeURIComponent('http://panel.local')}`, {
+          headers: { Cookie: `auth_token=${authToken}` },
+          redirect: 'manual',
+          signal: AbortSignal.timeout(3000),
+        }).catch(() => {})
+      }
+    } catch { /* ignore */ }
+  }
+
+  // 3. Clear all cookies
   clearAllAuthCookies(event)
   return { ok: true }
 })

--- a/client/server/api/portal/auth/sso/authorize.get.ts
+++ b/client/server/api/portal/auth/sso/authorize.get.ts
@@ -49,6 +49,24 @@ export default defineEventHandler(async (event) => {
   // If the user explicitly wants to switch accounts, pass prompt=select_account
   if (query.prompt) params.set('prompt', query.prompt as string)
 
+  // Save current page so callback can return here instead of always going to dashboard
+  let returnTo = (query.returnTo as string | undefined) || ''
+  if (!returnTo) {
+    const referer = getHeader(event, 'referer') || ''
+    if (referer) {
+      try { returnTo = new URL(referer).pathname } catch { /* ignore */ }
+    }
+  }
+  if (returnTo && returnTo.startsWith('/') && !returnTo.startsWith('/api/')) {
+    setCookie(event, 'post_login_redirect', returnTo, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 5,
+      path: '/',
+    })
+  }
+
   const authorizeUrl = `${config.public.ssoPublicUrl}/connect/authorize?${params}`
   return sendRedirect(event, authorizeUrl, 302)
 })

--- a/client/server/api/portal/auth/sso/callback.get.ts
+++ b/client/server/api/portal/auth/sso/callback.get.ts
@@ -100,10 +100,39 @@ export default defineEventHandler(async (event) => {
     path: '/',
   })
 
+  // Fetch real user info from SSO userinfo endpoint and expose it via a short-lived
+  // non-httpOnly cookie so the widget can merge it into innovayse_accounts localStorage.
+  // This seeds the "switch account" list on panel.local without requiring the user to
+  // visit app.local first. Using /connect/userinfo because JWT access_token has no email claim.
+  try {
+    const ssoUrl = (config.ssoUrl as string) || 'http://innovayse-sso-sso-api-1:8080'
+    const userinfo = await $fetch<Record<string, unknown>>(`${ssoUrl}/connect/userinfo`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    })
+    const sub = (userinfo.sub as string) || ''
+    const email = (userinfo.email as string) || sub
+    const firstName = (userinfo.given_name as string) || (userinfo.name as string)?.split(' ')[0] || ''
+    const lastName = (userinfo.family_name as string) || (userinfo.name as string)?.split(' ').slice(1).join(' ') || ''
+    if (email) {
+      setCookie(event, 'inno_pending_account', JSON.stringify({ ssoSub: sub, email, firstName, lastName }), {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60,
+        path: '/',
+      })
+    }
+  } catch { /* non-critical */ }
+
   // If came from silent SSO on a public page — return there (now logged in)
   deleteCookie(event, 'sso_silent_tried', { path: '/' })
   const silentReturn = getCookie(event, 'sso_silent_return')
   deleteCookie(event, 'sso_silent_return', { path: '/' })
 
-  return sendRedirect(event, silentReturn || '/client/dashboard', 302)
+  // post_login_redirect set by authorize.get.ts — return to the page user was on
+  // (e.g. "Add another account" should bring back to current page, not dashboard)
+  const postLoginRedirect = getCookie(event, 'post_login_redirect')
+  deleteCookie(event, 'post_login_redirect', { path: '/' })
+
+  return sendRedirect(event, silentReturn || postLoginRedirect || '/client/dashboard', 302)
 })

--- a/client/server/api/portal/auth/sso/profile.get.ts
+++ b/client/server/api/portal/auth/sso/profile.get.ts
@@ -1,13 +1,38 @@
 /**
  * GET /api/portal/auth/sso/profile
  * Proxies to SSO GET /api/account/profile and returns user data.
+ * Appends panel.local-specific menuItems so the widget can render
+ * quick-links (Dashboard, Services, Domains, Invoices, Support) inside
+ * the account popup under "Manage your Innovayse Account".
  */
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const accessToken = getCookie(event, 'auth_token')
   if (!accessToken) throw createError({ statusCode: 401 })
 
-  return $fetch<Record<string, unknown>>(`${config.ssoUrl}/api/account/profile`, {
+  const profile = await $fetch<Record<string, unknown>>(`${config.ssoUrl}/api/account/profile`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   })
+
+  // Extract ssoSub from JWT for account-switching (widget needs it to call /api/portal/auth/sso/switch)
+  let ssoSub = (profile.sub as string | undefined) || ''
+  if (!ssoSub) {
+    try {
+      const payload = accessToken.split('.')[1] ?? ''
+      const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+      ssoSub = (decoded.sub as string | undefined) || ''
+    } catch { /* ignore */ }
+  }
+
+  return {
+    ...profile,
+    ssoSub,
+    menuItems: [
+      { label: 'Dashboard',   url: '/client/dashboard', icon: 'dashboard' },
+      { label: 'My Services', url: '/client/services',  icon: 'services'  },
+      { label: 'My Domains',  url: '/client/domains',   icon: 'domains'   },
+      { label: 'Invoices',    url: '/client/invoices',  icon: 'invoices'  },
+      { label: 'Support',     url: '/client/tickets',   icon: 'support'   },
+    ],
+  }
 })

--- a/client/server/api/portal/auth/sso/switch.get.ts
+++ b/client/server/api/portal/auth/sso/switch.get.ts
@@ -1,0 +1,68 @@
+import { randomBytes, createHash } from 'node:crypto'
+
+/**
+ * GET /api/portal/auth/sso/switch?sub=XXX&redirect=/some/path
+ *
+ * Switches the active SSO session to a remembered account.
+ * Generates a PKCE pair and redirects to accounts.local/switch-init
+ * which auto-submits to the SSO switch endpoint, then comes back
+ * via the normal OIDC callback with a new auth_token.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const query = getQuery(event)
+  const sub = query.sub as string | undefined
+  const redirectTo = (query.redirect as string | undefined) || '/client'
+
+  if (!sub) {
+    return sendRedirect(event, '/api/portal/auth/sso/authorize', 302)
+  }
+
+  // Generate PKCE
+  const codeVerifier = randomBytes(32).toString('base64url')
+  const codeChallenge = createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url')
+
+  setCookie(event, 'pkce_verifier', codeVerifier, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 5,
+    path: '/',
+  })
+
+  const state = randomBytes(16).toString('hex')
+  setCookie(event, 'oauth_state', state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 5,
+    path: '/',
+  })
+
+  setCookie(event, 'post_login_redirect', redirectTo, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 5,
+    path: '/',
+  })
+
+  const redirectUri = config.ssoCallbackUrl
+  const oidcParams = new URLSearchParams({
+    client_id: config.ssoClientId,
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    scope: 'openid profile email offline_access',
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    state,
+  })
+  const oidcReturnUrl = `/connect/authorize?${oidcParams}`
+
+  // Redirect to accounts.local/switch-init — runs same-origin so sso_remembered cookie is sent
+  const ssoPublicUrl = (config.public.ssoPublicUrl as string) || 'http://accounts.local'
+  const switchInitUrl = `${ssoPublicUrl}/switch-init?sub=${encodeURIComponent(sub)}&returnUrl=${encodeURIComponent(oidcReturnUrl)}`
+  return sendRedirect(event, switchInitUrl, 302)
+})

--- a/client/server/utils/api.ts
+++ b/client/server/utils/api.ts
@@ -236,4 +236,5 @@ export function clearAllAuthCookies(event: H3Event): void {
   deleteCookie(event, 'auth_token', { path: '/' })
   deleteCookie(event, 'refresh_token', { path: '/' })
   deleteCookie(event, 'authed', { path: '/' })
+  deleteCookie(event, 'inno_pending_account', { path: '/' })
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       Cors__AllowedOrigins__0: http://localhost:3001
       Cors__AllowedOrigins__1: http://localhost:5174
       Cors__AllowedOrigins__2: http://panel.local
+      Cors__AllowedOrigins__3: https://stage-panel.innovayse.com
       Smtp__Host: mailhog
       Smtp__Port: 1025
       Smtp__Username: ""
@@ -90,6 +91,7 @@ services:
       Sso__Authority: http://innovayse-sso-sso-api-1:8080
       Sso__ClientId: hostpanel
       Auth__Mode: ${AUTH_MODE:-sso}
+      BackchannelLogout__Key: ${HOSTPANEL_BACKCHANNEL_LOGOUT_KEY:-dev-hostpanel-backchannel-key}
     depends_on:
       postgres:
         condition: service_healthy
@@ -122,7 +124,7 @@ services:
       # between them, randomly routing requests to the wrong app's backend.
       API_URL: http://hostpanel-api-1:5148
       NUXT_PUBLIC_BASE_URL: http://panel.local
-      NUXT_PUBLIC_WIDGET_URL: http://app.local
+      NUXT_PUBLIC_MAIN_URL: http://app.local
       SSO_URL: http://innovayse-sso-sso-api-1:8080
       SSO_PUBLIC_URL: http://accounts.local
       NUXT_PUBLIC_TASKS_URL: http://tasks.local
@@ -137,6 +139,7 @@ services:
       SMTP_HOST: mailhog
       SMTP_PORT: 1025
       AUTH_MODE: ${AUTH_MODE:-sso}
+      NUXT_MAIN_API_URL: http://innovayse-main-client-1:3000
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"
     depends_on:
@@ -168,6 +171,9 @@ services:
       CHOKIDAR_USEPOLLING: "true"
     depends_on:
       - api
+    networks:
+      - default
+      - innovayse_network
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

Integrates the Innovayse header widget (AppLauncher + Account popup) into the
panel.local client area, adds a full SSO switch-account flow, and fixes several
auth and UX issues (mobile header, logout, cookie cleanup).

## Changes

### Widget integration
- Add `#inno-launcher-mount` and `#inno-account-mount` to client layout
- Unified mobile/desktop header — single mount point per widget, no duplicate IDs
- Widget reinit via `onMounted` polling + `onUpdated` guard (handles Vue re-renders wiping mount points)
- Hide profile quick-links (menuItems) on `/client/*` — sidebar already covers them

### SSO / Auth
- Add `sso/switch.get.ts` — switch-account endpoint with full PKCE flow, redirects to `accounts.local/switch-init`
- Add `post_login_redirect` cookie in `authorize.get.ts` (extracted from Referer) so users return to their page after SSO login, not always to dashboard
- Add `inno_pending_account` cookie in `callback.get.ts` — fetches real user info from `/connect/userinfo` (JWT has no email claim) and passes to widget for localStorage seeding
- Add `ssoSub` + `menuItems` to `profile.get.ts` response for widget account switching and quick-links
- Fix `handleLogout`: SSO mode now navigates browser to `accounts.local/connect/endsession` instead of server-side fetch (SSO session was never actually ended before)
- Fix `clearAllAuthCookies`: also clears `inno_pending_account` on logout
- Fix cookie `secure` flag in `switch.get.ts`: use `NODE_ENV === 'production'` consistently
- Add backchannel logout delegation to `app.local/logout-redirect` from `logout.post.ts`

### Mobile UX
- ThemeToggle and LanguageSwitcher now visible on mobile
- Account popup accessible on mobile (avatar + switch accounts)
- Account panel responsive width on small screens via CSS override

### Infrastructure
- Add `NUXT_MAIN_API_URL` env var to `docker-compose.yml` and `nuxt.config.ts` for backchannel logout
- Change widget script tag from `defer` to `async`

## Checklist

- [ ] Code follows the style rules (`rules/` folder)
- [ ] `dotnet format` run (backend changes)
- [ ] XML docs added to all new C# members
- [ ] JSDoc added to all new exported TypeScript/Vue functions
- [ ] No hardcoded secrets or credentials
- [ ] Tested locally
