### PR TITLE
fix(portal): restore live chat functionality

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -25,42 +25,42 @@ injectSchema([
   websiteSchema()
 ])
 
-// Close Innochat widget when clicking outside it
+// Close the live chat widget when clicking outside it
 onMounted(() => {
   document.addEventListener('click', (e: MouseEvent) => {
     const target = e.target as HTMLElement
-    const widget = document.querySelector('.woot-widget-holder')
+    const widget = document.querySelector(LIVE_CHAT_HOLDER_SELECTOR)
     if (widget && !widget.contains(target)) {
-      const w = window as any
-      try { w.$chatwoot?.toggle('close') } catch {}
+      closeLiveChat(window)
     }
   })
 })
 
 const langMap: Record<string, string> = { en: 'en', ru: 'ru', hy: 'hy' }
+
+/** Website token for the default locale, and the fallback for any other. */
+const DEFAULT_CHAT_TOKEN = '9J2djCS9C979cK8qH55SKQgJ'
+
 const tokenMap: Record<string, string> = {
-  en: '9J2djCS9C979cK8qH55SKQgJ',
+  en: DEFAULT_CHAT_TOKEN,
   ru: 'UkwaS1xyNnNRv8SDj4kpNn2t',
   hy: 'aMzynyMYGE9p3oxwwUuMMEVa'
 }
 
