### PR TITLE
fix(auth): stop JWT issuance from silently disagreeing with validation

### DIFF
--- a/backend/src/Innovayse.API/Auth/JwtTokenService.cs
+++ b/backend/src/Innovayse.API/Auth/JwtTokenService.cs
@@ -9,10 +9,32 @@ using Microsoft.IdentityModel.Tokens;
 /// <summary>Issues local JWTs when Auth:Mode=local (no SSO dependency).</summary>
 public sealed class JwtTokenService(IConfiguration config)
 {
+    /// <summary>
+    /// Dev-only fallback signing secret, used when Jwt:Secret is unset. Program.cs applies
+    /// this same fallback for validating incoming tokens — shared here as the one place both
+    /// sides read from, so a token this service signs is never rejected by the validator that's
+    /// supposed to accept it (or, unset, throws instead of silently signing with two different
+    /// keys). Never set in a deployed environment; validated there via Program.cs's length check.
+    /// </summary>
+    public const string DevSecretFallback = "change-this-to-a-32-char-min-secret-key-here";
+
+    /// <summary>
+    /// Default issuer/audience, used whenever Jwt:Issuer / Jwt:Audience are unset. Unlike
+    /// <see cref="DevSecretFallback"/> these are fine to run with in any environment — they're
+    /// just identifier strings, not a secret — but they still have to be the exact values
+    /// Program.cs's token validators fall back to, or a token minted without either config key
+    /// set carries issuer/audience: null and gets rejected by validators expecting these
+    /// defaults, which is a 401 on every request with an otherwise-valid token.
+    /// </summary>
+    public const string DefaultIssuer = "innovayse-api";
+
+    /// <summary>See <see cref="DefaultIssuer"/>.</summary>
+    public const string DefaultAudience = "innovayse-clients";
+
     /// <summary>Generates a short-lived (15 min) access token for the given user.</summary>
     public string GenerateAccessToken(string userId, string email, string? firstName, string? lastName, IList<string> roles, bool emailVerified = true)
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Jwt:Secret"]!));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Jwt:Secret"] ?? DevSecretFallback));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var claims = new List<Claim>
@@ -29,8 +51,8 @@ public sealed class JwtTokenService(IConfiguration config)
             claims.Add(new(ClaimTypes.Role, role));
 
         var token = new JwtSecurityToken(
-            issuer: config["Jwt:Issuer"],
-            audience: config["Jwt:Audience"],
+            issuer: config["Jwt:Issuer"] ?? DefaultIssuer,
+            audience: config["Jwt:Audience"] ?? DefaultAudience,
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(15),
             signingCredentials: creds);

--- a/backend/src/Innovayse.API/ExceptionMiddleware.cs
+++ b/backend/src/Innovayse.API/ExceptionMiddleware.cs
@@ -8,7 +8,8 @@ using System.Text.Json;
 /// Prevents unhandled exceptions from propagating to the test host or client.
 /// </summary>
 /// <param name="next">The next middleware in the pipeline.</param>
-public sealed class ExceptionMiddleware(RequestDelegate next)
+/// <param name="logger">Logger for unhandled exceptions.</param>
+public sealed class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger)
 {
     /// <summary>Invokes the middleware.</summary>
     /// <param name="context">The current HTTP context.</param>
@@ -28,9 +29,15 @@ public sealed class ExceptionMiddleware(RequestDelegate next)
         }
         catch (Exception ex)
         {
+            // The response body deliberately never includes ex.Message — this is the last
+            // handler in the pipeline, so whatever reaches here hasn't been classified as a
+            // client-facing error by anything upstream, and echoing it back risks leaking
+            // internals (connection strings, stack frames) to the caller. This log line is
+            // the only place the real exception surfaces; previously it was discarded
+            // entirely (`_ = ex;`), which is how a JwtTokenService config bug went unnoticed
+            // through every 500 it caused.
+            logger.LogError(ex, "Unhandled exception");
             await WriteErrorAsync(context, HttpStatusCode.InternalServerError, "An unexpected error occurred.");
-            // Log the original message in non-production environments
-            _ = ex;
         }
     }
 

--- a/backend/src/Innovayse.API/Program.cs
+++ b/backend/src/Innovayse.API/Program.cs
@@ -50,7 +50,7 @@ try
     builder.Services.AddSingleton<Innovayse.API.Auth.JwtTokenService>();
 
     var jwtSecret = builder.Configuration["Jwt:Secret"]
