### PR TITLE
fix(portal): let the public site render for signed-out visitors

### DIFF
--- a/admin/src/modules/auth/useSso.ts
+++ b/admin/src/modules/auth/useSso.ts
@@ -32,9 +32,24 @@ function randomToken(byteLength: number): string {
   return base64UrlEncode(bytes)
 }
 
+/**
+ * Origin plus the app's base path, always with exactly one trailing slash.
+ *
+ * The base matters because the panel can be served under a path rather than its own
+ * subdomain (VITE_BASE_URL=/admin, as on host.innovayse.com); the bare origin there is
+ * the client portal, not this app. The slash is normalised by hand rather than trusted
+ * from import.meta.env.BASE_URL — vite.config sets `base` straight from an env var, and
+ * a value written without a trailing slash reaches the bundle that way, producing
+ * "/adminauth/callback".
+ */
+function appRoot(): string {
+  const base = import.meta.env.BASE_URL || '/'
+  return `${window.location.origin}${base.endsWith('/') ? base : `${base}/`}`
+}
+
 /** Builds the redirect_uri used for both the authorize request and the token exchange. */
 function callbackUrl(): string {
-  return `${window.location.origin}/auth/callback`
+  return `${appRoot()}auth/callback`
 }
 
 /**
@@ -141,7 +156,9 @@ export async function refreshSsoToken(refreshToken: string): Promise<SsoTokenRes
 
 /** Redirects the browser to SSO's end-session endpoint, ending the SSO session too. */
 export function ssoLogoutRedirect(idTokenHint?: string): void {
-  const params = new URLSearchParams({ post_logout_redirect_uri: window.location.origin })
+  // Same reasoning as callbackUrl(): on a path-mounted deployment the bare origin is
+  // the client portal, so logging out of the admin panel would drop the user there.
+  const params = new URLSearchParams({ post_logout_redirect_uri: appRoot() })
   if (idTokenHint) params.set('id_token_hint', idTokenHint)
   window.location.href = `${SSO_URL}/connect/logout?${params}`
 }

--- a/client/server/api/portal/auth/sso/callback.get.ts
+++ b/client/server/api/portal/auth/sso/callback.get.ts
@@ -8,12 +8,14 @@ export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const query = getQuery(event)
 
-  // Silent SSO (prompt=none) returned an error — not logged in, go back to homepage
+  // Silent SSO (prompt=none) returned an error — not logged in, go back to homepage.
+  // `sso_silent_tried` is deliberately left in place: it is the loop guard, and clearing
+  // it here would send the very next page render straight back through /authorize. It
+  // carries a short TTL of its own, so a later visit still gets a fresh session probe.
   const error = query.error as string | undefined
   if (error) {
     deleteCookie(event, 'pkce_verifier', { path: '/' })
     deleteCookie(event, 'oauth_state', { path: '/' })
-    deleteCookie(event, 'sso_silent_tried', { path: '/' })
     const returnTo = getCookie(event, 'sso_silent_return') || '/'
     deleteCookie(event, 'sso_silent_return', { path: '/' })
     return sendRedirect(event, returnTo, 302)


### PR DESCRIPTION
host.innovayse.com is unreachable while signed out: every request loops between `/` and the SSO probe until the browser gives up. The informational pages (Hosting, Domains, Products) never render.

The silent-SSO middleware sets `sso_silent_tried` as a loop guard before redirecting to `/authorize?prompt=none`. The callback deleted that cookie on `login_required` — removing the guard at the exact moment it was needed, so the redirect back to the page re-entered the middleware and probed again. The cookie carries its own 30s TTL, so leaving it in place ends the loop without pinning the visitor as a guest.

Also carries a base-path fix for the admin panel: served under `/admin`, its OAuth redirect_uri and post-logout URL were built from the bare origin, which is the client portal on that host.

Verified against production: with the guard cookie present, `/` answers 200 with the full page; without it, curl exhausts 12 redirects.