### PR TITLE
Render plan descriptions as text and features, not as markup

### DIFF
--- a/client/composables/usePortalPlans.ts
+++ b/client/composables/usePortalPlans.ts
@@ -1,3 +1,4 @@
+import { parseDescription } from '~/utils/whmcs'
 import type { PlanCard } from '~/templates/aurora/types'
 
 /**
@@ -58,10 +59,19 @@ export const usePortalPlans = () => {
       return `${prefix}${(value / divisor).toFixed(2)}${suffix}`
     }
 
+    // A description is authored either as plain text or as HTML with <br /> between
+    // items — WHMCS lets the same field be edited both ways, and both are in the
+    // catalogue. Printed straight into the card, the HTML variant showed its own
+    // markup: "✔ 20 GB Disk Space <br /> ✔ 200 GB Bandwidth". parseDescription
+    // already understands both, and separates the summary from the feature lines
+    // the card can then render as a list.
+    const { summary, features } = parseDescription(product.description ?? '')
+
     return {
       id: product.id,
       name: product.name,
-      description: product.description ?? '',
+      description: summary,
+      features,
       priceMonthly: format(money?.monthly),
       priceAnnual: format(money?.annually, 12),
       href: localePath(`/configure/${product.id}`),

--- a/client/templates/aurora/sections/PlanCards.vue
+++ b/client/templates/aurora/sections/PlanCards.vue
@@ -35,6 +35,13 @@
         <div class="text-[17px] font-bold text-tx">{{ plan.name }}</div>
         <div v-if="plan.description" class="mt-1.5 text-sm text-mut2">{{ plan.description }}</div>
 
+        <ul v-if="plan.features.length" class="mt-3.5 flex flex-col gap-2">
+          <li v-for="line in plan.features" :key="line" class="flex items-start gap-2 text-[13px] text-tx2">
+            <Icon name="lucide:check" class="mt-0.5 h-3.5 w-3.5 shrink-0 text-ok" />
+            <span class="min-w-0">{{ line }}</span>
+          </li>
+        </ul>
+
         <div class="mt-[22px] flex items-end gap-2">
           <span class="text-[38px] font-bold -tracking-[0.02em] text-tx">
             {{ yearly ? plan.priceAnnual : plan.priceMonthly }}
@@ -52,10 +59,13 @@
     </div>
 
     <!--
-      The product record carries no feature list, so this is one shared list for
-      every plan rather than per-card claims the backend cannot support.
+      A fallback, not a companion to the per-card lists above. An operator whose
+      descriptions are plain summaries gets no feature lines at all, and this keeps
+      the section from looking bare; where the plans do carry their own features,
+      repeating a single "included in every plan" list beside them would contradict
+      the cards the moment two plans differed.
     -->
-    <div v-if="plans.length" class="mt-9 rounded-[18px] border border-line bg-surf p-6">
+    <div v-if="plans.length && !plans.some(p => p.features.length)" class="mt-9 rounded-[18px] border border-line bg-surf p-6">
       <div class="text-[13px] uppercase tracking-[0.1em] text-ac2">{{ t('aurora.plans.includedTitle') }}</div>
       <div class="mt-4 grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(100%,200px),1fr))]">
         <div v-for="line in included" :key="line" class="flex items-center gap-2.5 text-[15px] text-tx2">

--- a/client/templates/aurora/types.ts
+++ b/client/templates/aurora/types.ts
@@ -36,8 +36,10 @@ export interface PlanCard {
   id: number
   /** Display name, e.g. "Business". */
   name: string
-  /** Short description from the product record; may be empty. */
+  /** Summary paragraph from the product record; may be empty. */
   description: string
+  /** Feature lines parsed out of the same record; may be empty. */
+  features: string[]
   /** Formatted monthly price, e.g. "$4.99". */
   priceMonthly: string
   /** Formatted annual price expressed per month. */

