### PR TITLE
hotfix(client): merge WHMCS billing fields into the sso-mode profile

### DIFF
--- a/client/server/api/portal/client/me.get.ts
+++ b/client/server/api/portal/client/me.get.ts
@@ -27,6 +27,10 @@ export default defineEventHandler(async (event) => {
       email: data.email,
       phonenumber: data.phoneNumber ?? '',
       permissions: 8191,
+      // The account screen reads this straight off the profile rather than a dedicated
+      // status route (see the local-mode branch below for why); SSO's own profile
+      // names the same flag totpEnabled.
+      twoFactorEnabled: data.totpEnabled ?? false,
     }
   }
 

--- a/client/server/api/portal/client/me.get.ts
+++ b/client/server/api/portal/client/me.get.ts
@@ -2,8 +2,15 @@
  * GET /api/portal/client/me
  * Returns the authenticated client's profile.
  *
- * In SSO mode: proxies to the SSO /api/account/profile endpoint.
- * In local mode: calls the WHMCS-style C# backend /clients/me.
+ * In SSO mode: identity (name, email, 2FA) comes from SSO's own /api/account/profile --
+ * that is where sign-in and 2FA actually live, so it is the one source of truth for both.
+ * Billing fields (company, address, payment method, language, email preferences) still
+ * come from the WHMCS-style C# backend /clients/me, the same record `PUT` (below) writes
+ * to -- without this, a real sso-mode client's edits would save but never read back.
+ * A staff/admin identity with no linked client record (checked via /clients/me 400/404)
+ * gets identity fields only, with billing fields left at their empty defaults.
+ *
+ * In local mode: everything, including identity, comes from /clients/me.
  */
 // @ts-ignore
 export default defineEventHandler(async (event) => {
@@ -18,19 +25,41 @@ export default defineEventHandler(async (event) => {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
     if (!res.ok) throw createError({ statusCode: res.status })
-    const data = await res.json() as Record<string, unknown>
+    const identity = await res.json() as Record<string, unknown>
+
+    const billing = await internalApiCall<Record<string, unknown>>(event, '/clients/me')
+      .catch(() => null)
 
     return {
-      id: data.id,
-      firstname: data.firstName,
-      lastname: data.lastName,
-      email: data.email,
-      phonenumber: data.phoneNumber ?? '',
+      id: identity.id,
+      firstname: (billing?.firstName as string | undefined) ?? identity.firstName,
+      lastname: (billing?.lastName as string | undefined) ?? identity.lastName,
+      companyname: billing?.companyName,
+      email: identity.email,
+      phonenumber: (billing?.phone as string | undefined) ?? identity.phoneNumber ?? '',
+      address1: billing?.street,
+      address2: billing?.address2,
+      city: billing?.city,
+      state: billing?.state,
+      postcode: billing?.postCode,
+      country: billing?.country,
+      defaultgateway: billing?.paymentMethod,
+      language: 'english',
+      currency: undefined,
+      currencyprefix: '',
+      currencysuffix: '',
       permissions: 8191,
-      // The account screen reads this straight off the profile rather than a dedicated
-      // status route (see the local-mode branch below for why); SSO's own profile
-      // names the same flag totpEnabled.
-      twoFactorEnabled: data.totpEnabled ?? false,
+      email_preferences: billing && {
+        general: billing.notifyGeneral ? 1 : 0,
+        invoice: billing.notifyInvoice ? 1 : 0,
+        support: billing.notifySupport ? 1 : 0,
+        product: billing.notifyProduct ? 1 : 0,
+        domain: billing.notifyDomain ? 1 : 0,
+        affiliate: billing.notifyAffiliate ? 1 : 0,
+      },
+      // SSO owns sign-in and 2FA in this mode, so its totpEnabled -- not anything the
+      // client record might carry -- is the one answer for whether it's actually on.
+      twoFactorEnabled: identity.totpEnabled ?? false,
     }
   }
 


### PR DESCRIPTION
## Summary
Two related gaps in GET /api/portal/client/me's sso-mode branch, found while verifying the sso-mode 2FA fix live on prod via Playwright:

1. **Missing 2FA flag.** The response never included \`twoFactorEnabled\`, even though the account screen depends on it. SSO's own profile carries the same flag as \`totpEnabled\` -- never mapped across. Every sso-mode account showed "2FA Disabled" regardless of actual state. Confirmed live: enabling 2FA against SSO returns 204 and the QR/secret are real, but the badge never updated.

2. **Missing billing fields.** The sso branch only called SSO's \`/api/account/profile\` for identity (name, email) and never called \`/clients/me\` for company, address, payment method, language or email preferences -- even though \`PUT /api/portal/client/me\` (unconditionally, in both modes) writes those exact fields to that exact record. A real sso-mode client's edits saved but never read back.

Fix: merge identity fields from SSO (authoritative for email/2FA) with billing fields from \`/clients/me\` (authoritative for company/address/payment/language/prefs, matching what PUT writes to). An identity with no linked client record (e.g. staff/admin SSO accounts) gets identity fields only, exactly as before -- the \`/clients/me\` call is caught and billing fields fall back to empty defaults.

## Test plan
- [ ] Enable 2FA on an sso-mode account, reload /client/account, confirm badge reads "Enabled"
- [ ] Edit billing address/company/payment method as an sso-mode client with a linked WHMCS record, reload, confirm it reads back
- [ ] A staff/admin sso account with no client record still loads /client/account without error