### PR TITLE
Resolve the caller of /auth/me under local mode, and report the auth mode

### DIFF
--- a/backend/src/Innovayse.API/Auth/AuthController.cs
+++ b/backend/src/Innovayse.API/Auth/AuthController.cs
@@ -13,8 +13,31 @@ using Wolverine;
 /// </summary>
 [ApiController]
 [Route("api/auth")]
-public sealed class AuthController(IMessageBus bus, IUserService userService) : ControllerBase
+public sealed class AuthController(
+    IMessageBus bus,
+    IUserService userService,
+    IConfiguration configuration) : ControllerBase
 {
+    /// <summary>
+    /// Returns how this deployment signs people in, so a browser client can offer the
+    /// right control instead of guessing.
+    /// </summary>
+    /// <remarks>
+    /// The admin SPA has no other way to know. It was rewritten to rely on the cookie
+    /// session the OIDC exchange issues, and that exchange only runs under
+    /// <c>Auth:Mode=sso</c> — so under <c>local</c> it showed an SSO button with nothing
+    /// behind it. Reporting the mode lets it show a password form there instead.
+    ///
+    /// Anonymous on purpose: a caller has to read this before it can authenticate, and
+    /// the answer is a deployment shape rather than a secret. It says which mechanism is
+    /// in use, nothing about who may use it.
+    /// </remarks>
+    /// <returns>200 with <c>{ mode }</c>, either <c>local</c> or <c>sso</c>.</returns>
+    [HttpGet("mode")]
+    [AllowAnonymous]
+    public IActionResult Mode() =>
+        Ok(new { mode = string.Equals(configuration["Auth:Mode"], "local", StringComparison.OrdinalIgnoreCase) ? "local" : "sso" });
+
     /// <summary>Returns whether initial admin setup is required (no users exist).</summary>
     [HttpGet("setup-required")]
     [AllowAnonymous]
@@ -71,10 +94,20 @@ public sealed class AuthController(IMessageBus bus, IUserService userService) : 
     [Authorize]
     public async Task<IActionResult> MeAsync(CancellationToken ct)
     {
-        var sub = User.FindFirst("sub")?.Value;
+        // Both claim names, because the two modes deliver the subject differently. SSO
+        // mode sets MapInboundClaims = false, so "sub" survives as itself; local mode
+        // leaves the default mapping on, which renames it to NameIdentifier. Reading only
+        // "sub" therefore found nothing under local and answered 401 — with a valid
+        // token, from an account with the Admin role.
+        var sub = User.FindFirst("sub")?.Value
+            ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
         if (sub is null) return Unauthorized();
 
-        var found = await userService.FindBySsoSubjectAsync(sub, ct);
+        // And the two mean different things by it. An SSO token carries the SSO's
+        // subject; a token this API issued from /api/auth/login carries this database's
+        // own user id. Only the first was resolved.
+        var found = await userService.FindBySsoSubjectAsync(sub, ct)
+            ?? await userService.FindByIdAsync(sub, ct);
         if (found is null) return Unauthorized();
 
         var roles = await userService.GetRolesAsync(found.Value.Id, ct);


### PR DESCRIPTION
Two fixes a standalone deployment needs, independent of what is later decided about signing a browser in (#105).

## `/auth/me` refused every local caller

It read the subject from `"sub"` alone. The two modes deliver it differently:

- SSO mode sets `MapInboundClaims = false`, so `"sub"` survives as itself.
- Local mode leaves the default mapping on, which renames it to `NameIdentifier`.

So under local, `User.FindFirst("sub")` found nothing and the endpoint answered **401 — with a valid token, from an account holding the Admin role**. It then resolved the subject as an SSO subject only, and a token this API issues carries this database's own user id, which is a second reason the same call could not succeed. Both claim names are read now, and both lookups tried.

This is what left the admin SPA with no way in under local mode: it asks `/auth/me` on every load, so the panel was unreachable even though `POST /api/auth/login` worked and returned the right role.

Verified against a live API in local mode:

```
before:  401  {"title":"Unauthorized","status":401,…}
after:   200  {"email":"admin@hostpanel.com","roles":["Admin"],"emailVerified":true}
```

## `GET /api/auth/mode` is new

A browser client has no way to know which mechanism a deployment uses, which is why the login page showed an SSO button on an install with no SSO behind it. Anonymous on purpose: a caller has to read it before it can authenticate, and the answer is a deployment shape rather than a secret — it says which mechanism is in use, nothing about who may use it.

## What this deliberately does not do

It does not make the admin panel signable-in. I built that too — a local password form, the bearer token held in memory, `useApi` attaching it — got it working end to end in a browser, and then **withdrew it**, because measuring it showed the shape does not hold up:

- The local token lives **15 minutes**, and `POST /api/auth/refresh` is present but unimplemented: *"short-lived tokens require re-login when expired"*. An operator would re-enter their password four times an hour.
- Held in memory, the session also dies on any full page load — a refresh or a pasted URL returns you to the login screen. Verified: it did.
- And the comment I had leaned on says *"Bearer stays for **the machines**"*. Machines, not browsers. LocalJwt was never meant to carry a browser session, so building one on it argues against the design rather than following it.

Storing the token in `sessionStorage` would fix the refresh problem and not the 15-minute one, while putting a credential where a script can read it — the category that was deliberately removed.

So the remaining work is a session mechanism or an implemented refresh, which is a decision rather than a patch. #105 now carries this evidence. These two fixes stand on their own either way: any local-mode client, browser or script, needs `/auth/me` to recognise it.

Application 28, Domain 77, Infrastructure 5, Integration 40. Build clean.
