### PR TITLE
Keep an unsaved setting when the save fails

### DIFF
--- a/admin/src/modules/settings/components/PortalAppearanceCard.vue
+++ b/admin/src/modules/settings/components/PortalAppearanceCard.vue
@@ -7,7 +7,7 @@
  * not break the site, but it would silently revert an operator's choice with no
  * indication why. Constraining the input removes the failure entirely.
  */
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { Setting } from '../../../types/models'
 
 const props = defineProps<{
@@ -42,8 +42,17 @@ const dirty = computed(() => draft.value !== null && draft.value !== setting.val
 function save() {
   if (!setting.value || !dirty.value) return
   emit('save', setting.value.id, selected.value)
-  draft.value = null
 }
+
+// The draft is cleared when the stored value catches up, not when the save is
+// requested. Clearing on emit discarded the operator's pick before anyone knew
+// whether it had been written: a failed save silently snapped the dropdown back
+// to the template already in use, with only an error banner to explain it.
+watch(() => setting.value?.value, (stored) => {
+  if (draft.value !== null && stored === draft.value) {
+    draft.value = null
+  }
+})
 </script>
 
 <template>

--- a/admin/src/modules/settings/views/SystemSettingsView.vue
+++ b/admin/src/modules/settings/views/SystemSettingsView.vue
@@ -19,12 +19,16 @@ onMounted(store.fetchSettings)
  * @param id - Setting ID.
  * @param value - New value.
  */
-async function onSave(id: number, value: string) {
+async function onSave(id: number, value: string): Promise<boolean> {
   saving.value = true
   try {
     await store.updateSetting(id, value)
+    return true
   } catch {
-    // store.error carries the message for the banner below.
+    // store.error carries the message for the banner below. The outcome is
+    // returned rather than swallowed, because the caller has to know whether it
+    // may drop the operator's unsaved text.
+    return false
   } finally {
     saving.value = false
   }
@@ -65,8 +69,13 @@ function isDirty(setting: Setting): boolean {
  */
 async function saveRow(setting: Setting) {
   if (!isDirty(setting)) return
-  await onSave(setting.id, drafts.value[setting.id])
-  delete drafts.value[setting.id]
+
+  // Only on success. This used to drop the draft either way, so a failed save
+  // replaced whatever the operator had typed with the value already stored —
+  // leaving an error banner and no way back to the text that caused it.
+  if (await onSave(setting.id, drafts.value[setting.id])) {
+    delete drafts.value[setting.id]
+  }
 }
 </script>
 


### PR DESCRIPTION
Found by reviewing #101 after it merged. Both settings controls lose the operator's edit when a save fails.

## What happens today

`saveRow` in the settings table:

```ts
await onSave(setting.id, drafts.value[setting.id])
delete drafts.value[setting.id]          // unconditional
```

`onSave` catches the store's throw, so a failed PUT looks the same as a successful one from here. The draft is dropped either way, the input falls back to the value already stored, and the row stops reading as changed — so the Save button disappears too. The operator is left with an error banner, no idea what they had typed, and no way to retry it.

`PortalAppearanceCard.save()` has the same shape: it emits and then sets `draft.value = null` immediately, before anyone knows whether the write happened. A failed save silently snaps the dropdown back to the template already in use.

## The fix

- The table clears a row's draft **only on success**, which means `onSave` returns the outcome rather than swallowing it.
- The card clears its draft when the **stored value catches up** — `updateSetting` refetches after a successful write, so the prop changing is the signal — rather than on the click.

## Verified in a browser, on the failure path

Against a live API, with every `PUT /api/admin/settings/*` forced to 500:

| | Result |
|---|---|
| PUTs intercepted | 1 |
| Typed value after the failed save | `SHOULD-SURVIVE-FAILURE` — kept |
| Save button still offered | yes, so the edit can be retried |
| Error banner shown | yes |

Worth recording how close this came to a false pass: the first run registered its route handlers in the wrong order, so Playwright's catch-all won and the PUT was never intercepted. The check "passed" against the success path, and the value survived for the wrong reason — the save had simply worked. The numbers above are from the run that actually blocked the PUT.

## Why it was missed in #101

That verification exercised the happy path only: type, save, read the value back from the API. Nothing forced a failure, and this bug is invisible until one happens.
