### PR TITLE
Merge develop into main: app launcher fetches from the main API

### DIFF
--- a/client/components/layout/AppLauncher.vue
+++ b/client/components/layout/AppLauncher.vue
@@ -10,9 +10,9 @@
     </button>
 
     <Transition name="launcher-panel">
-      <div v-if="open" class="absolute right-0 top-full pt-2 z-50">
-        <div class="w-72 rounded-xl overflow-hidden" style="background:rgba(17,24,39,0.97);border:1px solid rgba(255,255,255,0.1);box-shadow:0 25px 50px -12px rgba(0,0,0,0.5);backdrop-filter:blur(12px);">
-          <div class="grid grid-cols-2 gap-2 p-3">
+      <div v-if="open" class="launcher-panel-wrap">
+        <div class="launcher-panel-inner">
+          <div class="grid grid-cols-3 gap-2 p-3">
             <template v-for="app in apps" :key="app.id">
               <!-- Coming soon -->
               <div
@@ -71,16 +71,45 @@ const config = useRuntimeConfig()
 const open = ref(false)
 const rootEl = ref<HTMLElement | null>(null)
 
-const apps = computed(() => [
-  { id: 'account',   name: 'Account',   desc: 'Your profile & settings',      icon: 'lucide:user-circle', url: config.public.baseUrl + '/account',          comingSoon: false },
-  { id: 'tasks',     name: 'Tasks',     desc: 'Project & task management',     icon: 'lucide:list-checks', url: config.public.tasksUrl + '/auth/gitlab/',    comingSoon: false },
-  { id: 'erp',       name: 'ERP',       desc: 'Business & operations',         icon: 'lucide:building-2',  url: config.public.erpUrl + '/app',               comingSoon: false },
-  { id: 'sheets',    name: 'Sheets',    desc: 'Collaborative spreadsheets',    icon: 'lucide:table',       url: config.public.sheetsUrl,                     comingSoon: false },
-  { id: 'email',     name: 'Email',     desc: 'Read and send emails',          icon: 'lucide:mail',        url: config.public.emailUrl,                      comingSoon: false },
-  { id: 'drive',     name: 'Files',     desc: 'Files & collaboration',         icon: 'lucide:folder',      url: config.public.driveUrl,                      comingSoon: false },
-])
+interface AppEntry {
+  id: string
+  name: string
+  desc: string
+  icon: string
+  url: string
+  comingSoon: boolean
+}
 