-        ?? "change-this-to-a-32-char-min-secret-key-here";
+        ?? Innovayse.API.Auth.JwtTokenService.DevSecretFallback;
 
     if (authMode == "local")
     {
@@ -67,8 +67,8 @@ try
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKey = new SymmetricSecurityKey(
                         System.Text.Encoding.UTF8.GetBytes(jwtSecret)),
-                    ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? "innovayse-api",
-                    ValidAudience = builder.Configuration["Jwt:Audience"] ?? "innovayse-clients",
+                    ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? Innovayse.API.Auth.JwtTokenService.DefaultIssuer,
+                    ValidAudience = builder.Configuration["Jwt:Audience"] ?? Innovayse.API.Auth.JwtTokenService.DefaultAudience,
                     RoleClaimType = System.Security.Claims.ClaimTypes.Role,
                     NameClaimType = "sub",
                 };
@@ -78,7 +78,7 @@ try
     {
         // SSO mode with local JWT fallback — admin panel uses local tokens,
         // client panel uses SSO tokens. Both are accepted.
-        var localJwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "innovayse-api";
+        var localJwtIssuer = builder.Configuration["Jwt:Issuer"] ?? Innovayse.API.Auth.JwtTokenService.DefaultIssuer;
         builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(opts =>
             {
@@ -145,8 +145,8 @@ try
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKey = new SymmetricSecurityKey(
                         System.Text.Encoding.UTF8.GetBytes(jwtSecret)),
-                    ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? "innovayse-api",
-                    ValidAudience = builder.Configuration["Jwt:Audience"] ?? "innovayse-clients",
+                    ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? Innovayse.API.Auth.JwtTokenService.DefaultIssuer,
+                    ValidAudience = builder.Configuration["Jwt:Audience"] ?? Innovayse.API.Auth.JwtTokenService.DefaultAudience,
                     RoleClaimType = System.Security.Claims.ClaimTypes.Role,
                     NameClaimType = "sub",
                 };

--- a/backend/tests/Innovayse.Integration.Tests/IntegrationTestFactory.cs
+++ b/backend/tests/Innovayse.Integration.Tests/IntegrationTestFactory.cs
@@ -42,7 +42,13 @@ public sealed class IntegrationTestFactory : WebApplicationFactory<Program>, IAs
             // Override connection string to point at the test container
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ConnectionStrings:DefaultConnection"] = _postgres.GetConnectionString()
+                ["ConnectionStrings:DefaultConnection"] = _postgres.GetConnectionString(),
+                // Every test here creates its users through POST /api/auth/register — the only
+                // user-creation path exercised anywhere in this suite — but LocalAuthController
+                // 404s that action unless Auth:Mode=local (it's SSO by default everywhere else,
+                // per docker-compose.yml's AUTH_MODE:-sso). Without this, registration 404s and
+                // every test that depends on it — nearly all of them — fails outright.
+                ["Auth:Mode"] = "local"
             });
         });
 


### PR DESCRIPTION
`backend:test` failed on nearly every integration test that needed a login (29 of 41). Root cause, found by re-enabling exception logging (fixed here too) and reading the actual stack trace instead of guessing:

- `IntegrationTestFactory` never set `Auth:Mode=local`, so every tests only way of creating a user — `POST /api/auth/register` — 404d by design.
- `JwtTokenService` read `Jwt:Secret`/`Jwt:Issuer`/`Jwt:Audience` straight from `IConfiguration` with **no fallback**, while `Program.cs`s token *validators* fall back to a dev secret and `innovayse-api`/`innovayse-clients` when those keys are unset. Unset (as in Testing), the service signed tokens with a null issuer/audience and crashed on the null secret — producing a token its own validator was never going to accept even where it didnt crash first. Pulled all three fallbacks into named constants on `JwtTokenService`; `Program.cs`s four copies of the same literals now point at them, so both sides read from one place.

**12/41 → 19/41 passing.** Every `AsAdmin`/`AsClient`-role test that was failing purely on login now passes. The remaining 22 are unrelated, scattered pre-existing bugs across billing/domains/provisioning/tickets (e.g. a couple of tests expect `POST /api/auth/register` to return an `accessToken`; it only ever returns `{ userId }`) — each its own issue, not one shared root cause.

Also fixed in passing: `ExceptionMiddleware`s catch-all discarded the original exception (`_ = ex;`, never logged, despite a comment saying it should be) — this is literally what let today’s diagnosis happen once fixed, and the same silent-swallow would hide the next unrelated 500 exactly the same way.

Unit tests (Domain/Application/Infrastructure) unaffected, all green.