-// Reactively update Innochat when locale changes
-watch(locale, (newLocale) => {
-  if (!process.client) return
-  
-  const apiLocale = langMap[newLocale] || 'en'
-  const w = window as any
+/** Language name recorded on the conversation, so an agent knows how to answer. */
+const languageOf = (code: string) =>
+  code === 'hy' ? 'Armenian' : code === 'ru' ? 'Russian' : 'English'
 
-  if (w.$chatwoot) {
-    w.$chatwoot.setLocale(apiLocale)
-    w.$chatwoot.setCustomAttributes({
-      language: newLocale === 'hy' ? 'Armenian' : newLocale === 'ru' ? 'Russian' : 'English'
-    })
-  }
+// Tell a widget that is already running about a locale change. A widget that is
+// not running is not an error here — the visitor may simply not have opened it.
+watch(locale, (newLocale) => {
+  if (!import.meta.client) return
+
+  setLiveChatLocale(window, langMap[newLocale] || 'en', languageOf(newLocale))
 })
 
 // Correct token for SSR injection
-const currentToken = computed(() => tokenMap[locale.value] ?? tokenMap.en)
+const currentToken = computed(() => tokenMap[locale.value] ?? DEFAULT_CHAT_TOKEN)
 
 useHead({
   htmlAttrs: {
@@ -73,28 +73,16 @@ useHead({
       tagPosition: 'head'
     },
     {
-      // Chatwoot live chat widget loader - SSR Injected token
-      innerHTML: `window.chatwootSettings = {"position":"right","type":"standard","launcherTitle":"","hideMessageBubble":true};
-      (function(d,t){
-        var BASE_URL="https://chat.innovayse.com";
-        var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-        g.src=BASE_URL+"/packs/js/sdk.js";
-        g.async=true;
-        s.parentNode.insertBefore(g,s);
-        g.onload=function(){
-          if (!window.chatwootSDK) return;
-          window.chatwootSDK.run({
-            websiteToken: '${currentToken.value}',
-            baseUrl: BASE_URL
-          });
-          window.addEventListener('chatwoot:ready', function() {
-            window.$chatwoot.setLocale('${langMap[locale.value] || 'en'}');
-            window.$chatwoot.setCustomAttributes({
-              language: '${locale.value === 'hy' ? 'Armenian' : locale.value === 'ru' ? 'Russian' : 'English'}'
-            });
-          });
-        }
-      })(document,"script");`,
+      // Live chat widget loader. The globals it drives are named in
+      // utils/liveChat.ts rather than inline, because the provider is an
+      // Innochat build whose SDK shares none of Chatwoot's global names, and
+      // reaching for the wrong one fails without an error.
+      innerHTML: buildLiveChatLoader({
+        baseUrl: 'https://chat.innovayse.com',
+        websiteToken: currentToken.value,
+        locale: langMap[locale.value] || 'en',
+        language: languageOf(locale.value)
+      }),
       type: 'text/javascript',
       tagPosition: 'bodyClose'
     },

--- a/client/components/ui/FloatingActions.vue
+++ b/client/components/ui/FloatingActions.vue
@@ -1,6 +1,12 @@
 <template>
   <!-- Floating Action Button — Peafowl fan-out -->
-  <div ref="fabRef" class="fixed bottom-6 right-6 z-50">
+  <!--
+    z-[60] rather than z-50: UiCookieBanner is a full-width bar fixed to the same
+    corner at z-50, and being later in the document it took every click meant for
+    this button until it was dismissed. The button stayed visible the whole time,
+    which is the worst version of the problem — it looked live and was not.
+  -->
+  <div ref="fabRef" class="fixed bottom-6 right-6 z-[60]">
 
     <!-- Fan-out sub-buttons -->
     <div class="absolute bottom-0 right-0">
@@ -15,10 +21,10 @@
         leave-to-class="opacity-0 scale-0"
       >
         <button
-          v-if="isOpen && chatProvider === 'chatwoot'"
+          v-if="isOpen && liveChatEnabled"
           class="group absolute bottom-0 right-0 flex items-center justify-center"
           style="transform: translate(-5px, -75px); transition-delay: 0ms;"
-          aria-label="Live Chat"
+          :aria-label="$t('contact.info.quickConnect.liveChat')"
           @click.stop="openChat"
         >
           <span class="absolute right-full mr-2 px-2.5 py-1 bg-gray-900/90 text-white text-xs font-medium rounded-lg whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
@@ -104,6 +110,7 @@
       class="relative w-12 h-12 rounded-full flex items-center justify-center shadow-2xl transition-all duration-300 hover:scale-110 focus:outline-none"
       :class="isOpen ? 'bg-gray-700 rotate-45' : 'bg-gradient-to-br from-cyan-500 to-primary-600'"
       :style="isOpen ? '' : 'box-shadow: 0 4px 24px rgba(6,182,212,0.5);'"
+      :aria-expanded="isOpen"
       aria-label="Contact us"
       @click="isOpen = !isOpen"
     >
@@ -132,8 +139,19 @@ function handleOutsideClick(e: MouseEvent) {
   }
 }
 
-onMounted(() => document.addEventListener('click', handleOutsideClick))
-onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
+/** Escape closes the fan-out, the keyboard equivalent of clicking away from it. */
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === 'Escape') isOpen.value = false
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick)
+  document.addEventListener('keydown', handleEscape)
+})
+onUnmounted(() => {
+  document.removeEventListener('click', handleOutsideClick)
+  document.removeEventListener('keydown', handleEscape)
+})
 const defaultMessage = computed(() => t('whatsapp.defaultMessage'))
 
 // Contact channels come from the operator's settings rather than being baked in,
@@ -147,10 +165,33 @@ const telegramHandle = computed(() => getPortalSetting('portal.contact.telegram'
 /** Chat provider from configuration; empty hides the chat bubble. */
 const chatProvider = computed(() => getPortalSetting('portal.chat.provider', 'portalChatProvider'))
 
-/** Open Innochat widget */
+/**
+ * Whether to offer the live chat action.
+ *
+ * Both spellings are accepted. The provider is Innochat, which is what an
+ * operator configuring this today would reasonably write, but the setting has
+ * shipped seeded with `chatwoot` since the first release and existing installs
+ * have that value stored. Refusing it would have switched the widget off for
+ * every one of them on upgrade.
+ */
+const liveChatEnabled = computed(() =>
+  ['chatwoot', 'innochat'].includes(chatProvider.value.toLowerCase()))
+
+/**
+ * Opens the live chat widget.
+ *
+ * The widget is started by the loader in app.vue and exposes itself on the
+ * window; `openLiveChat` knows which global that is. It reports back rather
+ * than failing silently, and a failure is logged: a visitor clicking a chat
+ * button that does nothing has no way to tell that anything went wrong, and
+ * neither did anyone reading the console.
+ */
 function openChat() {
   isOpen.value = false
-  if (typeof window === 'undefined') return
-  ;(window as any).$chatwoot?.toggle('open')
+  if (!import.meta.client) return
+
+  if (!openLiveChat(window)) {
+    console.warn('[live chat] widget is not running; the SDK has not started it yet')
+  }
 }
 </script>

--- a/client/utils/liveChat.test.ts
+++ b/client/utils/liveChat.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  LIVE_CHAT_READY_EVENT,
+  buildLiveChatLoader,
+  closeLiveChat,
+  openLiveChat,
+  setLiveChatLocale,
+} from './liveChat'
+
+/**
+ * Stands in for the Innochat SDK bundle.
+ *
+ * Modelled on what the real bundle at the chat host actually does: it defines
+ * `window.innochatSDK`, and `run()` starts the widget, which some time later
+ * defines `window.$innochat` and fires `innochat:ready`. Nothing here knows
+ * about Chatwoot, which is the point — the bundle this application loads does
+ * not either.
+ *
+ * The delay is why `fireReady` is separate rather than being called from inside
+ * `run`: the loader registers its listener after calling `run`, and a stub that
+ * fired the event synchronously would fail a loader that is correct.
+ *
+ * @param win The fake window the loader is run against.
+ * @returns The widget the SDK creates, and a trigger for its ready event.
+ */
+const installSdk = (win: Record<string, any>) => {
+  const widget = {
+    toggle: vi.fn(),
+    setLocale: vi.fn(),
+    setCustomAttributes: vi.fn(),
+  }
+
+  win.innochatSDK = {
+    run: vi.fn((options: { websiteToken: string, baseUrl: string }) => {
+      win.$innochat = widget
+      return options
+    }),
+  }
+
+  const fireReady = () => {
+    for (const listener of win.__listeners[LIVE_CHAT_READY_EVENT] ?? []) listener()
+  }
+
+  return { widget, fireReady }
+}
+
+/**
+ * Runs a loader script the way a browser would.
+ *
+ * The script is executed with `window` and `document` as parameters, so the
+ * free variables it references resolve to these stubs. The stub document
+ * records the script element the loader inserts, which is what lets the test
+ * fire its `onload` at the right moment.
+ *
+ * @param source Loader source from {@link buildLiveChatLoader}.
+ */
+const runLoader = (source: string) => {
+  const inserted: any[] = []
+  const firstScript = { parentNode: { insertBefore: (node: any) => inserted.push(node) } }
+
+  const win: Record<string, any> = {
+    __listeners: {} as Record<string, Array<() => void>>,
+    addEventListener(event: string, listener: () => void) {
+      (this.__listeners[event] ??= []).push(listener)
+    },
+  }
+
+  const doc = {
+    createElement: () => ({}) as Record<string, any>,
+    getElementsByTagName: () => [firstScript],
+  }
+
+  // eslint-disable-next-line no-new-func -- executing the built source is the point of the test
+  new Function('window', 'document', source)(win, doc)
+
+  return { win, script: inserted[0] as Record<string, any> }
+}
+
+const OPTIONS = {
+  baseUrl: 'https://chat.example.com',
+  websiteToken: 'test-token',
+  locale: 'hy',
+  language: 'Armenian',
+}
+
+describe('buildLiveChatLoader', () => {
+  it('fetches the SDK from the configured chat host', () => {
+    const { script } = runLoader(buildLiveChatLoader(OPTIONS))
+
+    expect(script.src).toBe('https://chat.example.com/packs/js/sdk.js')
+    expect(script.async).toBe(true)
+  })
+
+  it('starts the widget once the SDK bundle has loaded', () => {
+    const { win, script } = runLoader(buildLiveChatLoader(OPTIONS))
+    const { widget } = installSdk(win)
+
+    // Nothing has started the widget yet: the bundle has only just arrived.
+    expect(win.$innochat).toBeUndefined()
+
+    script.onload()
+
+    // This is the assertion the old loader failed. It looked for a Chatwoot
+    // global the Innochat bundle never defines, returned early, and left the
+    // page with a chat button wired to an API that was never created.
+    expect(win.innochatSDK.run).toHaveBeenCalledWith({
+      websiteToken: 'test-token',
+      baseUrl: 'https://chat.example.com',
+    })
+    expect(win.$innochat).toBe(widget)
+  })
+
+  it('hands the widget the visitor\'s language once it is ready', () => {
+    const { win, script } = runLoader(buildLiveChatLoader(OPTIONS))
+    const { widget, fireReady } = installSdk(win)
+
+    script.onload()
+    fireReady()
+
+    expect(widget.setLocale).toHaveBeenCalledWith('hy')
+    expect(widget.setCustomAttributes).toHaveBeenCalledWith({ language: 'Armenian' })
+  })
+
+  it('does nothing when the bundle fails to define its SDK', () => {
+    const { win, script } = runLoader(buildLiveChatLoader(OPTIONS))
+
+    expect(() => script.onload()).not.toThrow()
+    expect(win.$innochat).toBeUndefined()
+  })
+})
+
+describe('openLiveChat', () => {
+  it('opens the running widget and reports that it did', () => {
+    const win: Record<string, any> = {}
+    const widget = { toggle: vi.fn(), setLocale: vi.fn(), setCustomAttributes: vi.fn() }
+    win.$innochat = widget
+
+    expect(openLiveChat(win)).toBe(true)
+    expect(widget.toggle).toHaveBeenCalledWith('open')
+  })
+
+  it('reports failure rather than pretending, when the widget never started', () => {
+    // The whole bug in one line: the click handler used to reach for a global
+    // that was not there and say nothing about it.
+    expect(openLiveChat({})).toBe(false)
+  })
+
+  it('survives being called during server rendering, where there is no window', () => {
+    expect(openLiveChat(undefined)).toBe(false)
+  })
+})
+
+describe('closeLiveChat', () => {
+  it('closes the running widget', () => {
+    const widget = { toggle: vi.fn(), setLocale: vi.fn(), setCustomAttributes: vi.fn() }
+
+    expect(closeLiveChat({ $innochat: widget })).toBe(true)
+    expect(widget.toggle).toHaveBeenCalledWith('close')
+  })
+
+  it('reports failure when there is no widget', () => {
+    expect(closeLiveChat({})).toBe(false)
+  })
+})
+
+describe('setLiveChatLocale', () => {
+  it('passes the locale and the language on to a running widget', () => {
+    const widget = { toggle: vi.fn(), setLocale: vi.fn(), setCustomAttributes: vi.fn() }
+
+    expect(setLiveChatLocale({ $innochat: widget }, 'ru', 'Russian')).toBe(true)
+    expect(widget.setLocale).toHaveBeenCalledWith('ru')
+    expect(widget.setCustomAttributes).toHaveBeenCalledWith({ language: 'Russian' })
+  })
+
+  it('reports failure when there is no widget to tell', () => {
+    expect(setLiveChatLocale({}, 'ru', 'Russian')).toBe(false)
+  })
+})

--- a/client/utils/liveChat.ts
+++ b/client/utils/liveChat.ts
@@ -1,0 +1,166 @@
+/**
+ * Live chat widget integration.
+ *
+ * The provider is Innochat, self-hosted at the operator's own chat host. It is
+ * built from Chatwoot and keeps Chatwoot's DOM class names — `.woot-widget-holder`
+ * is still what the widget mounts into — but its SDK is rebranded all the way
+ * down and exposes none of Chatwoot's globals. Everything the page talks to is
+ * named here rather than spelled out at each call site, because the two sets
+ * differ by one word and the wrong one fails silently: `window.$chatwoot?.toggle()`
+ * on a page running Innochat is a no-op with no error, which is exactly how this
+ * went unnoticed.
+ */
+
+/** Global the SDK reads its configuration from, before it runs. */
+export const LIVE_CHAT_SETTINGS_GLOBAL = 'innochatSettings'
+
+/** Global the loaded SDK bundle defines. Carries `run()`. */
+export const LIVE_CHAT_SDK_GLOBAL = 'innochatSDK'
+
+/** Global the SDK creates once `run()` has started the widget. Carries the API. */
+export const LIVE_CHAT_API_GLOBAL = '$innochat'
+
+/** Event the SDK fires on `window` when the widget is ready to be called. */
+export const LIVE_CHAT_READY_EVENT = 'innochat:ready'
+
+/** Class the widget's container carries — inherited from Chatwoot, still emitted. */
+export const LIVE_CHAT_HOLDER_SELECTOR = '.woot-widget-holder'
+
+/** Path of the SDK bundle under the chat host. */
+export const LIVE_CHAT_SDK_PATH = '/packs/js/sdk.js'
+
+/** The subset of the widget API this application calls. */
+export interface LiveChatApi {
+  toggle: (state: 'open' | 'close') => void
+  setLocale: (locale: string) => void
+  setCustomAttributes: (attributes: Record<string, string>) => void
+}
+
+/** A window that may or may not have the widget running on it yet. */
+export interface LiveChatWindow {
+  [LIVE_CHAT_API_GLOBAL]?: LiveChatApi
+}
+
+/**
+ * Reads the widget API off a window, if the SDK has started it.
+ *
+ * The parameter is `unknown` rather than `LiveChatWindow` because the real
+ * argument is always the browser's own `Window`, which TypeScript will not
+ * accept for a type whose properties are all optional and none of which it
+ * declares. Narrowing here keeps the assertion in one place instead of at every
+ * call site, and the check below is a real one: the SDK adds this property at
+ * runtime, so nothing can prove it is there.
+ *
+ * @param win Window to look at; `undefined` during server rendering.
+ * @returns The API, or null when the widget is not running.
+ */
+const api = (win: unknown): LiveChatApi | null => {
+  const widget = (win as LiveChatWindow | undefined)?.[LIVE_CHAT_API_GLOBAL]
+
+  return typeof widget?.toggle === 'function' ? widget : null
+}
+
+/**
+ * Opens the widget.
+ *
+ * @param win The browser window.
+ * @returns Whether the widget was there to open. A false is worth acting on —
+ *   it means the visitor clicked a control that did nothing.
+ */
+export const openLiveChat = (win: unknown): boolean => {
+  const widget = api(win)
+  if (!widget) return false
+
+  widget.toggle('open')
+  return true
+}
+
+/**
+ * Closes the widget.
+ *
+ * @param win The browser window.
+ * @returns Whether the widget was there to close.
+ */
+export const closeLiveChat = (win: unknown): boolean => {
+  const widget = api(win)
+  if (!widget) return false
+
+  widget.toggle('close')
+  return true
+}
+
+/**
+ * Tells a running widget which language the visitor is reading the site in.
+ *
+ * @param win The browser window.
+ * @param locale Locale code the widget understands, e.g. `hy`.
+ * @param language Language name passed through as a conversation attribute, so
+ *   an agent picking the conversation up knows which language to answer in.
+ * @returns Whether the widget was running to be told.
+ */
+export const setLiveChatLocale = (
+  win: unknown,
+  locale: string,
+  language: string,
+): boolean => {
+  const widget = api(win)
+  if (!widget) return false
+
+  widget.setLocale(locale)
+  widget.setCustomAttributes({ language })
+  return true
+}
+
+/** Everything the loader needs to start the widget. */
+export interface LiveChatLoaderOptions {
+  /** Origin of the chat host, without a trailing slash. */
+  baseUrl: string
+  /** Website token identifying this site to the chat host. */
+  websiteToken: string
+  /** Locale code to hand the widget once it is ready. */
+  locale: string
+  /** Language name recorded on the conversation. */
+  language: string
+}
+
+/**
+ * Builds the inline script that loads the SDK and starts the widget.
+ *
+ * Returned as source rather than executed here because it is injected through
+ * `useHead` at `bodyClose`, so the fetch starts from the server-rendered HTML
+ * instead of waiting for hydration. Building it in a function is what lets the
+ * globals it names be asserted in a test — the previous version was a template
+ * literal inside `app.vue`, unreachable from anything that could have caught
+ * the names being wrong.
+ *
+ * The message bubble is suppressed: the floating contact button is the only way
+ * into the widget, so a second launcher would sit on top of it.
+ *
+ * @param options Chat host, token and language for this render.
+ * @returns JavaScript source, ready to inline.
+ */
+export const buildLiveChatLoader = ({
+  baseUrl,
+  websiteToken,
+  locale,
+  language,
+}: LiveChatLoaderOptions): string => `
+window.${LIVE_CHAT_SETTINGS_GLOBAL} = {"position":"right","type":"standard","launcherTitle":"","hideMessageBubble":true};
+(function(d,t){
+  var BASE_URL=${JSON.stringify(baseUrl)};
+  var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+  g.src=BASE_URL+${JSON.stringify(LIVE_CHAT_SDK_PATH)};
+  g.async=true;
+  s.parentNode.insertBefore(g,s);
+  g.onload=function(){
+    if (!window.${LIVE_CHAT_SDK_GLOBAL}) return;
+    window.${LIVE_CHAT_SDK_GLOBAL}.run({
+      websiteToken: ${JSON.stringify(websiteToken)},
+      baseUrl: BASE_URL
+    });
+    window.addEventListener(${JSON.stringify(LIVE_CHAT_READY_EVENT)}, function(){
+      window.${LIVE_CHAT_API_GLOBAL}.setLocale(${JSON.stringify(locale)});
+      window.${LIVE_CHAT_API_GLOBAL}.setCustomAttributes({ language: ${JSON.stringify(language)} });
+    });
+  }
+})(document,"script");`


### PR DESCRIPTION
The live chat button opened nothing. Not on nova — on every template, since the first open-source release.

## Root cause

The chat host at `chat.innovayse.com` serves **Innochat**, a Chatwoot fork rebranded all the way down. Its bundle defines `window.innochatSDK` and `window.$innochat`, reads `window.innochatSettings`, and fires `innochat:ready`. The word "chatwoot" does not appear anywhere in the payload.

The page was written against Chatwoot's names:

- The loader in `app.vue` fetched the bundle, checked `window.chatwootSDK`, found nothing and **returned before calling `run()`** — the widget was never started.
- The click handler then reached for `window.$chatwoot?.toggle('open')`, which optional-chained into a no-op.

No console error, no failed request, nothing in the network log. The button simply did nothing, which is why this survived unnoticed for so long.

## What changed

The contract now lives in one place, `client/utils/liveChat.ts`: `innochatSettings`, `innochatSDK`, `$innochat`, `innochat:ready`, and the `.woot-widget-holder` class the fork still emits. The loader is built by a function rather than spelled out as a template literal inside `app.vue`, which is what makes it testable at all — the previous version was unreachable from anything that could have caught the names being wrong.

`openLiveChat` returns whether the widget was there, and the caller logs when it was not. The next time this breaks, it will say so.

**`portal.chat.provider` accepts both `chatwoot` and `innochat`.** The backend seeds the former and existing installs have it stored, so refusing it would have switched the widget off for all of them on upgrade. No backend change was needed or made.

## Found alongside it, in the same control

- `UiCookieBanner` is fixed to the same corner at `z-50` and comes later in the document, so until it was dismissed it took **every click** aimed at the floating contact button — which stayed visible throughout. The button moves to `z-[60]`.
- The chat action's `aria-label` was a hard-coded English string while its own tooltip was already translated; the toggle never announced its state and could not be closed from the keyboard. Both fixed.

## Verification

`utils/liveChat.test.ts` executes the built loader against a stub bundle that behaves like the real one — `run()` creates `$innochat`, then `innochat:ready` fires separately, as it does in the browser. Against the old Chatwoot names **5 of its assertions fail**, so it is a real regression test rather than a check that a button exists in the DOM.

- **76/76 tests passed** across 9 files
- **`nuxt build` passed**
- Browser, on the built site with the widget enabled: desktop (1440×900) and mobile (390×844) both open the widget against the live chat host, which issues a real conversation token; keyboard path verified (`aria-expanded` false→true→false, Escape closes)
- **nova, aurora and classic all verified** — the fault was in shared code, so all three were broken and all three are fixed
- SSR renders 200 under all three templates; `window` is only touched behind client guards
- `vue-tsc` reports the same 231 pre-existing errors before and after, none in the changed files

No backend, database, auth or payment-flow changes.
