### PR TITLE
fix(panel): render product descriptions written as HTML

### DIFF
--- a/client/utils/whmcs.ts
+++ b/client/utils/whmcs.ts
@@ -65,6 +65,33 @@ export function nameToKey(name: string): string {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
 }
 
+const ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#39': "'", '#x27': "'",
+}
+
+/**
+ * Flatten a WHMCS description into plain text lines.
+ *
+ * WHMCS lets each product's description be edited as HTML, so the same field
+ * arrives either as newline-separated plain text or as one long line with
+ * <br /> between items — the two are indistinguishable to whoever typed them,
+ * and both are in use across the catalogue. Line-based parsing sees the HTML
+ * variant as a single unbroken line, which is how raw "<strong>…<br />" ended
+ * up printed on the product cards. Convert the block-level tags back into the
+ * newlines they stand for, drop the rest, and the parser below works on either.
+ */
+function htmlToLines(text: string): string {
+  return text
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|ul|ol|h[1-6])\s*>/gi, '\n')
+    .replace(/<li\b[^>]*>/gi, '\n• ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (m, e: string) => ENTITIES[e.toLowerCase()] ?? m)
+}
+
+/** Bullet markers seen across the catalogue: •, -, *, and the ✓ the HTML descriptions use. */
+const BULLET = /^[\u2022\u2713\-*]\s*/
+
 /**
  * Parse a WHMCS description text into a summary paragraph and a features list.
  * - Summary  = lines before the first blank line or section header
@@ -76,7 +103,7 @@ export function parseDescription(text: string): { summary: string; features: str
   const features: string[] = []
   let pastSummary = false
 
-  for (const line of text.split(/\r?\n/)) {
+  for (const line of htmlToLines(text).split(/\r?\n/)) {
     const t = line.trim()
     const isHeader = /:\s*$/.test(t)
 
@@ -85,15 +112,15 @@ export function parseDescription(text: string): { summary: string; features: str
         if (summaryLines.length) pastSummary = true
       } else if (isHeader) {
         pastSummary = true
-      } else if (t.startsWith('\u2022') || t.startsWith('-') || t.startsWith('*')) {
+      } else if (BULLET.test(t)) {
         pastSummary = true
-        features.push(t.replace(/^[\u2022\-*]\s*/, '').trim())
+        features.push(t.replace(BULLET, '').trim())
       } else {
         summaryLines.push(t)
       }
     } else {
       if (!t || isHeader) continue
-      features.push(t.replace(/^[\u2022\-*]\s*/, '').trim())
+      features.push(t.replace(BULLET, '').trim())
     }
   }
 


### PR DESCRIPTION
Product cards printed raw markup — "<strong>Elpida AI Professional</strong> delivers... <br /><br />" — instead of a summary and a feature list.

WHMCS lets each description be edited as HTML, so the field arrives either as newline-separated plain text or as one long line with <br /> between items. Both are in use across the catalogue, which is why some cards read correctly and others did not. parseDescription split on newlines only, so the HTML variant was a single unbroken line: it matched neither the section header nor a bullet, fell through to the summary, and took the tags with it. Features came out empty for those products.

Flatten the block-level tags back into the newlines they stand for, strip the rest, decode entities, and parse as before — plain-text descriptions go through unchanged. Also recognise the ✓ those descriptions use as a bullet, alongside the •, - and * already handled.

## Summary

<!-- What does this PR do? Why? -->

## Related Issue

Closes #

## Changes

-
-

## Checklist

- [ ] Code follows the style rules (`rules/` folder)
- [ ] `dotnet format` run (backend changes)
- [ ] XML docs added to all new C# members
- [ ] JSDoc added to all new exported TypeScript/Vue functions
- [ ] No hardcoded secrets or credentials
- [ ] Tested locally
