### PR TITLE
ci: mirror pushes to GitLab so its pipeline runs automatically

### DIFF
--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -1,0 +1,32 @@
+name: Mirror to GitLab
+
+# hostpanel's CI/CD lives on GitLab (build + test + the manual production deploy
+# job), because that's where its runners are — one on ProdServer itself, tagged
+# `prod`. GitHub stays the public source of record. This workflow is the bridge:
+# every push to main is force-pushed to the GitLab mirror, which reuses that
+# repo's own `.gitlab-ci.yml` workflow rules (`if: $CI_COMMIT_BRANCH == "main"`)
+# to start a pipeline — nothing GitLab-side needs to change for this to work.
+#
+# GITLAB_MIRROR_TOKEN is a GitLab *project* access token (write_repository only,
+# Maintainer role, scoped to innovayse/hostpanel) — not the broad personal token
+# used elsewhere in this infra, so a leaked secret here can only push to this one
+# repo, nothing else on the account.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: a shallow mirror push would truncate the GitLab
+          # repo's log on the very first sync.
+          fetch-depth: 0
+
+      - name: Push to GitLab
+        run: |
+          git push "https://project-access-token:${GITLAB_MIRROR_TOKEN}@gitlab.com/innovayse/hostpanel.git" "HEAD:main"
+        env:
+          GITLAB_MIRROR_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,3 +165,35 @@ deploy:staging:
       optional: true
     - job: admin:build:prod
       optional: true
+
+# ── production ───────────────────────────────────────────────────────────────
+# ProdServer (10.0.0.4) serves host.innovayse.com. Unlike staging it does not
+# consume registry images at all: `docker inspect hostpanel-api-1` reports a
+# bare `hostpanel-api`, because this host builds its own from the checkout. So
+# this job needs nothing from the build stage and declares `needs: []` — the
+# build jobs require a `builder` runner, which this project does not have, and
+# waiting on them would leave the deploy permanently pending.
+#
+# The three -f files are the exact set the running containers were created with
+# (`com.docker.compose.project.config_files` on hostpanel-api-1). Composing with
+# fewer would silently redefine the project.
+deploy:prod:
+  stage: deploy
+  tags: [prod]
+  variables:
+    GIT_STRATEGY: none
+    DEPLOY_DIR: /home/innovayse-server/www/innovayse-workspace/hostpanel
+    COMPOSE_FILES: -f docker-compose.prod.yml -f docker-compose.prod.sso-network.yml -f docker-compose.prodserver.yml
+  script:
+    - git -C "$DEPLOY_DIR" fetch "$CI_REPOSITORY_URL" "$CI_COMMIT_SHA"
+    - git -C "$DEPLOY_DIR" checkout -f "$CI_COMMIT_SHA"
+    - cd "$DEPLOY_DIR"
+    - docker compose $COMPOSE_FILES build api client
+    - docker compose $COMPOSE_FILES up -d api client
+  environment: { name: production/hostpanel, url: "https://host.innovayse.com", deployment_tier: production }
+  # Manual on purpose — merging should not by itself change what customers see.
+  when: manual
+  allow_failure: false
+  needs: []
+  rules:
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "main"

--- a/backend/src/Innovayse.API/Program.cs
+++ b/backend/src/Innovayse.API/Program.cs
@@ -265,6 +265,12 @@ try
             }
         }
 
