### PR TITLE
Accept a registrar module in any casing, and name the valid ones

### DIFF
--- a/backend/src/Innovayse.Application/Domains/Commands/CreateTldConfig/CreateTldConfigHandler.cs
+++ b/backend/src/Innovayse.Application/Domains/Commands/CreateTldConfig/CreateTldConfigHandler.cs
@@ -26,7 +26,17 @@ public sealed class CreateTldConfigHandler(ITldConfigRepository repo, IUnitOfWor
     /// </exception>
     public async Task<int> HandleAsync(CreateTldConfigCommand cmd, CancellationToken ct)
     {
-        var module = Enum.Parse<RegistrarModule>(cmd.RegistrarModule);
+        // TryParse, not Parse: Parse raises ArgumentException, which no handler in the
+        // pipeline classifies, so a misspelled module came back as
+        // 500 "An unexpected error occurred." — indistinguishable from the server
+        // falling over. InvalidOperationException already maps to 400, and naming the
+        // accepted values saves the caller guessing at their casing.
+        if (!Enum.TryParse<RegistrarModule>(cmd.RegistrarModule, ignoreCase: true, out var module))
+        {
+            throw new InvalidOperationException(
+                $"Unknown registrar module '{cmd.RegistrarModule}'. Accepted values: "
+                + string.Join(", ", Enum.GetNames<RegistrarModule>()) + ".");
+        }
         var normalizedTld = cmd.Tld.ToLower().Trim();
 
         var existing = await repo.FindByTldAsync(normalizedTld, ct);

--- a/backend/src/Innovayse.Application/Domains/Commands/ImportTldPricing/ImportTldPricingHandler.cs
+++ b/backend/src/Innovayse.Application/Domains/Commands/ImportTldPricing/ImportTldPricingHandler.cs
@@ -33,7 +33,17 @@ public sealed class ImportTldPricingHandler(
     /// <returns>An <see cref="ImportTldPricingResult"/> with counts of imported and updated TLDs.</returns>
     public async Task<ImportTldPricingResult> HandleAsync(ImportTldPricingCommand cmd, CancellationToken ct)
     {
-        var module = Enum.Parse<RegistrarModule>(cmd.Module);
+        // TryParse, not Parse: Parse raises ArgumentException, which no handler in the
+        // pipeline classifies, so a misspelled module came back as
+        // 500 "An unexpected error occurred." — indistinguishable from the server
+        // falling over. InvalidOperationException already maps to 400, and naming the
+        // accepted values saves the caller guessing at their casing.
+        if (!Enum.TryParse<RegistrarModule>(cmd.Module, ignoreCase: true, out var module))
+        {
+            throw new InvalidOperationException(
+                $"Unknown registrar module '{cmd.Module}'. Accepted values: "
+                + string.Join(", ", Enum.GetNames<RegistrarModule>()) + ".");
+        }
         var provider = factory.GetProvider(module);
 
         var pricingList = await provider.GetTldPricingAsync(ct);

--- a/backend/src/Innovayse.Application/Domains/Commands/UpdateTldConfig/UpdateTldConfigHandler.cs
+++ b/backend/src/Innovayse.Application/Domains/Commands/UpdateTldConfig/UpdateTldConfigHandler.cs
@@ -28,7 +28,17 @@ public sealed class UpdateTldConfigHandler(ITldConfigRepository repo, IUnitOfWor
         var entity = await repo.FindByIdAsync(cmd.Id, ct)
             ?? throw new InvalidOperationException($"TLD configuration {cmd.Id} not found.");
 
-        var module = Enum.Parse<RegistrarModule>(cmd.RegistrarModule);
+        // TryParse, not Parse: Parse raises ArgumentException, which no handler in the
+        // pipeline classifies, so a misspelled module came back as
+        // 500 "An unexpected error occurred." — indistinguishable from the server
+        // falling over. InvalidOperationException already maps to 400, and naming the
+        // accepted values saves the caller guessing at their casing.
+        if (!Enum.TryParse<RegistrarModule>(cmd.RegistrarModule, ignoreCase: true, out var module))
+        {
+            throw new InvalidOperationException(
+                $"Unknown registrar module '{cmd.RegistrarModule}'. Accepted values: "
+                + string.Join(", ", Enum.GetNames<RegistrarModule>()) + ".");
+        }
 
         entity.Update(
             module,


### PR DESCRIPTION
Found while entering data through the API to verify #101.

## The problem

Three TLD handlers parsed the registrar module with `Enum.Parse`, which raises `ArgumentException`. Nothing in the pipeline classifies that, so it reached the last handler and came back as:

```
500 {"error":"An unexpected error occurred."}
```

That is the message for a fault, and this is not one. It says nothing about the field, the value, or the spelling — posting `"namecheap"` where the enum spells it `Namecheap` looked like an outage. Worse, anything built against this API would *retry* it, since a 500 means "try again later".

## The fix

`Enum.TryParse` with `ignoreCase: true` at the three sites that parse caller input — `CreateTldConfig`, `UpdateTldConfig`, `ImportTldPricing`.

So the case that started this now simply **works**: `"namecheap"` is accepted. A genuinely unknown value raises `InvalidOperationException`, which already maps to 400, and the message lists what is accepted rather than leaving the caller to guess at casing.

## Verified against a live API

| Request | Before | After |
|---|---|---|
| `registrarModule: "totallywrong"` | 500 `An unexpected error occurred.` | 400 `Unknown registrar module 'totallywrong'. Accepted values: NameAm, Namecheap.` |
| `registrarModule: "namecheap"` | 500 | **201** |

Build clean; Application 24, Domain 77, Infrastructure 5.

## What this branch used to do, and why it changed

The first version caught `ArgumentException` globally in `ExceptionMiddleware` and returned 400 with the exception's message. Re-reading it before asking for review, that is the wrong instrument:

- `ArgumentException` also comes from internal misuse — a duplicate dictionary key, a bad format string, a library called wrongly. Those are server faults. Mapping them to 400 tells the caller they made a mistake, and hides the fault from anything that alerts on 500s.
- It would return an internal message to the caller, which is exactly what the general handler's own comment warns against.

It traded a narrow problem for a broader one. Fixed at the three parse sites instead, and the middleware is untouched.

## Still open

A blank required string reaching a domain guard (`ArgumentException.ThrowIfNullOrWhiteSpace`) still returns 500, because those commands have no validator at the boundary. `FluentValidation` validators exist in the codebase but are not wired into the pipeline and `ValidationException` is unhandled, so fixing that properly is its own change rather than something to squeeze in here.
