### PR TITLE
fix: standardize responsive breakpoints and mobile viewport handling

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Innovayse Admin</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/admin/src/assets/base.css
+++ b/admin/src/assets/base.css
@@ -59,7 +59,7 @@
 }
 
 body {
-  min-height: 100vh;
+  min-height: 100dvh;
   color: var(--color-text);
   background: var(--color-background);
   transition:

--- a/admin/src/components/layout/AppLayout.vue
+++ b/admin/src/components/layout/AppLayout.vue
@@ -28,7 +28,7 @@ function closeDrawer(): void {
 </script>
 
 <template>
-  <div class="flex min-h-screen bg-surface-base">
+  <div class="flex min-h-dvh bg-surface-base">
 
     <!-- Mobile backdrop -->
     <Transition name="fade">

--- a/admin/src/components/layout/AppSidebar.vue
+++ b/admin/src/components/layout/AppSidebar.vue
@@ -192,7 +192,7 @@ function isExpanded(item: NavItem): boolean {
 </script>
 
 <template>
-  <aside class="flex flex-col w-[220px] min-h-screen shrink-0 bg-surface-panel border-r border-border">
+  <aside class="flex flex-col w-[220px] min-h-dvh shrink-0 bg-surface-panel border-r border-border">
 
     <!-- Logo -->
     <div class="flex items-center px-5 py-[18px] border-b border-border">

--- a/admin/src/modules/auth/views/LoginView.vue
+++ b/admin/src/modules/auth/views/LoginView.vue
@@ -34,7 +34,7 @@ async function handleLogin(): Promise<void> {
 
 <template>
   <!-- Root: dark bg + ambient orbs -->
-  <div class="relative min-h-screen bg-surface-base flex items-center justify-center overflow-hidden">
+  <div class="relative min-h-dvh bg-surface-base flex items-center justify-center overflow-hidden">
 
     <!-- Orb blue (top-left) -->
     <div

--- a/admin/src/modules/auth/views/SetupView.vue
+++ b/admin/src/modules/auth/views/SetupView.vue
@@ -80,7 +80,7 @@ async function handleSetup(): Promise<void> {
 </script>
 
 <template>
-  <div class="relative min-h-screen bg-surface-base flex items-center justify-center overflow-hidden">
+  <div class="relative min-h-dvh bg-surface-base flex items-center justify-center overflow-hidden">
 
     <!-- Orb blue (top-left) -->
     <div

--- a/admin/src/modules/auth/views/VerifyEmailView.vue
+++ b/admin/src/modules/auth/views/VerifyEmailView.vue
@@ -51,7 +51,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="relative min-h-screen bg-surface-base flex items-center justify-center overflow-hidden">
+  <div class="relative min-h-dvh bg-surface-base flex items-center justify-center overflow-hidden">
 
     <!-- Orb blue (top-left) -->
     <div

--- a/admin/src/modules/clients/components/AddBillableItemModal.vue
+++ b/admin/src/modules/clients/components/AddBillableItemModal.vue
@@ -133,7 +133,7 @@ onMounted(() => fetchServices())
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       @click.self="emit('close')"
     >
-      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-lg p-6 space-y-4 max-h-[90dvh] overflow-y-auto">
         <div class="flex items-center justify-between">
           <h2 class="text-white font-semibold text-lg">Add Billable Item</h2>
           <button class="text-zinc-400 hover:text-white transition" @click="emit('close')">&#10005;</button>

--- a/admin/src/modules/clients/components/AddTimeBillingModal.vue
+++ b/admin/src/modules/clients/components/AddTimeBillingModal.vue
@@ -126,7 +126,7 @@ onMounted(() => fetchServices())
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       @click.self="emit('close')"
     >
-      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-4xl p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-4xl p-6 space-y-4 max-h-[90dvh] overflow-y-auto">
         <div class="flex items-center justify-between">
           <h2 class="text-white font-semibold text-lg">Add Time Billing Entries</h2>
           <button class="text-zinc-400 hover:text-white transition" @click="emit('close')">&#10005;</button>

--- a/admin/src/modules/clients/components/AddTransactionModal.vue
+++ b/admin/src/modules/clients/components/AddTransactionModal.vue
@@ -103,7 +103,7 @@ async function handleSave(): Promise<void> {
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       @click.self="emit('close')"
     >
-      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-2xl p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+      <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-2xl p-6 space-y-4 max-h-[90dvh] overflow-y-auto">
         <div class="flex items-center justify-between">
           <h2 class="text-white font-semibold text-lg">Add New Transaction</h2>
           <button class="text-zinc-400 hover:text-white transition" @click="emit('close')">&#10005;</button>

--- a/admin/src/modules/clients/components/ClientFormModal.vue
+++ b/admin/src/modules/clients/components/ClientFormModal.vue
@@ -326,7 +326,7 @@ onMounted(() => {
   <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
-    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[92vh] flex flex-col shadow-2xl">
+    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[92dvh] flex flex-col shadow-2xl">
 
       <!-- Header -->
       <div class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-border shrink-0">

--- a/admin/src/modules/clients/components/ContactFormModal.vue
+++ b/admin/src/modules/clients/components/ContactFormModal.vue
@@ -209,7 +209,7 @@ onMounted(() => {
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
     <!-- Modal -->
-    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90dvh] overflow-y-auto">
 
       <!-- Header -->
       <div class="px-6 pt-5 pb-4 border-b border-border flex items-center justify-between">

--- a/admin/src/modules/clients/components/DomainContactModal.vue
+++ b/admin/src/modules/clients/components/DomainContactModal.vue
@@ -78,7 +78,7 @@ function handleSave(): void {
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
     <!-- Modal -->
-    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90dvh] overflow-y-auto">
 
       <!-- Header -->
       <div class="px-6 pt-5 pb-4 border-b border-border flex items-center justify-between">

--- a/admin/src/modules/clients/components/UserFormModal.vue
+++ b/admin/src/modules/clients/components/UserFormModal.vue
@@ -117,7 +117,7 @@ function handleDelete(): void {
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
     <!-- Modal -->
-    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+    <div class="relative bg-surface-card border border-border rounded-2xl shadow-2xl w-full max-w-lg max-h-[90dvh] overflow-y-auto">
 
       <!-- Header -->
       <div class="px-6 pt-5 pb-4 border-b border-border">

--- a/admin/src/modules/servers/components/GroupFormModal.vue
+++ b/admin/src/modules/servers/components/GroupFormModal.vue
@@ -68,7 +68,7 @@ function handleSubmit(): void {
   <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
-    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto shadow-2xl">
+    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-lg max-h-[90dvh] overflow-y-auto shadow-2xl">
 
       <!-- Header -->
       <div class="flex items-center justify-between px-6 py-4 border-b border-border">

--- a/admin/src/modules/servers/components/ServerFormModal.vue
+++ b/admin/src/modules/servers/components/ServerFormModal.vue
@@ -181,7 +181,7 @@ function validate(): boolean {
   <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
-    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[92vh] flex flex-col shadow-2xl">
+    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[92dvh] flex flex-col shadow-2xl">
 
       <!-- Header -->
       <div class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-border shrink-0">

--- a/admin/src/modules/settings/components/ProductFormModal.vue
+++ b/admin/src/modules/settings/components/ProductFormModal.vue
@@ -189,7 +189,7 @@ function handleSubmit(): void {
   <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
 
-    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-2xl">
+    <div class="relative bg-surface-card border border-border rounded-2xl w-full max-w-2xl max-h-[90dvh] overflow-y-auto shadow-2xl">
 
       <!-- Header -->
       <div class="flex items-center justify-between px-6 py-4 border-b border-border">

--- a/admin/src/views/AboutView.vue
+++ b/admin/src/views/AboutView.vue
@@ -7,7 +7,7 @@
 <style>
 @media (min-width: 1024px) {
   .about {
-    min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     align-items: center;
   }

--- a/client/components/client/AddPaymentForm.vue
+++ b/client/components/client/AddPaymentForm.vue
@@ -249,7 +249,7 @@
         >
           <div
             v-if="showAddressModal"
-            class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white dark:bg-[#13131a] border border-gray-200 dark:border-white/10 shadow-2xl"
+            class="w-full max-w-2xl max-h-[90dvh] overflow-y-auto rounded-2xl bg-white dark:bg-[#13131a] border border-gray-200 dark:border-white/10 shadow-2xl"
           >
             <!-- Modal header -->
             <div class="flex items-center justify-between px-6 py-5 border-b border-gray-100 dark:border-white/10">

--- a/client/components/sections/Hero.vue
+++ b/client/components/sections/Hero.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="relative min-h-screen flex items-center justify-center bg-[#0a0a0f] overflow-hidden">
+  <section class="relative min-h-dvh flex items-center justify-center bg-[#0a0a0f] overflow-hidden">
     <!-- Animated background blobs -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">
       <!-- Large animated gradient blobs -->
@@ -291,24 +291,19 @@ function scrollToNextSection() {
 }
 
 .container-custom {
+  @apply w-full mx-auto px-4;
   max-width: 1400px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
-@media (min-width: 640px) {
+@screen sm {
   .container-custom {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    @apply px-6;
   }
 }
 
-@media (min-width: 1024px) {
+@screen lg {
   .container-custom {
-    padding-left: 3rem;
-    padding-right: 3rem;
+    @apply px-12;
   }
 }
 

--- a/client/components/sections/ProductsFullSlider.vue
+++ b/client/components/sections/ProductsFullSlider.vue
@@ -1,5 +1,5 @@
 <template>
-  <section ref="sectionRef" class="relative h-[75vh] sm:h-[85vh] md:h-screen w-full overflow-hidden">
+  <section ref="sectionRef" class="relative h-[75dvh] sm:h-[85dvh] md:h-dvh w-full overflow-hidden">
     <ClientOnly>
       <!-- SSR / pre-hydration hero — full first slide rendered immediately -->
       <template #fallback>

--- a/client/components/ui/Modal.vue
+++ b/client/components/ui/Modal.vue
@@ -13,7 +13,7 @@
         <!-- Modal container -->
         <div
           :class="modalClasses"
-          class="relative bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-h-[90vh] overflow-y-auto"
+          class="relative bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-h-[90dvh] overflow-y-auto"
           @click.stop
         >
           <!-- Header -->

--- a/client/composables/useAppLauncher.ts
+++ b/client/composables/useAppLauncher.ts
@@ -17,6 +17,7 @@ export interface AppEntry {
 
 /** Maps app IDs to Lucide icon names. */
 const ICON_MAP: Record<string, string> = {
+  home:      'lucide:home',
   account:   'lucide:user-circle',
   tasks:     'lucide:list-checks',
   hostpanel: 'lucide:server',

--- a/client/error.vue
+++ b/client/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center relative overflow-hidden">
     <!-- Background -->
     <div class="absolute inset-0 pointer-events-none">
       <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 via-transparent to-secondary-500/10" />

--- a/client/layouts/client.vue
+++ b/client/layouts/client.vue
@@ -106,7 +106,7 @@
               <slot />
             </template>
             <template #fallback>
-              <div class="flex items-center justify-center min-h-[40vh]">
+              <div class="flex items-center justify-center min-h-[40dvh]">
                 <div class="w-10 h-10 border-4 border-cyan-500/20 border-t-cyan-500 rounded-full animate-spin" />
               </div>
             </template>
@@ -223,10 +223,10 @@ async function handleLogout() {
 
 <style>
 /* Account panel responsive width on small screens */
-@media (max-width: 640px) {
+@media (max-width: 639px) {
   #inno-account-panel {
+    @apply right-[-4px];
     width: calc(100vw - 16px);
-    right: -4px;
   }
 }
 </style>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen flex flex-col bg-page">
+  <div class="min-h-dvh flex flex-col bg-page">
     <!-- Header supplied by the active template -->
     <component :is="header" />
 

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -213,7 +213,7 @@ export default defineNuxtConfig({
       title: 'Innovayse - Full-Cycle Digital Agency | Web Development, SEO, PPC',
       meta: [
         { charset: 'utf-8' },
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' },
         { name: 'description', content: 'Innovayse is a full-cycle digital agency specializing in web & mobile development, technical SEO, PPC advertising, and SaaS products. Transform your business with our expert solutions.' },
         { name: 'keywords', content: 'web development, mobile development, SEO, PPC, Google Ads, Yandex Direct, SaaS, digital agency, e-commerce development, technical SEO, content optimization' },
         { name: 'author', content: 'Innovayse' },

--- a/client/pages/acceptable-use.vue
+++ b/client/pages/acceptable-use.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f]">
+  <div class="min-h-dvh bg-[#0a0a0f]">
     <!-- Hero Section -->
     <section class="py-10 md:py-24 bg-[#0a0a0f] relative overflow-hidden">
       <!-- Background -->

--- a/client/pages/announcements/[id].vue
+++ b/client/pages/announcements/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-screen">
+    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-dvh">
       <div class="container-custom max-w-3xl">
 
         <!-- Back link -->

--- a/client/pages/client/accept-invite.vue
+++ b/client/pages/client/accept-invite.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
 
     <!-- ── Background (matches login/register pages) ──────────────────────── -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">

--- a/client/pages/client/account/index.vue
+++ b/client/pages/client/account/index.vue
@@ -556,7 +556,7 @@
         >
           <div
             v-if="editModal.open"
-            class="w-full max-w-2xl rounded-2xl bg-white dark:bg-[#13131a] border border-gray-200 dark:border-white/10 shadow-2xl flex flex-col max-h-[90vh]"
+            class="w-full max-w-2xl rounded-2xl bg-white dark:bg-[#13131a] border border-gray-200 dark:border-white/10 shadow-2xl flex flex-col max-h-[90dvh]"
           >
             <!-- Header -->
             <div class="flex items-center justify-between px-6 py-5 border-b border-gray-100 dark:border-white/10">
@@ -712,7 +712,7 @@
             </div>
 
             <!-- Body -->
-            <div class="px-6 py-5 grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-[65vh] overflow-y-auto">
+            <div class="px-6 py-5 grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-[65dvh] overflow-y-auto">
               <UiInput v-model="contactModal.firstname" :label="$t('client.profile.firstName')" type="text" size="sm" required />
               <UiInput v-model="contactModal.lastname"  :label="$t('client.profile.lastName')"  type="text" size="sm" required />
               <div class="sm:col-span-2">

--- a/client/pages/client/confirm-email.vue
+++ b/client/pages/client/confirm-email.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
     <div class="absolute inset-0 overflow-hidden pointer-events-none">
       <div class="absolute top-0 left-1/4 w-[500px] h-[500px] bg-primary-500/30 rounded-full blur-[120px] animate-blob" />
       <div class="absolute inset-0" style="background: radial-gradient(circle at center, transparent 40%, #0a0a0f 100%)" />

--- a/client/pages/client/forgot-password.vue
+++ b/client/pages/client/forgot-password.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
     <div class="absolute inset-0 overflow-hidden pointer-events-none">
       <div class="absolute top-0 left-1/4 w-[500px] h-[500px] bg-primary-500/30 rounded-full blur-[120px] animate-blob" />
       <div class="absolute inset-0" style="background: radial-gradient(circle at center, transparent 40%, #0a0a0f 100%)" />

--- a/client/pages/client/forgot.vue
+++ b/client/pages/client/forgot.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
 
     <!-- ── Background ─────────────────────────────────────────────────────── -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">

--- a/client/pages/client/login.vue
+++ b/client/pages/client/login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
 
     <!-- ── Background ─────────────────────────────────────────────────── -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">

--- a/client/pages/client/order-success.vue
+++ b/client/pages/client/order-success.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-[60vh] flex items-center justify-center px-4">
+  <div class="min-h-[60dvh] flex items-center justify-center px-4">
     <div class="text-center max-w-md w-full">
       <!-- Success icon -->
       <div class="mx-auto w-20 h-20 rounded-full bg-green-500/10 flex items-center justify-center mb-6">

--- a/client/pages/client/register.vue
+++ b/client/pages/client/register.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
 
     <!-- Background -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">

--- a/client/pages/client/reset-password.vue
+++ b/client/pages/client/reset-password.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
+  <div class="min-h-dvh bg-[#0a0a0f] flex items-center justify-center px-4 py-16 relative overflow-hidden">
 
     <!-- ── Background ─────────────────────────────────────────────────────── -->
     <div class="absolute inset-0 overflow-hidden pointer-events-none">

--- a/client/pages/client/services/[id]/setup.vue
+++ b/client/pages/client/services/[id]/setup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-[60vh] flex items-center justify-center py-10">
+  <div class="min-h-[60dvh] flex items-center justify-center py-10">
     <div class="max-w-xl w-full">
       <!-- Loading State -->
       <div v-if="pending" class="text-center p-12">

--- a/client/pages/configure/[pid].vue
+++ b/client/pages/configure/[pid].vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f] py-10 md:py-16">
+  <div class="min-h-dvh bg-[#0a0a0f] py-10 md:py-16">
     <div class="container-custom max-w-6xl mx-auto">
 
       <!-- Back link -->

--- a/client/pages/cookie-policy.vue
+++ b/client/pages/cookie-policy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f]">
+  <div class="min-h-dvh bg-[#0a0a0f]">
     <!-- Hero Section -->
     <section class="py-10 md:py-24 bg-[#0a0a0f] relative overflow-hidden">
       <!-- Background -->

--- a/client/pages/knowledgebase/[id].vue
+++ b/client/pages/knowledgebase/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-screen">
+    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-dvh">
       <div class="container-custom max-w-3xl">
 
         <!-- Back link -->

--- a/client/pages/knowledgebase/category/[id].vue
+++ b/client/pages/knowledgebase/category/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-screen">
+    <section class="py-12 md:py-20 bg-[#0a0a0f] min-h-dvh">
       <div class="container-custom max-w-4xl">
 
         <!-- Back link -->

--- a/client/pages/payment/result.vue
+++ b/client/pages/payment/result.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-[60vh] flex items-center justify-center px-4 py-16">
+  <div class="min-h-[60dvh] flex items-center justify-center px-4 py-16">
     <div class="w-full max-w-md p-8 rounded-3xl bg-white/5 border border-white/10 text-center">
       <!-- Verifying -->
       <template v-if="state === 'verifying'">

--- a/client/pages/products/[product].vue
+++ b/client/pages/products/[product].vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="productData">
     <!-- Single Full Page Section -->
-    <section class="py-10 md:py-24 bg-[#0a0a0f] relative overflow-hidden min-h-screen">
+    <section class="py-10 md:py-24 bg-[#0a0a0f] relative overflow-hidden min-h-dvh">
       <!-- Animated Background -->
       <div class="absolute inset-0 pointer-events-none">
         <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 via-transparent to-secondary-500/10" />
@@ -233,7 +233,7 @@
   </div>
 
   <!-- 404 State -->
-  <div v-else class="min-h-screen flex items-center justify-center bg-[#0a0a0f]">
+  <div v-else class="min-h-dvh flex items-center justify-center bg-[#0a0a0f]">
     <div class="text-center">
       <Icon name="mdi:package-variant" class="text-6xl text-gray-600 mx-auto mb-4" />
       <h1 class="text-2xl font-bold text-white mb-2">{{ $t('products.notFound') }}</h1>

--- a/client/pages/refund-policy.vue
+++ b/client/pages/refund-policy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f]">
+  <div class="min-h-dvh bg-[#0a0a0f]">
     <!-- Hero Section -->
     <section class="py-10 md:py-24 bg-[#0a0a0f] relative overflow-hidden">
       <!-- Background -->

--- a/client/pages/trial/[product].vue
+++ b/client/pages/trial/[product].vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a0f]">
+  <div class="min-h-dvh bg-[#0a0a0f]">
     <!-- Hero -->
     <section class="relative py-20 md:py-32 overflow-hidden">
       <div class="absolute inset-0 pointer-events-none">

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -19,6 +19,14 @@ export default <Partial<Config>>{
     './error.vue',
   ],
   theme: {
+    screens: {
+      xs: '480px',
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
+    },
     extend: {
       colors: {
         primary: {

--- a/client/templates/aurora/pages/Checkout.vue
+++ b/client/templates/aurora/pages/Checkout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative mx-auto min-h-screen max-w-[1440px] overflow-hidden font-aurora text-tx">
+  <div class="relative mx-auto min-h-dvh max-w-[1440px] overflow-hidden font-aurora text-tx">
     <div
       class="pointer-events-none absolute -top-[280px] left-1/2 h-[600px] w-[1000px] -translate-x-1/2 bg-glow1"
     />

--- a/client/templates/classic/pages/Checkout.vue
+++ b/client/templates/classic/pages/Checkout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-[#0a0a10] text-white selection:bg-cyan-500/30">
+  <div class="min-h-dvh bg-[#0a0a10] text-white selection:bg-cyan-500/30">
     <!-- Hero Header -->
     <div class="relative py-12 md:py-20 overflow-hidden border-b border-white/5">
       <div class="absolute inset-0 pointer-events-none">


### PR DESCRIPTION
Summary
Standardize all responsive breakpoints and mobile viewport handling across every Innovayse product. Fixes layout issues on notched/Dynamic Island devices and mobile browsers where the address bar collapses.

Changes

- Add viewport-fit=cover to all products for env(safe-area-inset-*) support on notched devices
- Replace 100vh with 100dvh in all inline CSS styles across SSO, Email, Calendar, Hostpanel
- Replace h-screen/min-h-screen with h-dvh/min-h-dvh in all root layouts (~50 files)
- Replace arbitrary [Nvh] Tailwind values with [Ndvh] in modals and panels (Drive, Sheets, Docs, Main, Hostpanel, Email, SSO, Calendar)
- Add xs: 480px breakpoint to Tailwind configs (AI, Drive, Email, Docs)
- Standardize useBreakpoint composables with correct thresholds (Calendar, Docs, Drive, Sheets)
- Fix non-standard breakpoint in Sheets header-widget (380px → 479px)
- Fix semantic inversion of isPhone/isMobile in Sheets useBreakpoint
- Add mobile-scrollable Frappe settings section in ERP Avatar popup
- Fix search placeholder overflow in Calendar AppHeader

Checklist

- [x] Code follows the style rules (`rules/` folder)
- [x] No hardcoded secrets or credentials
- [x] Tested locally