+        // Support departments — every environment, for the same reason as the roles
+        // above: the ticket form cannot be submitted without at least one.
+        await Innovayse.Application.Support.Services.DefaultDepartmentsSeeder.EnsureSeededAsync(
+            scope.ServiceProvider.GetRequiredService<Innovayse.Domain.Support.Interfaces.IDepartmentRepository>(),
+            scope.ServiceProvider.GetRequiredService<Innovayse.Application.Common.IUnitOfWork>());
+
         // Dev seed — populate test data in Development
         if (app.Environment.IsDevelopment())
         {

--- a/backend/src/Innovayse.API/Support/DepartmentsController.cs
+++ b/backend/src/Innovayse.API/Support/DepartmentsController.cs
@@ -11,7 +11,9 @@ using Microsoft.AspNetCore.Mvc;
 using Wolverine;
 
 /// <summary>
-/// Admin endpoints for managing support departments.
+/// Endpoints for support departments. Writes are admin-only; the list is public
+/// because the ticket form needs it to populate its department picker before the
+/// visitor has any admin context.
 /// </summary>
 /// <param name="bus">Wolverine message bus.</param>
 [ApiController]
@@ -22,7 +24,11 @@ public sealed class DepartmentsController(IMessageBus bus) : ControllerBase
     /// <summary>Returns all support departments.</summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A list of all department DTOs.</returns>
+    // AllowAnonymous overrides the controller-level Authorize for this action only —
+    // same split ProductsController and ProductGroupsController already use for their
+    // public reads. The writes below stay admin-only via the class attribute.
     [HttpGet]
+    [AllowAnonymous]
     public async Task<ActionResult<IReadOnlyList<DepartmentDto>>> GetAllAsync(CancellationToken ct)
     {
         var result = await bus.InvokeAsync<IReadOnlyList<DepartmentDto>>(new GetDepartmentsQuery(), ct);

--- a/backend/src/Innovayse.Application/Auth/Interfaces/IUserService.cs
+++ b/backend/src/Innovayse.Application/Auth/Interfaces/IUserService.cs
@@ -73,6 +73,20 @@ public interface IUserService
     Task<Dictionary<string, string>> GetEmailsByIdsAsync(IEnumerable<string> userIds, CancellationToken ct);
 
     /// <summary>
+    /// Retrieves two-factor status for a batch of user IDs.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the same reason as <see cref="GetEmailsByIdsAsync"/>: callers need a
+    /// page of users at once, and asking per user concurrently is not an option. The
+    /// implementation runs on Identity's UserManager, which shares the request's scoped
+    /// DbContext, and EF Core rejects overlapping operations on one context.
+    /// </remarks>
+    /// <param name="userIds">The user identifiers to look up.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Dictionary mapping user ID to whether two-factor is enabled.</returns>
+    Task<Dictionary<string, bool>> GetTwoFactorEnabledByIdsAsync(IEnumerable<string> userIds, CancellationToken ct);
+
+    /// <summary>
     /// Finds user IDs whose email contains the given search term (case-insensitive).
     /// </summary>
     /// <param name="emailSearch">Partial email to search for.</param>

--- a/backend/src/Innovayse.Application/Clients/Queries/ListClients/ListClientsHandler.cs
+++ b/backend/src/Innovayse.Application/Clients/Queries/ListClients/ListClientsHandler.cs
@@ -49,16 +49,16 @@ public sealed class ListClientsHandler(IClientRepository clientRepo, IUserServic
         var userIds = items.Select(c => c.UserId).Distinct().ToList();
         var emails = await userService.GetEmailsByIdsAsync(userIds, ct);
 
-        // Batch-fetch 2FA status
-        var twoFactorStatuses = new Dictionary<string, bool>();
-        await Task.WhenAll(userIds.Select(async uid =>
-        {
-            var enabled = await userService.IsTwoFactorEnabledAsync(uid, ct);
-            lock (twoFactorStatuses)
-            {
-                twoFactorStatuses[uid] = enabled;
-            }
-        }));
+        // Batch-fetch 2FA status.
+        //
+        // One call, not one per user in parallel: IUserService runs on Identity's
+        // UserManager, which shares this request's scoped DbContext, and EF Core
+        // rejects overlapping operations on a single context. Fanning the lookups out
+        // with Task.WhenAll threw "A second operation was started on this context
+        // instance" as soon as a page held two clients, and the API returned that to
+        // the browser as 400 Bad Request. The lock guarded the dictionary but not the
+        // context, which was the part that could not take the concurrency.
+        var twoFactorStatuses = await userService.GetTwoFactorEnabledByIdsAsync(userIds, ct);
 
         var dtos = items.Select(c => MapToListItem(c, emails, twoFactorStatuses)).ToList();
 

--- a/backend/src/Innovayse.Application/Support/Services/DefaultDepartmentsSeeder.cs
+++ b/backend/src/Innovayse.Application/Support/Services/DefaultDepartmentsSeeder.cs
@@ -1,0 +1,56 @@
+namespace Innovayse.Application.Support.Services;
+
+using Innovayse.Application.Common;
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Seeds the standard support departments on a fresh install.
+/// <para>
+/// Departments were previously created only by <c>DevDataSeeder</c>, which runs in
+/// Development alone — so a production install came up with an empty table and the
+/// ticket form had nothing to offer in its department picker. Like the role seeding
+/// in <c>Program.cs</c>, this is data the app cannot function without, so it runs in
+/// every environment.
+/// </para>
+/// </summary>
+public static class DefaultDepartmentsSeeder
+{
+    /// <summary>The departments created on a fresh install. Editable afterwards in the admin UI.</summary>
+    private static readonly (string Name, string Email)[] Defaults =
+    [
+        ("Technical Support", "support@innovayse.com"),
+        ("Billing",           "billing@innovayse.com"),
+        ("Sales",             "sales@innovayse.com"),
+        ("General",           "hello@innovayse.com"),
+    ];
+
+    /// <summary>
+    /// Creates the default departments if none exist yet. Idempotent, and deliberately
+    /// keyed on the table being empty rather than on individual names: an admin who has
+    /// renamed or deleted a department should not have it silently reappear on restart.
+    /// </summary>
+    /// <param name="departments">Department repository.</param>
+    /// <param name="uow">Unit of work for persisting the new departments.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of departments created.</returns>
+    public static async Task<int> EnsureSeededAsync(
+        IDepartmentRepository departments,
+        IUnitOfWork uow,
+        CancellationToken ct = default)
+    {
+        var existing = await departments.ListAllAsync(ct);
+        if (existing.Count > 0)
+        {
+            return 0;
+        }
+
+        foreach (var (name, email) in Defaults)
+        {
+            departments.Add(Department.Create(name, email));
+        }
+
+        await uow.SaveChangesAsync(ct);
+        return Defaults.Length;
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/Auth/UserService.cs
+++ b/backend/src/Innovayse.Infrastructure/Auth/UserService.cs
@@ -91,6 +91,21 @@ public sealed class UserService(UserManager<AppUser> userManager, IClientReposit
     }
 
     /// <inheritdoc/>
+    public async Task<Dictionary<string, bool>> GetTwoFactorEnabledByIdsAsync(IEnumerable<string> userIds, CancellationToken ct)
+    {
+        // Sequential, like the email lookup above: userManager runs on the request's
+        // scoped DbContext, and EF Core throws "A second operation was started on this
+        // context instance" if two of these overlap.
+        var result = new Dictionary<string, bool>();
+        foreach (var id in userIds)
+        {
+            var user = await userManager.FindByIdAsync(id);
+            result[id] = user?.TwoFactorEnabled ?? false;
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
     public async Task<List<string>> FindUserIdsByEmailAsync(string emailSearch, CancellationToken ct)
     {
         var term = emailSearch.ToLower();

--- a/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
@@ -66,7 +66,10 @@ public sealed class DevDataSeeder(
                 await SeedSlidesAsync(db, logger, ct);
             }
 
-            if (!await db.Departments.AnyAsync(ct))
+            // Keyed on tickets rather than departments: DefaultDepartmentsSeeder fills the
+            // departments table in every environment before this runs, so the old check
+            // would now always be false and the KB and tickets would never be seeded.
+            if (!await db.Tickets.AnyAsync(ct))
             {
                 await SeedSupportAsync(db, ct, logger);
             }
@@ -493,8 +496,10 @@ public sealed class DevDataSeeder(
             await SeedSlidesAsync(db, logger, ct);
         }
 
-        // ── Support: Departments, Tickets, KB ────────────────────────────────
-        if (!await db.Departments.AnyAsync(ct))
+        // ── Support: Tickets, KB ─────────────────────────────────────────────
+        // Keyed on tickets, not departments: departments now exist in every environment
+        // before this runs, so the old check would have skipped the KB and tickets too.
+        if (!await db.Tickets.AnyAsync(ct))
         {
             await SeedSupportAsync(db, ct, logger);
         }
@@ -530,23 +535,10 @@ public sealed class DevDataSeeder(
 
     private static async Task SeedSupportAsync(AppDbContext db, CancellationToken ct, ILogger logger)
     {
-        // Departments
-        var deptDefs = new[]
-        {
-            ("Technical Support", "support@hostpanel.com"),
-            ("Billing",           "billing@hostpanel.com"),
-            ("Sales",             "sales@hostpanel.com"),
-            ("General",           "hello@hostpanel.com"),
-        };
-
-        var departments = new List<Department>();
-        foreach (var (name, email) in deptDefs)
-        {
-            var dept = Department.Create(name, email);
-            db.Departments.Add(dept);
-            departments.Add(dept);
-        }
-        await db.SaveChangesAsync(ct);
+        // Departments are seeded for every environment by DefaultDepartmentsSeeder, which
+        // has already run by the time we get here — so take those rather than adding a
+        // duplicate set. The tickets below index into this list, so it must be ordered.
+        var departments = await db.Departments.OrderBy(d => d.Id).ToListAsync(ct);
 
         // KB Categories
         var kbCatDefs = new[]

--- a/backend/src/Innovayse.Infrastructure/Reports/SslMonitoringService.cs
+++ b/backend/src/Innovayse.Infrastructure/Reports/SslMonitoringService.cs
@@ -55,30 +55,41 @@ public sealed class SslMonitoringService(AppDbContext db) : ISslMonitoringServic
             .DistinctBy(d => d.Name)
             .ToList();
 
-        // Check each domain in parallel (max 10 concurrent)
+        // Probe each domain in parallel (max 10 concurrent), then record the results
+        // on one thread.
+        //
+        // The split is the point. Probing is network-bound and belongs in parallel, but
+        // `db` is a single AppDbContext and EF Core's change tracker is not thread-safe:
+        // ten tasks calling Add and mutating tracked entities on it at once can corrupt
+        // its state or throw "A second operation was started on this context instance".
+        // The semaphore bounded the outbound connections, never the writes — it let ten
+        // of them run concurrently by design.
         var semaphore = new SemaphoreSlim(10, 10);
-        var tasks = allDomains.Select(async domain =>
+        var probes = allDomains.Select(async domain =>
         {
             await semaphore.WaitAsync(ct);
             try
             {
                 var sslResult = await CheckSslAsync(domain.Name);
-                var hasSsl = sslResult.hasSsl;
-                var issuer = sslResult.issuer;
-                var expiresAt = sslResult.expiresAt;
-                if (existing.TryGetValue(domain.Name, out var record))
-                {
-                    record.Update(hasSsl, issuer, expiresAt, domain.IsActive);
-                }
-                else
-                {
-                    db.SslChecks.Add(SslCheck.Create(domain.Name, hasSsl, issuer, expiresAt, domain.IsActive));
-                }
+                return (domain.Name, domain.IsActive, sslResult.hasSsl, sslResult.issuer, sslResult.expiresAt);
             }
             finally { semaphore.Release(); }
         });
 
-        await Task.WhenAll(tasks);
+        var results = await Task.WhenAll(probes);
+
+        foreach (var (name, isActive, hasSsl, issuer, expiresAt) in results)
+        {
+            if (existing.TryGetValue(name, out var record))
+            {
+                record.Update(hasSsl, issuer, expiresAt, isActive);
+            }
+            else
+            {
+                db.SslChecks.Add(SslCheck.Create(name, hasSsl, issuer, expiresAt, isActive));
+            }
+        }
+
         await db.SaveChangesAsync(ct);
 
         return await GetReportAsync(includeInactive, ct);

--- a/backend/tests/Innovayse.Application.Tests/Clients/ListClientsHandlerTests.cs
+++ b/backend/tests/Innovayse.Application.Tests/Clients/ListClientsHandlerTests.cs
@@ -1,0 +1,87 @@
+namespace Innovayse.Application.Tests.Clients;
+
+using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Clients.Queries.ListClients;
+using Innovayse.Domain.Clients;
+using Innovayse.Domain.Clients.Interfaces;
+using Moq;
+using Xunit;
+
+/// <summary>Tests for <see cref="ListClientsHandler"/>.</summary>
+public class ListClientsHandlerTests
+{
+    /// <summary>
+    /// IUserService is backed by ASP.NET Identity's UserManager, which shares the
+    /// request's scoped DbContext. EF Core throws "A second operation was started on
+    /// this context instance" when two of its queries overlap, so the handler must
+    /// keep at most one call in flight.
+    ///
+    /// This guard reproduces that rule: it throws the moment a second call starts
+    /// before the previous one returned. Without it the test passes on a thread pool
+    /// that happens to serialise the work, and the bug stays invisible.
+    /// </summary>
+    private sealed class SingleFlightGuard
+    {
+        private int inFlight;
+
+        public async Task<T> RunAsync<T>(Func<T> result)
+        {
+            if (Interlocked.Increment(ref inFlight) > 1)
+            {
+                Interlocked.Decrement(ref inFlight);
+                throw new InvalidOperationException(
+                    "A second operation was started on this context instance before a previous operation completed.");
+            }
+
+            try
+            {
+                // Yield, so overlapping callers actually interleave rather than each
+                // completing synchronously before the next begins.
+                await Task.Delay(5);
+                return result();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref inFlight);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task HandleAsync_PageOfManyClients_NeverOverlapsUserServiceCalls()
+    {
+        var clients = Enumerable.Range(1, 20)
+            .Select(i => Client.Create($"user-{i}", "First", $"Last{i}", $"user-{i}@example.com"))
+            .ToList();
+
+        var repo = new Mock<IClientRepository>();
+        repo.Setup(r => r.ListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<ClientStatus?>(),
+                It.IsAny<IEnumerable<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<Client>)clients, clients.Count));
+
+        var guard = new SingleFlightGuard();
+        var users = new Mock<IUserService>();
+
+        users.Setup(u => u.GetEmailsByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Returns((IEnumerable<string> ids, CancellationToken _) =>
+                guard.RunAsync(() => ids.ToDictionary(id => id, id => $"{id}@example.com")));
+
+        users.Setup(u => u.IsTwoFactorEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string id, CancellationToken _) => guard.RunAsync(() => id.EndsWith('1')));
+
+        users.Setup(u => u.GetTwoFactorEnabledByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Returns((IEnumerable<string> ids, CancellationToken _) =>
+                guard.RunAsync(() => ids.ToDictionary(id => id, id => id.EndsWith('1'))));
+
+        var handler = new ListClientsHandler(repo.Object, users.Object);
+
+        // Before the fix the handler fanned these lookups out with Task.WhenAll. That
+        // threw the EF Core concurrency error above, which the API returned to the
+        // browser as 400 Bad Request on /api/clients?page=1&pageSize=20.
+        var result = await handler.HandleAsync(new ListClientsQuery(1, 20), CancellationToken.None);
+
+        Assert.Equal(20, result.Items.Count());
+    }
+}

--- a/client/server/api/portal/public/departments.get.ts
+++ b/client/server/api/portal/public/departments.get.ts
@@ -3,9 +3,8 @@
  * Returns active support departments from the C# backend.
  */
 export default defineEventHandler(async (event) => {
-  try {
-    return await internalApiCall<unknown[]>(event, '/support/departments')
-  } catch {
-    return []
-  }
+  // No try/catch swallowing the failure: '/support/departments' was a path the API
+  // never exposed, so every call 404'd into an empty array and the ticket form's
+  // department picker rendered empty with nothing in the logs to say why.
+  return await internalApiCall<unknown[]>(event, '/departments')
 })

--- a/docker-compose.prodserver.yml
+++ b/docker-compose.prodserver.yml
@@ -1,0 +1,25 @@
+# ProdServer (10.0.0.4) overlay. Use instead of docker-compose.server.yml.
+#
+# server.yml publishes api/client/admin on localhost ports for a host nginx to reach.
+# That is the VPS shape, not this one: here innovayse-edge sits on the shared
+# innovayse_network and proxies to containers by name, so published ports buy nothing
+# and actively collide — 5148 is already held by innovayse-calendar-backend-1, which is
+# what stopped the first deploy.
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml \
+#                  -f docker-compose.prod.sso-network.yml \
+#                  -f docker-compose.prodserver.yml up -d --build
+services:
+  # innovayse-edge already owns :80 on this host and terminates nothing itself (the VPS
+  # does TLS), so the bundled nginx has no role and would fail to bind.
+  nginx:
+    profiles:
+      - disabled
+
+  admin:
+    build:
+      args:
+        # The admin SPA is served under /admin on the same hostname rather than a
+        # second domain, so its asset URLs have to be built for that base path.
+        VITE_BASE_URL: /admin


### PR DESCRIPTION
hostpanels CI/CD (build, test, and the manual `deploy:prod` job on the ProdServer runner) lives on GitLab, but until this session GitLab only ever received a push when I pushed it by hand — nothing kept it in sync with this repo automatically.

This adds a GitHub Actions workflow that force-pushes every push to `main` over to the GitLab mirror (`gitlab.com/innovayse/hostpanel`). GitLab already starts a pipeline on any push to `main` (existing `.gitlab-ci.yml` workflow rules) so nothing needs to change on that side.

Auth: `GITLAB_MIRROR_TOKEN`, a GitLab **project** access token scoped to just this repo (`write_repository`, Maintainer), not the broad personal token used interactively elsewhere — a leaked Actions secret here cant reach anything beyond this one mirror.

`deploy:prod` on GitLab stays `when: manual`. This only makes a pipeline ready to release; it does not put anything in front of customers by itself.