### PR TITLE
ci: cut staging from develop, production from main

### DIFF
--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -3,9 +3,18 @@ name: Mirror to GitLab
 # hostpanel's CI/CD lives on GitLab (build + test + the manual production deploy
 # job), because that's where its runners are — one on ProdServer itself, tagged
 # `prod`. GitHub stays the public source of record. This workflow is the bridge:
-# every push to main is force-pushed to the GitLab mirror, which reuses that
-# repo's own `.gitlab-ci.yml` workflow rules (`if: $CI_COMMIT_BRANCH == "main"`)
-# to start a pipeline — nothing GitLab-side needs to change for this to work.
+# every push to main or develop is mirrored to GitLab, which reuses that repo's
+# own `.gitlab-ci.yml` workflow rules to start a pipeline for the branch that
+# arrived.
+#
+# Both branches have to cross, because the two tiers are cut from different ones,
+# the same way the rest of the Innovayse suite does it:
+#
+#   develop -> staging (LocalServer)
+#   main    -> production (ProdServer, manual)
+#
+# Mirroring only main, as this did at first, left the GitLab side with no develop
+# to run a staging pipeline from at all.
 #
 # GITLAB_MIRROR_TOKEN is a GitLab *project* access token (write_repository only,
 # Maintainer role, scoped to innovayse/hostpanel) — not the broad personal token
@@ -13,7 +22,7 @@ name: Mirror to GitLab
 # repo, nothing else on the account.
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   mirror:
@@ -27,6 +36,9 @@ jobs:
 
       - name: Push to GitLab
         run: |
-          git push "https://project-access-token:${GITLAB_MIRROR_TOKEN}@gitlab.com/innovayse/hostpanel.git" "HEAD:main"
+          # Push to the branch the event came from, not a hardcoded main, or a
+          # develop push would land on GitLab's main and deploy staging code to
+          # the production branch.
+          git push "https://project-access-token:${GITLAB_MIRROR_TOKEN}@gitlab.com/innovayse/hostpanel.git" "HEAD:${GITHUB_REF_NAME}"
         env:
           GITLAB_MIRROR_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 workflow:
   rules:
     - if: $CI_SERVER_HOST == "gitlab.com" && $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "main"
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "main"      # → production (ProdServer, manual)
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"   # → staging (LocalServer)
     - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "ci-test"   # throwaway verification branch
 
 stages: [test, build, deploy]
@@ -81,12 +82,25 @@ stages: [test, build, deploy]
     - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token --password-stdin "$CI_REGISTRY"
   script:
     - cd "$DEPLOY_DIR"
+    # GIT_STRATEGY is none, so the runner never touches this checkout — but the
+    # deploy builds the api, client and admin images from it (neither compose file
+    # gives those services an `image:`, so there is nothing to pull). Left alone it
+    # deploys whatever was last checked out by hand; this host sat 33 commits back
+    # that way. Sync it to the branch that triggered the pipeline so the tier
+    # really is the branch.
+    - git fetch --prune origin
+    - git checkout -B "$CI_COMMIT_BRANCH" "origin/$CI_COMMIT_BRANCH"
     # docker-compose.platform.yml joins the shared innovayse_network — without it
     # the containers are unreachable by name from the reverse proxy.
     - docker compose -f docker-compose.prod.yml -f docker-compose.platform.yml pull
-    - docker compose -f docker-compose.prod.yml -f docker-compose.platform.yml up -d
+    # Services named one by one to leave nginx out. It publishes 80 and 443, which
+    # on this host belong to the shared Nginx Proxy Manager that fronts every
+    # Innovayse product — so it can never bind, and `up -d` fails the whole deploy
+    # on it. Inside the workspace this product is reached through that proxy; its
+    # own nginx is for a standalone deployment.
+    - docker compose -f docker-compose.prod.yml -f docker-compose.platform.yml up -d hostpanel-db hostpanel-api hostpanel-client admin
   rules:
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "main"
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
 
 # ── backend (Innovayse.API, .NET) ──────────────────────────────────────────────
 
@@ -187,7 +201,7 @@ deploy:staging:
     ASPNETCORE_ENVIRONMENT: Staging
   environment: { name: staging/hostpanel }
   rules:
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "main"
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
   needs:
     - job: backend:build:api:prod
       optional: true


### PR DESCRIPTION
hostpanel was the one product in the suite whose two tiers came from the same branch. This brings it in line with the rest of Innovayse:

- `develop` -> staging (LocalServer)
- `main` -> production (ProdServer, manual)

The mirror now carries both branches to GitLab and pushes to the branch the event came from. `deploy:staging` keys on `develop`, skips the `nginx` service (ports 80/443 belong to the shared proxy on that host), and syncs the deploy checkout to the triggering branch.