### PR TITLE
fix(auth): role-annotated endpoints stopped reading the Authorization…

### DIFF
--- a/backend/src/Innovayse.API/Program.cs
+++ b/backend/src/Innovayse.API/Program.cs
@@ -48,6 +48,10 @@ try
 
     var authMode = builder.Configuration["Auth:Mode"] ?? "sso";
 
+    // The scheme that stands in front of the real ones under SSO mode. See where it is
+    // registered, below AddInnovayseAuth, for what it is for.
+    const string SmartAuthScheme = "InnovayseSmart";
+
     // JwtTokenService is always registered — admin panel uses local auth regardless of mode
     builder.Services.AddSingleton<Innovayse.API.Auth.JwtTokenService>();
 
@@ -159,6 +163,44 @@ try
         // API with an SSO token, and standalone deployments keep LocalJwt. That is
         // why this is an additional scheme rather than a replacement.
         builder.Services.AddInnovayseAuth(builder.Configuration);
+
+        // …except that registering it made it the default scheme, which is not what
+        // "additional" means. Everything below turns on the difference between the
+        // default POLICY and the default SCHEME:
+        //
+        //   [Authorize]                     uses DefaultPolicy, which names all three
+        //                                   schemes below and therefore worked.
+        //   [Authorize(Roles = "Client")]   does not. Naming a role makes MVC build a
+        //                                   policy on the spot, and that policy carries
+        //                                   no schemes, so it falls back to the default
+        //                                   authenticate scheme — the cookie.
+        //
+        // So every one of the 85 role-annotated endpoints stopped reading the
+        // Authorization header. A caller presenting a perfectly good SSO token was
+        // challenged for a cookie it does not have and got a bare 401, with no
+        // WWW-Authenticate to say why. That is the whole client portal: its Nuxt server
+        // calls this API with a bearer token, so /api/me/* answered 401 to every
+        // request and the customer's dashboard rendered empty.
+        //
+        // A policy scheme restores the intent. It authenticates nothing itself; it
+        // picks the real scheme per request, so a bearer token is read as a bearer
+        // token whether or not the attribute happened to name a role.
+        builder.Services.AddAuthentication(opts =>
+            {
+                opts.DefaultAuthenticateScheme = SmartAuthScheme;
+                opts.DefaultChallengeScheme = SmartAuthScheme;
+            })
+            .AddPolicyScheme(SmartAuthScheme, "Bearer when one is offered, cookie otherwise", opts =>
+            {
+                opts.ForwardDefaultSelector = context =>
+                    context.Request.Headers.Authorization.FirstOrDefault()
+                        ?.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) == true
+                            // The bearer handler has its own selector that sends locally
+                            // issued tokens on to LocalJwt, so this only has to choose
+                            // between "a token" and "a cookie".
+                            ? JwtBearerDefaults.AuthenticationScheme
+                            : global::Innovayse.Auth.CookieSessionHandler.SchemeName;
+            });
 
         // The cookie principal carries the SSO's claims; the roles live in this
         // database. The transformation maps one onto the other.

