### PR TITLE
feat(auth): support dual authentication — local JWT for admin panel, SSO for client panel

### DIFF
--- a/backend/src/Innovayse.API/Auth/JwtTokenService.cs
+++ b/backend/src/Innovayse.API/Auth/JwtTokenService.cs
@@ -10,7 +10,7 @@ using Microsoft.IdentityModel.Tokens;
 public sealed class JwtTokenService(IConfiguration config)
 {
     /// <summary>Generates a short-lived (15 min) access token for the given user.</summary>
-    public string GenerateAccessToken(string userId, string email, string? firstName, string? lastName, IList<string> roles)
+    public string GenerateAccessToken(string userId, string email, string? firstName, string? lastName, IList<string> roles, bool emailVerified = true)
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Jwt:Secret"]!));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
@@ -19,6 +19,7 @@ public sealed class JwtTokenService(IConfiguration config)
         {
             new("sub", userId),
             new("email", email),
+            new("email_verified", emailVerified ? "true" : "false"),
         };
         if (!string.IsNullOrEmpty(firstName))
             claims.Add(new("given_name", firstName));

--- a/backend/src/Innovayse.API/Auth/LocalAuthController.cs
+++ b/backend/src/Innovayse.API/Auth/LocalAuthController.cs
@@ -6,8 +6,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 /// <summary>
-/// Local authentication endpoints — only active when Auth:Mode=local.
-/// When Auth:Mode=sso, all endpoints return 404.
+/// Local authentication endpoints.
+/// Login/2FA are always active (needed by admin panel).
+/// Registration and password flows are only active when Auth:Mode=local.
 /// </summary>
 [ApiController]
 [Route("api/auth")]
@@ -21,12 +22,12 @@ public sealed class LocalAuthController(
     /// <summary>
     /// Authenticates a user with email and password.
     /// Returns an access token, or a pending token if 2FA is required.
+    /// Always active — the admin panel uses local auth regardless of Auth:Mode.
     /// </summary>
     [HttpPost("login")]
     [AllowAnonymous]
     public async Task<IActionResult> LoginAsync([FromBody] LoginRequest request, CancellationToken ct)
     {
-        if (!IsLocalMode) return NotFound();
 
         var user = await userService.FindByEmailAndPasswordAsync(request.Email, request.Password, ct);
         if (user is null)
@@ -44,10 +45,10 @@ public sealed class LocalAuthController(
 
         await userService.UpdateLastLoginAsync(user.Value.Id, ct);
         var roles = await userService.GetRolesAsync(user.Value.Id, ct);
-        var found = await userService.FindByIdAsync(user.Value.Id, ct);
+        var emailConfirmed = await userService.IsEmailConfirmedAsync(user.Value.Id, ct);
 
         var accessToken = tokenService.GenerateAccessToken(
-            user.Value.Id, user.Value.Email, null, null, roles);
+            user.Value.Id, user.Value.Email, null, null, roles, emailConfirmed);
 
         return Ok(new { accessToken, expiresIn = 900 });
     }
@@ -60,7 +61,6 @@ public sealed class LocalAuthController(
     [AllowAnonymous]
     public async Task<IActionResult> TwoFactorLoginAsync([FromBody] TwoFactorLoginRequest request, CancellationToken ct)
     {
-        if (!IsLocalMode) return NotFound();
 
         // Decode pending token
         string userId;
@@ -165,7 +165,6 @@ public sealed class LocalAuthController(
     [AllowAnonymous]
     public IActionResult RefreshAsync()
     {
-        if (!IsLocalMode) return NotFound();
         // Refresh token handling would need a token store — out of scope for now
         // The BFF sets short-lived access tokens; the user re-logs when expired
         return Unauthorized(new { error = "Token expired. Please log in again." });

--- a/backend/src/Innovayse.API/Program.cs
+++ b/backend/src/Innovayse.API/Program.cs
@@ -46,11 +46,15 @@ try
 
     var authMode = builder.Configuration["Auth:Mode"] ?? "sso";
 
+    // JwtTokenService is always registered — admin panel uses local auth regardless of mode
+    builder.Services.AddSingleton<Innovayse.API.Auth.JwtTokenService>();
+
+    var jwtSecret = builder.Configuration["Jwt:Secret"]
+        ?? "change-this-to-a-32-char-min-secret-key-here";
+
     if (authMode == "local")
     {
-        // Local JWT authentication — tokens issued by this server
-        var jwtSecret = builder.Configuration["Jwt:Secret"]
-            ?? throw new InvalidOperationException("Jwt:Secret is required when Auth:Mode=local");
+        // Local-only mode
         if (jwtSecret.Length < 32)
             throw new InvalidOperationException("Jwt:Secret must be at least 32 characters");
 
@@ -69,12 +73,12 @@ try
                     NameClaimType = "sub",
                 };
             });
-
-        builder.Services.AddSingleton<Innovayse.API.Auth.JwtTokenService>();
     }
     else
     {
-        // SSO Authentication — validate JWTs issued by Innovayse SSO (OpenIddict)
+        // SSO mode with local JWT fallback — admin panel uses local tokens,
+        // client panel uses SSO tokens. Both are accepted.
+        var localJwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "innovayse-api";
         builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(opts =>
             {
@@ -87,6 +91,23 @@ try
                     RoleClaimType = System.Security.Claims.ClaimTypes.Role,
                     NameClaimType = "sub",
                     ValidateAudience = false,
+                };
+                // If the JWT was issued by our local server, forward to LocalJwt scheme
+                opts.ForwardDefaultSelector = context =>
+                {
+                    var auth = context.Request.Headers.Authorization.FirstOrDefault();
+                    if (auth?.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) == true)
+                    {
+                        var token = auth["Bearer ".Length..];
+                        try
+                        {
+                            var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+                            var jwt = handler.ReadJwtToken(token);
+                            if (jwt.Issuer == localJwtIssuer) return "LocalJwt";
+                        }
+                        catch { /* not a valid JWT — let default scheme handle */ }
+                    }
+                    return null; // use default (SSO) scheme
                 };
                 opts.Events = new JwtBearerEvents
                 {
@@ -115,13 +136,45 @@ try
                         }
                     },
                 };
+            })
+            .AddJwtBearer("LocalJwt", opts =>
+            {
+                opts.RequireHttpsMetadata = false;
+                opts.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(
+                        System.Text.Encoding.UTF8.GetBytes(jwtSecret)),
+                    ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? "innovayse-api",
+                    ValidAudience = builder.Configuration["Jwt:Audience"] ?? "innovayse-clients",
+                    RoleClaimType = System.Security.Claims.ClaimTypes.Role,
+                    NameClaimType = "sub",
+                };
             });
     }
 
     builder.Services.AddAuthorization(opts =>
     {
-        opts.AddPolicy("AdminOnly", p => p.RequireRole(Roles.Admin));
-        opts.AddPolicy("ResellerOrAdmin", p => p.RequireRole(Roles.Admin, Roles.Reseller));
+        if (authMode != "local")
+        {
+            // Accept tokens from either SSO or local JWT scheme
+            opts.DefaultPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder(
+                JwtBearerDefaults.AuthenticationScheme, "LocalJwt")
+                .RequireAuthenticatedUser()
+                .Build();
+        }
+        opts.AddPolicy("AdminOnly", p =>
+        {
+            if (authMode != "local")
+                p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "LocalJwt");
+            p.RequireRole(Roles.Admin);
+        });
+        opts.AddPolicy("ResellerOrAdmin", p =>
+        {
+            if (authMode != "local")
+                p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "LocalJwt");
+            p.RequireRole(Roles.Admin, Roles.Reseller);
+        });
     });
 
     // MVC + OpenAPI


