### PR TITLE
Promote develop to main: portal moves to the apex

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,7 @@ ADMIN_BASE_URL_PATH=/
 
 # ── Links to other products ──────────────────────────────────────────────────
 # Browser-facing addresses. A product left unset is hidden rather than broken.
-NUXT_PUBLIC_MAIN_URL=https://app.innovayse.com
+NUXT_PUBLIC_MAIN_URL=https://innovayse.com
 NUXT_PUBLIC_SHEETS_URL=https://sheets.innovayse.com
 NUXT_PUBLIC_EMAIL_URL=https://inbox.innovayse.com
 NUXT_PUBLIC_ERP_URL=http://erp.local


### PR DESCRIPTION
The launcher link follows `innovayse.com` now that the apex serves the portal and `app.innovayse.com` is being pointed back at the older site it replaced.