--- a/backend/tests/Innovayse.Integration.Tests/Auth/SsoModeAuthenticationSchemeTests.cs
+++ b/backend/tests/Innovayse.Integration.Tests/Auth/SsoModeAuthenticationSchemeTests.cs
@@ -1,0 +1,132 @@
+namespace Innovayse.Integration.Tests.Auth;
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+/// <summary>
+/// Boots the API the way a deployment whose people live in the SSO boots it, and checks
+/// which authentication scheme a request is measured against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rest of this suite runs <c>Auth:Mode=local</c>, deliberately — it creates its users
+/// through <c>POST /api/auth/register</c>, which only exists there. The cost of that is
+/// that nothing exercised the SSO mode's authentication wiring, and a bug lived in it for
+/// five days: registering the platform cookie handler made the cookie the default scheme,
+/// so every <c>[Authorize(Roles = …)]</c> endpoint — 85 of them — stopped reading the
+/// Authorization header. `[Authorize]` on its own kept working, because it uses
+/// DefaultPolicy and that names all three schemes; naming a role makes MVC build its own
+/// policy, which carries none and falls back to the default. The client portal calls this
+/// API with a bearer token, so its dashboard rendered empty against a 401 that said
+/// nothing.
+/// </para>
+/// <para>
+/// These two tests are the cheapest thing that would have caught it. They assert the
+/// decision rather than a response, so they need no SSO to talk to.
+/// </para>
+/// </remarks>
+public sealed class SsoModeAuthenticationSchemeTests : IAsyncLifetime
+{
+    private const string SmartAuthScheme = "InnovayseSmart";
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder()
+        .WithImage("postgres:16-alpine")
+        .Build();
+
+    private WebApplicationFactory<Program>? _factory;
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        _factory = new SsoModeFactory(_postgres.GetConnectionString());
+        // Force the host to build. Nothing is requested over HTTP: what is under test is
+        // how the container was composed, not how it answers.
+        _ = _factory.Services;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _factory?.Dispose();
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public void TheDefaultSchemeIsTheSelector_NotTheCookie()
+    {
+        var options = _factory!.Services.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
+
+        options.DefaultAuthenticateScheme.Should().Be(SmartAuthScheme);
+        options.DefaultChallengeScheme.Should().Be(SmartAuthScheme);
+    }
+
+    [Theory]
+    [InlineData("Bearer eyJhbGciOiJSUzI1NiJ9.e30.x", JwtBearerDefaults.AuthenticationScheme)]
+    [InlineData(null, Innovayse.Auth.CookieSessionHandler.SchemeName)]
+    [InlineData("", Innovayse.Auth.CookieSessionHandler.SchemeName)]
+    [InlineData("Basic dXNlcjpwYXNz", Innovayse.Auth.CookieSessionHandler.SchemeName)]
+    public async Task TheSelectorSendsABearerToTheBearerHandlerAndEverythingElseToTheCookie(
+        string? authorization, string expected)
+    {
+        var provider = _factory!.Services.GetRequiredService<IAuthenticationSchemeProvider>();
+        var scheme = await provider.GetSchemeAsync(SmartAuthScheme);
+        scheme.Should().NotBeNull("the selector scheme has to exist for anything below to mean anything");
+
+        var options = _factory.Services
+            .GetRequiredService<IOptionsMonitor<PolicySchemeOptions>>()
+            .Get(SmartAuthScheme);
+
+        var context = new DefaultHttpContext();
+        if (authorization is not null) context.Request.Headers.Authorization = authorization;
+
+        options.ForwardDefaultSelector!(context).Should().Be(expected);
+    }
+
+    /// <summary>Boots Program.cs with the settings an SSO-owned deployment supplies.</summary>
+    private sealed class SsoModeFactory(string connectionString) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+
+            // UseSetting rather than ConfigureAppConfiguration, for the reason spelled out
+            // in IntegrationTestFactory: Program.cs is top-level code and reads these while
+            // composing the builder, before ConfigureAppConfiguration's sources exist.
+            builder.UseSetting("Auth:Mode", "sso");
+            // Base64 of 32 bytes, not 32 characters — AddInfrastructure decodes it and
+            // refuses anything that is not exactly a 256-bit key. Same value the rest of
+            // the suite uses.
+            builder.UseSetting("EncryptionKey", "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=");
+
+            // AddInnovayseAuth validates that each of these is present and refuses to start
+            // naming the one that is missing. None is contacted while the host is built —
+            // the bearer handler fetches discovery lazily, on the first token it is asked
+            // to validate, and no test here presents one.
+            builder.UseSetting("Auth:AppName", "hostpanel");
+            builder.UseSetting("Auth:Authority", "https://sso.invalid");
+            builder.UseSetting("Auth:PublicAuthority", "https://sso.invalid");
+            builder.UseSetting("Auth:ClientId", "hostpanel");
+            builder.UseSetting("Auth:ClientSecret", "test-secret");
+            builder.UseSetting("Auth:RedisConnection", "localhost:6379");
+            builder.UseSetting("Sso:Authority", "https://sso.invalid");
+            builder.UseSetting("Sso:ClientId", "hostpanel");
+            builder.UseSetting("Sso:ServiceKey", "test-service-key");
+
+            builder.ConfigureAppConfiguration((_, config) =>
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = connectionString,
+                }));
+        }
+    }
+}


### PR DESCRIPTION
… header

The client portal has shown every customer an empty dashboard since 17 August. Signing in worked, the session was real, and every request for the data on the page came back 401 — with no WWW-Authenticate to say why and nothing in the log but a routine "InnovayseCookie was challenged".

Registering the platform cookie handler made it the default scheme. That is the whole bug, and it hid in the difference between the default POLICY and the default SCHEME:

  [Authorize]                    resolves DefaultPolicy, which names all three
                                 schemes, so it kept working.
  [Authorize(Roles = "Client")]  does not. Naming a role makes MVC build a
                                 policy on the spot; that policy carries no
                                 schemes and falls back to the default one.

There are 85 role-annotated endpoints, so all 85 stopped accepting bearer tokens. The admin SPA was unaffected — it authenticates with the cookie that had become the default — which is why this looked like nothing was wrong. The client portal's Nuxt server calls this API with an SSO bearer token, so /api/me/* refused all of it.

Fixed once rather than 85 times: a policy scheme now stands in front, and picks the real scheme per request — bearer handler when a bearer token is offered, the cookie otherwise. The bearer handler's own selector still forwards locally issued tokens to LocalJwt, so nothing about standalone mode changes.

Covered by the first tests in this repository that boot the API in SSO mode. The other 53 integration tests run Auth:Mode=local on purpose — they create users through POST /api/auth/register, which exists only there — and that is exactly why nothing caught this. The new ones assert the default scheme and the selector's choice, and need no SSO to talk to.

## Summary

<!-- What does this PR do? Why? -->

## Related Issue

Closes #

## Changes

-
-

## Checklist

- [ ] Code follows the style rules (`rules/` folder)
- [ ] `dotnet format` run (backend changes)
- [ ] XML docs added to all new C# members
- [ ] JSDoc added to all new exported TypeScript/Vue functions
- [ ] No hardcoded secrets or credentials
- [ ] Tested locally
