### PR TITLE
fix(migration): map WHMCS hosting products to SharedHosting, not Other

### DIFF
--- a/backend/src/Innovayse.Application/Migration/Services/MigrationPullWorker.cs
+++ b/backend/src/Innovayse.Application/Migration/Services/MigrationPullWorker.cs
@@ -768,7 +768,7 @@ public sealed class MigrationPullWorker(
                         null,
                         null,
                         null,
-                        ProductType.Other,
+                        MapProductType(rec.Type),
                         rec.MonthlyPrice,
                         rec.AnnualPrice);
 
@@ -788,6 +788,20 @@ public sealed class MigrationPullWorker(
             await repo.SaveAsync(ct);
         }
     }
+
+    /// <summary>
+    /// Maps a WHMCS product `type` column value to the closest <see cref="ProductType"/>.
+    /// WHMCS's type is a provisioning-module category, not a marketing category, so this
+    /// only recognizes the one value with an unambiguous match; everything else — custom
+    /// SaaS products, "other", "server", "reselleraccount" — stays <see cref="ProductType.Other"/>
+    /// rather than guessing at Vps/Dedicated/Ssl/Domain from a string that doesn't carry that
+    /// information.
+    /// </summary>
+    private static ProductType MapProductType(string whmcsType) => whmcsType switch
+    {
+        "hostingaccount" => ProductType.SharedHosting,
+        _ => ProductType.Other,
+    };
 
     // ── Orders ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
`PullProductsAsync` hardcoded every migrated products `ProductType` to `Other` regardless of what WHMCS reported. Found while filling in real prices for host.innovayse.coms catalogue from WHMCS: the six Web Hosting plans came through indistinguishable from the unrelated SaaS products (SmartLearn, PropSystem, ShopKit, etc.) migrated into the same catalogue.

`MapProductType()` maps WHMCS`s `hostingaccount` type to `SharedHosting`; everything else stays `Other`. Deliberately not attempting to infer Vps/Dedicated/Ssl/Domain from the type string — WHMCSs `type` column is a provisioning-module category, not a marketing one, and guessing from it would misclassify as often as it helps.

The pricing half of this same investigation — a companion fix to the WHMCS-side migration plugin (its `products` action was reading a non-existent `pricing_monthly` column instead of joining `tblpricing`, so every migrated price came through as 0) — already shipped directly to the WHMCS install; that file lives outside this repo so there is nothing to PR for it here.

Build verified locally (0 errors, 0 warnings). The six existing Web Hosting products in prod were updated to `SharedHosting` directly, matching what this code will now produce for any future migration.