### PR TITLE
hotfix(client): resolve duplicate paymentError declaration blocking prod deploy

### DIFF
--- a/client/pages/client/account/index.vue
+++ b/client/pages/client/account/index.vue
@@ -479,7 +479,7 @@
         </UiCard>
 
 
-        <UiAlert v-if="paymentError" variant="error">{{ paymentError }}</UiAlert>
+        <UiAlert v-if="paymentActionError" variant="error">{{ paymentActionError }}</UiAlert>
         <UiAlert v-if="paymentSuccess" variant="success">{{ paymentSuccess }}</UiAlert>
       </template>
     </div>
@@ -1430,7 +1430,7 @@ const paymentError = computed<string | null>(() => {
 
 const removingId      = ref<number | null>(null)
 const settingDefaultId = ref<number | null>(null)
-const paymentError    = ref('')
+const paymentActionError = ref('')
 const paymentSuccess  = ref('')
 
 function openAddForm() {
@@ -1603,14 +1603,14 @@ async function savePaymentEdit() {
 
 async function setDefaultPaymentMethod(id: number) {
   settingDefaultId.value = id
-  paymentError.value = ''
+  paymentActionError.value = ''
   paymentSuccess.value = ''
   try {
     await apiFetch(`/api/portal/client/payment-methods/${id}`, { method: 'PUT', body: { set_as_default: true } })
     paymentSuccess.value = t('client.payment.defaultSet')
     refreshPayment()
   } catch {
-    paymentError.value = t('client.payment.defaultError')
+    paymentActionError.value = t('client.payment.defaultError')
   } finally {
     settingDefaultId.value = null
   }
@@ -1628,7 +1628,7 @@ function removePaymentMethod(id: number) {
 async function doRemovePaymentMethod(id: number) {
   confirmDialog.loading = true
   removingId.value      = id
-  paymentError.value    = ''
+  paymentActionError.value = ''
   paymentSuccess.value  = ''
   try {
     await apiFetch(`/api/portal/client/payment-methods/${id}`, { method: 'DELETE' })
@@ -1636,7 +1636,7 @@ async function doRemovePaymentMethod(id: number) {
     confirmDialog.open   = false
     refreshPayment()
   } catch {
-    paymentError.value = t('client.payment.removeError')
+    paymentActionError.value = t('client.payment.removeError')
     confirmDialog.open = false
   } finally {
     removingId.value      = null


### PR DESCRIPTION
## Summary
main's client build has been failing since #130 merged (Vue rejects a duplicate \`const paymentError\` declaration in \`client/pages/client/account/index.vue\`), which has silently blocked the pending prod deploy of everything in that merge, including the sso-mode 2FA fix and Auth:Mode centralization. Confirmed via GitLab pipeline 2795360173 (\`client:test\` failing on this exact error) and by testing prod directly -- \`sso-frontend\`/\`sso-api\` sibling deploys went out fine, but hostpanel's own containers are still 7 days old.

Same fix as #131 (targeting develop), applied directly to main since production is currently stuck on it.

## Test plan
- [ ] GitLab pipeline's \`client:test\` passes
- [ ] \`deploy:prod\` (manual) triggered once green