--- a/client/utils/whmcs.test.ts
+++ b/client/utils/whmcs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { parseDescription } from './whmcs'
+
+/**
+ * The exact shape a WHMCS-authored description arrives in when it was edited as
+ * HTML: prose, then check-marked items separated by `<br />`. Printed straight into
+ * a card it showed its own markup — "✔ 20 GB Disk Space <br /> ✔ 200 GB Bandwidth".
+ */
+const HTML_DESCRIPTION =
+  'The Business Hosting plan provides the optimal performance for medium-sized '
+  + 'enterprises and online stores. It includes everything you need to run a fast, '
+  + 'secure, and professional website. <br /> ✔ 20 GB Disk Space <br /> ✔ 200 GB '
+  + 'Bandwidth <br /> ✔ 50 Email Accounts <br /> ✔ 20 MySQL Databases <br /> '
+  + '✔ 20 Subdomains <br /> ✔ 20 FTP Accounts <br /> ✔ Free SSL Certificate <br />'
+
+describe('parseDescription', () => {
+  it('separates the prose from the check-marked items in an HTML description', () => {
+    const { summary, features } = parseDescription(HTML_DESCRIPTION)
+
+    expect(summary).toBe(
+      'The Business Hosting plan provides the optimal performance for medium-sized '
+      + 'enterprises and online stores. It includes everything you need to run a fast, '
+      + 'secure, and professional website.')
+    expect(features).toEqual([
+      '20 GB Disk Space',
+      '200 GB Bandwidth',
+      '50 Email Accounts',
+      '20 MySQL Databases',
+      '20 Subdomains',
+      '20 FTP Accounts',
+      'Free SSL Certificate',
+    ])
+  })
+
+  it('leaves no markup anywhere in the result', () => {
+    const { summary, features } = parseDescription(HTML_DESCRIPTION)
+
+    for (const text of [summary, ...features]) {
+      expect(text).not.toMatch(/<[^>]+>/)
+      expect(text).not.toContain('&')
+    }
+  })
+
+  it('handles a description that is nothing but items, with no prose', () => {
+    const { summary, features } = parseDescription(
+      '✔ 600 MB Disk Space <br /> ✔ 5 GB Bandwidth <br /> ✔ 2 Email Accounts')
+
+    expect(summary).toBe('')
+    expect(features).toEqual(['600 MB Disk Space', '5 GB Bandwidth', '2 Email Accounts'])
+  })
+
+  it('still reads a plain-text description, which the catalogue also holds', () => {
+    const { summary, features } = parseDescription(
+      'A simple plan.\n\n• 10 GB Disk\n• 1 TB Bandwidth')
+
+    expect(summary).toBe('A simple plan.')
+    expect(features).toEqual(['10 GB Disk', '1 TB Bandwidth'])
+  })
+
+  it('reports an empty description as empty rather than as one blank feature', () => {
+    expect(parseDescription('')).toEqual({ summary: '', features: [] })
+  })
+})

--- a/client/utils/whmcs.ts
+++ b/client/utils/whmcs.ts
@@ -89,8 +89,15 @@ function htmlToLines(text: string): string {
     .replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (m, e: string) => ENTITIES[e.toLowerCase()] ?? m)
 }
 
-/** Bullet markers seen across the catalogue: •, -, *, and the ✓ the HTML descriptions use. */
-const BULLET = /^[\u2022\u2713\-*]\s*/
+/**
+ * Bullet markers seen across the catalogue: •, -, * and both check marks.
+ *
+ * U+2713 ✓ and U+2714 ✔ sit one codepoint apart and look identical at body size.
+ * Only the first was listed, and the catalogue is written with the second, so no
+ * feature line was ever recognised as one: every item fell through to the summary,
+ * and a card printed one long paragraph with check marks running through it.
+ */
+const BULLET = /^[\u2022\u2713\u2714\-*]\s*/
 
 /**
  * Parse a WHMCS description text into a summary paragraph and a features list.


### PR DESCRIPTION
Reported from a live catalogue — the plan cards were printing their own markup:

> The Business Hosting plan provides the optimal performance for medium-sized enterprises and online stores. It includes everything you need to run a fast, secure, and professional website. `<br />` ✔ 20 GB Disk Space `<br />` ✔ 200 GB Bandwidth `<br />` ✔ 50 Email Accounts …

Two faults, and fixing either alone would still have looked wrong.

## 1. The aurora cards never parsed the description

They printed `product.description` straight into the template. A description is authored either as plain text or as HTML with `<br />` between items — WHMCS lets the same field be edited both ways and both are in the catalogue. `parseDescription` already understands both and separates the summary from the feature lines, so the cards now use it and render those lines as a list.

## 2. `parseDescription` did not recognise the items as items

Its bullet pattern listed **U+2713 ✓**. The catalogue is written with **U+2714 ✔** — one codepoint apart, identical at body size:

```
const BULLET = /^[•✓\-*]\s*/     // before
const BULLET = /^[•✓✔\-*]\s*/  // after
```

So every feature line fell through into the summary and came out as one long paragraph with check marks running through it. **This half affects the `classic` template too**, which has been calling this parser since #100 — its cards have been showing the same paragraph, just without the visible `<br />`.

## The shared "included in every plan" block

Now shown only when no plan carries its own features. Beside per-card lists it would contradict them the moment two plans differed. The comment above it claimed the product record has no feature list; that was wrong — the features were in the description the whole time. (Which is also worth knowing next to #101's `product_features` table: that table gives the comparison matrix structure the description cannot, but the cards never needed it.)

## Verification

Rendered against the reported description shape, plus an items-only one like the Free plan's:

| | Result |
|---|---|
| Literal markup in the output | none |
| Summary | clean prose, no check marks |
| Feature lines rendered | 13 across two cards |
| Shared "included" block | gone, as the plans have their own |
| `/hosting` | 200 |

Five new unit tests cover the parser against that exact string, an items-only description, plain text, and empty. Client suite 27 (was 22).

**Not verified against a live backend:** Docker Desktop stopped partway through this session, so the render was checked against a stub carrying the reported description verbatim rather than the real API. The change is client-side and the parser is covered by tests, but the end-to-end path is a stub this time.