### PR DESCRIPTION
## Summary

Enable both local JWT and SSO authentication to coexist in the same API instance, so the admin panel (`localhost:5174`, internal, local auth) and the client panel (`localhost:3001`, customer-facing, SSO) can both function simultaneously without switching `Auth:Mode`.

### Problem

The API previously operated in either `Auth:Mode=local` or `Auth:Mode=sso`, but never both. When configured for SSO (required for the client panel), the admin panel could not function because:
1. `LocalAuthController` endpoints (`/api/auth/login`, `/api/auth/2fa-login`) returned 404
2. `JwtTokenService` was not registered in the DI container, causing 400 errors
3. Locally-issued JWTs were rejected by the SSO token validator, causing 401 on all authenticated endpoints

### Architecture

In SSO mode, two JWT bearer schemes are now registered:
- **Default (`Bearer`)** — validates tokens against the SSO authority (OpenIddict). Used by the client panel.
- **LocalJwt** — validates tokens using the local HMAC signing key. Used by the admin panel.

A \`ForwardDefaultSelector\` on the default scheme inspects incoming tokens: if the JWT's \`iss\` (issuer) claim matches the local API issuer (\`innovayse-api\`), the request is transparently forwarded to the \`LocalJwt\` scheme. This means controllers don't need any changes — \`[Authorize]\` works with both token types automatically.

### Changed files

**\`Program.cs\`**
- Register \`JwtTokenService\` unconditionally (previously only in local mode)
- In SSO mode, add second \`LocalJwt\` JWT bearer scheme with the local signing key
- Add \`ForwardDefaultSelector\` that routes tokens by issuer claim
- Update \`DefaultPolicy\`, \`AdminOnly\`, and \`ResellerOrAdmin\` authorization policies to accept both schemes

**\`LocalAuthController.cs\`**
- Remove \`IsLocalMode\` guard from \`login\`, \`2fa-login\`, and \`refresh\` endpoints (admin panel needs these always)
- Keep guard on \`register\`, \`forgot-password\`, \`reset-password\`, \`confirm-email\` (user self-service only in local-only deployments)

**\`JwtTokenService.cs\`**
- Add \`emailVerified\` parameter to \`GenerateAccessToken\` and include \`email_verified\` claim in the JWT
- Pass actual \`IsEmailConfirmedAsync\` result from the database during login so the admin frontend's email verification check works with local tokens

### Test plan
- [ ] Start with \`Auth:Mode=sso\` (default) — verify admin panel login at \`localhost:5174\` works with \`admin@hostpanel.com\` / \`Admin123!\`
- [ ] After login, verify dashboard stats load (no 401 errors)
- [ ] Verify email verification modal does not appear (admin user has confirmed email)
- [ ] Verify client panel at \`localhost:3001\` still works with SSO login
- [ ] Test that \`/api/auth/register\` returns 404 in SSO mode (user registration disabled)
- [ ] Test 2FA login flow if admin has 2FA enabled