-function toggle() { open.value = !open.value }
+const ICON_MAP: Record<string, string> = {
+  account:  'lucide:user-circle',
+  tasks:    'lucide:list-checks',
+  hostpanel:'lucide:server',
+  erp:      'lucide:building-2',
+  sheets:   'lucide:table',
+  email:    'lucide:mail',
+  docs:     'lucide:file-text',
+  calendar: 'lucide:calendar',
+  drive:    'lucide:hard-drive',
+}
+
+const apps = ref<AppEntry[]>([])
+
+async function fetchApps() {
+  try {
+    const data: AppEntry[] = await fetch(`${config.public.mainUrl}/api/portal/public/apps`).then(r => r.json())
+    apps.value = data.map((app: AppEntry) => ({
+      ...app,
+      icon: ICON_MAP[app.id] ?? 'lucide:box',
+    }))
+  } catch {
+    // API недоступен — оставляем пустой список
+  }
+}
+
+function toggle() {
+  open.value = !open.value
+  if (open.value && apps.value.length === 0) fetchApps()
+}
 
 function onClickOutside(e: MouseEvent) {
   if (open.value && rootEl.value && !rootEl.value.contains(e.target as Node)) {
@@ -104,6 +133,25 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.launcher-panel-wrap {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  padding-top: 8px;
+  z-index: 50;
+}
+
+.launcher-panel-inner {
+  width: min(360px, calc(100vw - 16px));
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(17, 24, 39, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(12px);
+}
+
+
 .launcher-panel-enter-active,
 .launcher-panel-leave-active {
   transition: opacity 0.15s ease, transform 0.15s ease;

--- a/client/components/layout/AppLauncher.vue
+++ b/client/components/layout/AppLauncher.vue
@@ -71,44 +71,11 @@ const config = useRuntimeConfig()
 const open = ref(false)
 const rootEl = ref<HTMLElement | null>(null)
 
-interface AppEntry {
-  id: string
-  name: string
-  desc: string
-  icon: string
-  url: string
-  comingSoon: boolean
-}
-
-const ICON_MAP: Record<string, string> = {
-  account:  'lucide:user-circle',
-  tasks:    'lucide:list-checks',
-  hostpanel:'lucide:server',
-  erp:      'lucide:building-2',
-  sheets:   'lucide:table',
-  email:    'lucide:mail',
-  docs:     'lucide:file-text',
-  calendar: 'lucide:calendar',
-  drive:    'lucide:hard-drive',
-}
-
-const apps = ref<AppEntry[]>([])
-
-async function fetchApps() {
-  try {
-    const data: AppEntry[] = await fetch(`${config.public.mainUrl}/api/portal/public/apps`).then(r => r.json())
-    apps.value = data.map((app: AppEntry) => ({
-      ...app,
-      icon: ICON_MAP[app.id] ?? 'lucide:box',
-    }))
-  } catch {
-    // API недоступен — оставляем пустой список
-  }
-}
+const { apps, fetchApps } = useAppLauncher()
 
 function toggle() {
   open.value = !open.value
-  if (open.value && apps.value.length === 0) fetchApps()
+  if (open.value) fetchApps()
 }
 
 function onClickOutside(e: MouseEvent) {

--- a/client/composables/useAppLauncher.ts
+++ b/client/composables/useAppLauncher.ts
@@ -1,0 +1,58 @@
+/**
+ * Composable for fetching the list of Innovayse apps from the central portal API.
+ *
+ * Apps are loaded lazily on the first call to `open()` and cached for the
+ * lifetime of the component. If the API is unreachable the list stays empty
+ * and the launcher renders nothing rather than crashing.
+ */
+
+/** A single app entry returned by the portal API. */
+export interface AppEntry {
+  id: string
+  name: string
+  desc: string
+  url: string
+  comingSoon: boolean
+}
+
+/** Maps app IDs to Lucide icon names. */
+const ICON_MAP: Record<string, string> = {
+  account:   'lucide:user-circle',
+  tasks:     'lucide:list-checks',
+  hostpanel: 'lucide:server',
+  erp:       'lucide:building-2',
+  sheets:    'lucide:table',
+  email:     'lucide:mail',
+  docs:      'lucide:file-text',
+  calendar:  'lucide:calendar',
+  drive:     'lucide:hard-drive',
+}
+
+/** @returns icon name for the given app id, falling back to a generic box icon. */
+export function appIcon(id: string): string {
+  return ICON_MAP[id] ?? 'lucide:box'
+}
+
+/**
+ * Fetches and caches the Innovayse app list from `/api/portal/public/apps`.
+ *
+ * @example
+ * const { apps, fetchApps } = useAppLauncher()
+ */
+export function useAppLauncher() {
+  const config = useRuntimeConfig()
+  const apps = ref<(AppEntry & { icon: string })[]>([])
+
+  /** Fetches apps from the portal API and populates `apps`. No-op if already loaded. */
+  async function fetchApps() {
+    if (apps.value.length > 0) return
+    try {
+      const data: AppEntry[] = await fetch(`${config.public.mainUrl}/api/portal/public/apps`).then(r => r.json())
+      apps.value = data.map(app => ({ ...app, icon: appIcon(app.id) }))
+    } catch {
+      // API unreachable — leave list empty
+    }
+  }
+
+  return { apps, fetchApps }
+}


### PR DESCRIPTION
Release of what has landed on develop since #122.

## What goes to main

- **#123** — AppLauncher no longer carries a hardcoded app list. It fetches
  `/api/portal/public/apps` from innovayse-main through a new `useAppLauncher`
  composable, maps app IDs to Lucide icons via `ICON_MAP`, loads lazily on first
  open, and the grid moves from 2 to 3 columns.

## Scope

2 files, +85 / -12:

- `client/components/layout/AppLauncher.vue`
- `client/composables/useAppLauncher.ts`

## Note

No CI ran on #123 (this repo only runs the branch-flow guard and the GitLab
mirror), and it was not verified against a live `/api/portal/public/apps`. If
that endpoint is not reachable from production, the launcher opens empty.