### PR TITLE
Refuse a second specification line under the same label

### DIFF
--- a/admin/src/modules/settings/components/ProductFeaturesModal.vue
+++ b/admin/src/modules/settings/components/ProductFeaturesModal.vue
@@ -225,7 +225,8 @@ async function remove(feature: ProductFeature): Promise<void> {
 
         <p class="mt-3 text-xs text-text-muted">
           Plans line up by feature name, so spell it the same way across products — "Disk" and
-          "Disk space" become two separate rows.
+          "Disk space" become two separate rows. Within one product a name can only be used
+          once; reusing it is refused rather than saved where it would never show.
         </p>
       </template>
     </div>

--- a/backend/src/Innovayse.Application/Products/Commands/CreateProductFeature/CreateProductFeatureHandler.cs
+++ b/backend/src/Innovayse.Application/Products/Commands/CreateProductFeature/CreateProductFeatureHandler.cs
@@ -22,6 +22,15 @@ public sealed class CreateProductFeatureHandler(
         _ = await products.FindByIdAsync(cmd.ProductId, ct)
             ?? throw new InvalidOperationException($"Product {cmd.ProductId} not found.");
 
+        // The storefront's comparison table keys its rows on the label and takes the
+        // first value it finds, so a second line under the same label renders nowhere:
+        // an operator would add it, see no change, and have nothing to explain why.
+        if (await repo.ExistsWithLabelAsync(cmd.ProductId, cmd.Label, null, ct))
+        {
+            throw new InvalidOperationException(
+                $"This product already has a \"{cmd.Label.Trim()}\" line. Edit that one instead.");
+        }
+
         var feature = ProductFeature.Create(cmd.ProductId, cmd.Label, cmd.Value, cmd.SortOrder);
 
         repo.Add(feature);

--- a/backend/src/Innovayse.Application/Products/Commands/UpdateProductFeature/UpdateProductFeatureHandler.cs
+++ b/backend/src/Innovayse.Application/Products/Commands/UpdateProductFeature/UpdateProductFeatureHandler.cs
@@ -17,6 +17,15 @@ public sealed class UpdateProductFeatureHandler(IProductFeatureRepository repo, 
         var feature = await repo.FindByIdAsync(cmd.Id, ct)
             ?? throw new InvalidOperationException($"Product feature {cmd.Id} not found.");
 
+        // Renaming a line onto a label the product already uses would hide one of them
+        // from the comparison table, which keys its rows on the label. This line itself
+        // is excluded, so saving a line without renaming it is never blocked.
+        if (await repo.ExistsWithLabelAsync(feature.ProductId, cmd.Label, cmd.Id, ct))
+        {
+            throw new InvalidOperationException(
+                $"This product already has a \"{cmd.Label.Trim()}\" line. Edit that one instead.");
+        }
+
         feature.Update(cmd.Label, cmd.Value, cmd.SortOrder);
         await uow.SaveChangesAsync(ct);
     }

--- a/backend/src/Innovayse.Domain/Products/Interfaces/IProductFeatureRepository.cs
+++ b/backend/src/Innovayse.Domain/Products/Interfaces/IProductFeatureRepository.cs
@@ -22,6 +22,21 @@ public interface IProductFeatureRepository
     Task<IReadOnlyList<ProductFeature>> ListForProductsAsync(
         IEnumerable<int> productIds, CancellationToken ct);
 
+    /// <summary>
+    /// Whether the product already describes a feature under this label.
+    /// </summary>
+    /// <remarks>
+    /// Compared without regard to case, because the storefront groups its comparison
+    /// rows by the label as written: "Disk" and "disk" would become two rows that look
+    /// like a mistake rather than a distinction.
+    /// </remarks>
+    /// <param name="productId">Product to look in.</param>
+    /// <param name="label">Label to look for.</param>
+    /// <param name="excludingId">Line to ignore, so renaming a line does not clash with itself.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><see langword="true"/> when another line already uses the label.</returns>
+    Task<bool> ExistsWithLabelAsync(int productId, string label, int? excludingId, CancellationToken ct);
+
     /// <summary>Adds a new feature line. Call SaveChangesAsync to persist.</summary>
     /// <param name="feature">The new line.</param>
     void Add(ProductFeature feature);

--- a/backend/src/Innovayse.Infrastructure/Products/ProductFeatureRepository.cs
+++ b/backend/src/Innovayse.Infrastructure/Products/ProductFeatureRepository.cs
@@ -30,6 +30,19 @@ public sealed class ProductFeatureRepository(AppDbContext db) : IProductFeatureR
     }
 
     /// <inheritdoc/>
+    public async Task<bool> ExistsWithLabelAsync(
+        int productId, string label, int? excludingId, CancellationToken ct)
+    {
+        var needle = label.Trim().ToLower();
+
+        return await db.ProductFeatures.AnyAsync(
+            f => f.ProductId == productId
+                && f.Label.ToLower() == needle
+                && (excludingId == null || f.Id != excludingId),
+            ct);
+    }
+
+    /// <inheritdoc/>
     public void Add(ProductFeature feature) => db.ProductFeatures.Add(feature);
 
     /// <inheritdoc/>

--- a/backend/tests/Innovayse.Application.Tests/Products/ProductFeatureLabelUniquenessTests.cs
+++ b/backend/tests/Innovayse.Application.Tests/Products/ProductFeatureLabelUniquenessTests.cs
@@ -1,0 +1,109 @@
+namespace Innovayse.Application.Tests.Products;
+
+using Innovayse.Application.Common;
+using Innovayse.Application.Products.Commands.CreateProductFeature;
+using Innovayse.Application.Products.Commands.UpdateProductFeature;
+using Innovayse.Domain.Products;
+using Innovayse.Domain.Products.Interfaces;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Tests that a product cannot end up with two specification lines under one label.
+/// </summary>
+/// <remarks>
+/// The storefront's comparison table keys its rows on the label and takes the first
+/// value it finds, so a duplicate renders nowhere. An operator adding one would see
+/// no change and have nothing to explain why, which is worse than a refusal.
+/// </remarks>
+public class ProductFeatureLabelUniquenessTests
+{
+    private readonly Mock<IProductFeatureRepository> _features = new();
+    private readonly Mock<IProductRepository> _products = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    /// <summary>Builds a product for the existence check to pass.</summary>
+    private static Product AProduct() =>
+        Product.Create(1, "Starter", null, null, null, null, ProductType.SharedHosting, 5m, 50m, null);
+
+    /// <summary>Makes the product lookup succeed.</summary>
+    private void ProductExists() =>
+        _products
+            .Setup(r => r.FindByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AProduct());
+
+    /// <summary>Sets what the label check reports.</summary>
+    /// <param name="taken">Whether another line already uses the label.</param>
+    private void LabelTaken(bool taken) =>
+        _features
+            .Setup(r => r.ExistsWithLabelAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(taken);
+
+    /// <summary>Creating a second line under the same label is refused, and nothing is saved.</summary>
+    [Fact]
+    public async Task Create_RefusesADuplicateLabel()
+    {
+        ProductExists();
+        LabelTaken(true);
+        var handler = new CreateProductFeatureHandler(_features.Object, _products.Object, _uow.Object);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            handler.HandleAsync(new CreateProductFeatureCommand(1, "Disk", "10 GB", 0), CancellationToken.None));
+
+        Assert.Contains("Disk", ex.Message);
+        _features.Verify(r => r.Add(It.IsAny<ProductFeature>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>A label the product does not use yet is created as before.</summary>
+    [Fact]
+    public async Task Create_AllowsAFreeLabel()
+    {
+        ProductExists();
+        LabelTaken(false);
+        var handler = new CreateProductFeatureHandler(_features.Object, _products.Object, _uow.Object);
+
+        await handler.HandleAsync(new CreateProductFeatureCommand(1, "Disk", "10 GB", 0), CancellationToken.None);
+
+        _features.Verify(r => r.Add(It.IsAny<ProductFeature>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>Renaming a line onto a label the product already uses is refused.</summary>
+    [Fact]
+    public async Task Update_RefusesARenameOntoAnExistingLabel()
+    {
+        _features
+            .Setup(r => r.FindByIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProductFeature.Create(1, "Bandwidth", "1 TB", 1));
+        LabelTaken(true);
+        var handler = new UpdateProductFeatureHandler(_features.Object, _uow.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            handler.HandleAsync(new UpdateProductFeatureCommand(7, "Disk", "10 GB", 1), CancellationToken.None));
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// The line under edit is excluded from the check, so saving a line without renaming
+    /// it still works — otherwise every edit would collide with itself.
+    /// </summary>
+    [Fact]
+    public async Task Update_ExcludesTheLineUnderEdit()
+    {
+        _features
+            .Setup(r => r.FindByIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProductFeature.Create(1, "Disk", "10 GB", 0));
+        LabelTaken(false);
+        var handler = new UpdateProductFeatureHandler(_features.Object, _uow.Object);
+
+        await handler.HandleAsync(new UpdateProductFeatureCommand(7, "Disk", "20 GB", 0), CancellationToken.None);
+
+        _features.Verify(
+            r => r.ExistsWithLabelAsync(It.IsAny<int>(), "Disk", 7, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Follow-up to #101, found while driving that PR's admin dialog in a browser.

## The problem

The comparison table keys its rows on the feature name and takes the first value it finds. A second line under the same name on one product therefore rendered nowhere: an operator could add it, see no change on the plans page, and have nothing to explain why. The API accepted it, so the UI could not warn either.

## The fix

Both the create and the update path now refuse it, with a message naming the line to edit instead. `InvalidOperationException` already maps to 400, so the dialog shows that text as-is with no client-side changes.

Three details worth stating:

- **Compared without regard to case or surrounding space.** `"Disk"`, `"disk"` and `" Disk "` would each have become a separate row, which reads as a mistake rather than a distinction.
- **The line under edit is excluded from the check**, so saving a line without renaming it is never blocked — otherwise every edit would collide with itself.
- **The same name on *different* products is still allowed, and has to be.** That is precisely what lines the columns up across plans.

## Verified against a live API

| Case | Result |
|---|---|
| Duplicate label on the same product | 400, with the message |
| Same label miscased (`disk`) | 400 |
| Same label padded (`"  Disk  "`) | 400 |
| A label the product does not use | 201 |
| The same label on another product | 201 |
| Renaming a line onto an existing label | 400 |
| Saving a line without renaming it | 204 |

Test data was removed afterwards; the seeded specifications are back as they were.

Unit tests: 4 new, covering both handlers and the self-exclusion. Application suite 28, Domain 77, Infrastructure 5. Build clean, admin typecheck clean.

## Not addressed

No unique index is added. Enforcing it in the schema would be stronger, but the migration would fail at API startup on any install that already holds a duplicate, taking the whole API down for a data problem this refusal prevents going forward. Worth revisiting once there is a reason to believe no such rows exist.
