### PR TITLE
Let docker compose build the API image, and correct the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,25 @@ cd innovayse
 
 # 2. Copy and configure environment variables
 cp .env.example .env
-# Edit .env — set JWT_SECRET and any other required values
+# Edit .env — set JWT_SECRET, and NUGET_INNOVAYSE_CREDENTIALS if you are building
+# the API image yourself (see below)
 
 # 3. Start all services
 docker compose up -d
+# The API applies pending migrations on startup, so there is no separate step.
+# Follow it with: docker compose logs -f hostpanel-api
 
-# 4. Apply database migrations
-docker compose exec api dotnet ef database update
-
-# 5. Open in browser
-#   Client portal:  http://localhost:3000
-#   Admin panel:    http://localhost:5173
-#   API docs:       http://localhost:5148/scalar
-#   MailHog (dev):  http://localhost:8025
+# 4. Open in browser
+#   Client portal:  http://localhost:3001
+#   Admin panel:    http://localhost:5174
+#   API docs:       http://localhost:5149/scalar
+#   MailHog (dev):  http://localhost:8027
 ```
+
+The API depends on `Innovayse.Auth`, published to a private package registry, and
+the image restores it while it builds. Set `NUGET_INNOVAYSE_CREDENTIALS` in `.env`
+to a deploy token scoped to `read_package_registry` — the format is in
+`.env.example`. Without it the build stops at `NU1301 … 401 (Unauthorized)`.
 
 ---
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,12 @@ services:
       context: .
       dockerfile: docker/api.Dockerfile
       target: prod
+      args:
+        # Same reason as in docker-compose.yml: the restore happens during the build,
+        # so the credential has to arrive as a build arg. It is consumed by the
+        # intermediate `build` stage only — the published `prod` stage starts from a
+        # fresh base and never re-declares the ARG, so nothing carries it.
+        NuGetPackageSourceCredentials_innovayse: ${NUGET_INNOVAYSE_CREDENTIALS}
     environment:
       # The alias, not the bare service name: several products call their database
       # service "postgres", so on the shared network that name resolved to three

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,13 @@ services:
       context: .
       dockerfile: docker/api.Dockerfile
       target: dev
+      args:
+        # api.Dockerfile declares this ARG for its `dotnet restore`, and the restore
+        # runs while the image is built. Passing the credential only through
+        # `environment:` below reaches the running container and not the build, so
+        # `docker compose up` failed at NU1301 / 401 fetching Innovayse.Auth — the
+        # README's Quick Start could not work on any machine, with or without a token.
+        NuGetPackageSourceCredentials_innovayse: ${NUGET_INNOVAYSE_CREDENTIALS}
     # The name other products, the edge proxy and the dev proxy address this one
     # by. Declared here rather than in docker-compose.platform.yml so it resolves
     # in a standalone deployment too — the alternative was the container name,


### PR DESCRIPTION
Found while bringing up a stack to verify #101. Independent of that work.

## `docker compose up` cannot build the API image

`docker/api.Dockerfile` declares `ARG NuGetPackageSourceCredentials_innovayse` for its `dotnet restore`, and that restore runs **while the image is built**. Both compose files passed the credential only through `environment:`, which reaches the running container and not the build. So the build stops here:

```
NU1301: Failed to retrieve information about 'Innovayse.Auth' from remote source
        …/packages/nuget/download/innovayse.auth/index.json
        Response status code does not indicate success: 401 (Unauthorized).
```

The README's Quick Start therefore could not work on any machine. Having a token in `.env` did not help, because nothing carried it into the build.

Fixed by adding `args:` to the API service in both compose files — the same pattern the client service in `docker-compose.prod.yml` already uses for its own build args.

The credential is consumed by the intermediate `build` stage. The published `prod` stage starts from a fresh base and never re-declares the ARG, so nothing carries it into a shipped image.

## The quick start was wrong in three more ways

All checked against the compose file and a running stack:

- **Ports.** It documents 3000, 5173, 5148 and 8025; compose publishes **3001, 5174, 5149, 8027**. (The 3000 and 5173 further down the README are correct — those are the non-Docker dev servers.)
- **`docker compose exec api …`** names a service that does not exist. It is `hostpanel-api`.
- **That step is redundant anyway.** It told the reader to apply migrations by hand, but `Program.cs` calls `MigrateAsync` on startup. Confirmed live: bringing the API up created the `product_features` table on its own.

The README now also says where `NUGET_INNOVAYSE_CREDENTIALS` comes from, since a reader hits that wall before anything else.

## Scope of verification

Both compose files still parse, and `docker compose config` now shows the argument reaching the build:

```
args:
  NuGetPackageSourceCredentials_innovayse: Username=…;Password=…
target: dev
```

**A successful build was not observed.** That needs a real deploy token, which this checkout does not have. The change is structural — a declared ARG that nothing was supplying — so confidence is high, but it is not the same as watching the restore succeed. Worth one build on a machine that has a token before this is trusted.
