### PR TITLE
Point the portal link at innovayse.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,7 @@ ADMIN_BASE_URL_PATH=/
 
 # ── Links to other products ──────────────────────────────────────────────────
 # Browser-facing addresses. A product left unset is hidden rather than broken.
-NUXT_PUBLIC_MAIN_URL=https://app.innovayse.com
+NUXT_PUBLIC_MAIN_URL=https://innovayse.com
 NUXT_PUBLIC_SHEETS_URL=https://sheets.innovayse.com
 NUXT_PUBLIC_EMAIL_URL=https://inbox.innovayse.com
 NUXT_PUBLIC_ERP_URL=http://erp.local


### PR DESCRIPTION
`innovayse.com` used to serve an older site from the VPS itself, with the portal at `app.innovayse.com`. The apex has been cut over to the prod stack — both hostnames now return byte-identical HTML — and `app.innovayse.com` is being pointed back at that older site.

One line: `NUXT_PUBLIC_MAIN_URL` in `.env.example`. Left alone, the launcher would send people to whatever ends up on the old hostname.