### PR TITLE
Published content for clients, quieter refusals, one identity fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,12 @@ ADMIN_BASE_URL_PATH=/
 
 # ── Links to other products ──────────────────────────────────────────────────
 # Browser-facing addresses. A product left unset is hidden rather than broken.
-NUXT_PUBLIC_MAIN_URL=https://innovayse.com
+# The portal. Named MAIN_APP_URL because it is the same value the SSO, docs,
+# calendar, sheets and email all need; docker-compose passes it on to the client as
+# NUXT_PUBLIC_MAIN_URL, which is the name Nitro needs to override the frozen
+# runtimeConfig default. SSO_CALLBACK_URL above is unrelated — that is this panel's
+# own route on its own hostname.
+MAIN_APP_URL=https://innovayse.com
 NUXT_PUBLIC_SHEETS_URL=https://sheets.innovayse.com
 NUXT_PUBLIC_EMAIL_URL=https://inbox.innovayse.com
 NUXT_PUBLIC_ERP_URL=http://erp.local

--- a/backend/src/Innovayse.API/ControlFlowExceptionLogFilter.cs
+++ b/backend/src/Innovayse.API/ControlFlowExceptionLogFilter.cs
@@ -1,0 +1,83 @@
+namespace Innovayse.API;
+
+using Innovayse.Application.Billing.Common;
+using Innovayse.Application.Clients.Common;
+using Innovayse.Application.Support.Common;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// Drops the one Error-level line Wolverine writes when a handler refuses a request by throwing
+/// a control-flow exception, so the only record of that refusal is the single Information line
+/// <see cref="ExceptionMiddleware"/> writes when it answers 404.
+/// <para>
+/// <b>Why this is a log filter and not Wolverine configuration.</b> Wolverine's
+/// <c>Executor.InvokeAsync</c> (and its <c>TracingExecutor</c> twin) opens its catch block with
+/// an unconditional <c>_logger.LogError(e, "Invocation of {Message} failed!", …)</c>, emitted
+/// <i>before</i> any failure rule is consulted. Nothing in WolverineFx 5.31.0 guards it: the
+/// error-handling policies (<c>OnException&lt;T&gt;().Discard()</c> and friends) only decide
+/// what happens after the line is already written, <c>Policies.MessageExecutionLogLevel</c> and
+/// <c>MessageSuccessLogLevel</c> address the start/stop and success lines rather than this one,
+/// and <c>InvokeTracing</c> only chooses between the two executors that both write it. Its
+/// logger category is the message type, so silencing the category would silence real faults in
+/// the same handler. The event therefore has to be recognised where it lands, in the sink.
+/// </para>
+/// <para>
+/// <b>Why this cannot hide a genuine failure.</b> Both conditions below must hold: the event
+/// must carry Wolverine's exact message template, and its exception must be <i>exactly</i> one
+/// of the three refusal types. A handler that throws anything else — including a real fault
+/// whose inner exception happens to be one of these — still reaches the sink at Error with its
+/// stack trace, as does <see cref="ExceptionMiddleware"/>'s own "Unhandled exception" line,
+/// which carries a different template.
+/// </para>
+/// <para>
+/// <b>How it fails.</b> If a Wolverine upgrade rewords that template, the filter stops matching
+/// and the noise comes back — it never starts swallowing something new. That is the intended
+/// direction to fail in, and it is why the template is matched literally rather than loosely.
+/// </para>
+/// <para>
+/// Registered as a singleton in the composition root and picked up by Serilog's
+/// <c>ReadFrom.Services()</c>, which collects every <see cref="ILogEventFilter"/> in the
+/// container. The Testing environment does not configure Serilog at all, so this is inert
+/// there.
+/// </para>
+/// </summary>
+public sealed class ControlFlowExceptionLogFilter : ILogEventFilter
+{
+    /// <summary>
+    /// Wolverine's message template for the line this filter exists to remove, copied verbatim
+    /// from <c>Wolverine.Runtime.Handlers.Executor.InvokeAsync</c> in WolverineFx 5.31.0.
+    /// Matching the template rather than the rendered text keeps the check independent of which
+    /// message was being invoked.
+    /// </summary>
+    private const string WolverineInvocationFailedTemplate = "Invocation of {Message} failed!";
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogEvent logEvent)
+    {
+        // Cheapest discriminators first; almost every event leaves on one of these three lines.
+        if (logEvent.Level != LogEventLevel.Error) return true;
+        if (logEvent.Exception is null) return true;
+        if (logEvent.MessageTemplate.Text != WolverineInvocationFailedTemplate) return true;
+
+        return !IsRefusal(logEvent.Exception);
+    }
+
+    /// <summary>
+    /// Whether the exception is one of the refusals a healthy system throws as a matter of
+    /// course: a staff identity that was never onboarded as a customer, or a caller asking for a
+    /// ticket or invoice that is not theirs.
+    /// </summary>
+    /// <param name="exception">The exception Wolverine caught.</param>
+    /// <returns>
+    /// <c>true</c> when the exception is exactly one of the refusal types, so its Error line may
+    /// be dropped; <c>false</c> for everything else, which must stay.
+    /// </returns>
+    private static bool IsRefusal(Exception exception) =>
+        // Exact type, deliberately: an exception that merely *wraps* one of these is a fault
+        // that happened while refusing, and losing its stack trace is the outcome this whole
+        // filter is written to avoid.
+        exception is ClientProfileNotFoundException
+            or TicketNotFoundException
+            or InvoiceNotFoundException;
+}

--- a/backend/src/Innovayse.API/Program.cs
+++ b/backend/src/Innovayse.API/Program.cs
@@ -350,6 +350,15 @@ try
         opts.Discovery.IncludeAssembly(typeof(Innovayse.Application.Clients.Commands.AcceptInvitation.AcceptInvitationCommand).Assembly);
     });
 
+    // Wolverine logs "Invocation of {Message} failed!" at Error, with a stack trace, for every
+    // exception a handler throws — unconditionally, before its own error-handling policies get a
+    // say, and there is no knob in WolverineFx 5.31.0 that changes that. A staff identity with no
+    // client row is not a fault, so four of those stack traces per client-dashboard load were
+    // making a healthy platform read as a failing one and would eventually bury a real error.
+    // This drops exactly that line for exactly those refusals; see the filter for why nothing
+    // else can be lost. Serilog's ReadFrom.Services() above collects it from the container.
+    builder.Services.AddSingleton<Serilog.Core.ILogEventFilter, ControlFlowExceptionLogFilter>();
+
     // Domain scheduled jobs — daily expiry check (09:00 UTC) and auto-renew (10:00 UTC)
     builder.Services.AddHostedService<DomainScheduledJobsStartup>();
 

--- a/backend/src/Innovayse.API/Support/KnowledgebaseController.cs
+++ b/backend/src/Innovayse.API/Support/KnowledgebaseController.cs
@@ -1,7 +1,7 @@
 namespace Innovayse.API.Support;
 
 using Innovayse.Application.Support.DTOs;
-using Innovayse.Application.Support.Queries.GetKbArticle;
+using Innovayse.Application.Support.Queries.GetPublishedKbArticle;
 using Innovayse.Application.Support.Queries.ListKbArticles;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -31,11 +31,20 @@ public sealed class KnowledgebaseController(IMessageBus bus) : ControllerBase
     /// <summary>Returns a single published knowledge base article.</summary>
     /// <param name="id">Article primary key.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The article DTO.</returns>
+    /// <returns>
+    /// The article DTO. An unpublished draft and a nonexistent id answer identically: this route
+    /// is anonymous and ids are sequential, so telling those apart would be a way to enumerate
+    /// the unpublished backlog.
+    /// </returns>
+    /// <remarks>
+    /// Dispatches <see cref="GetPublishedKbArticleQuery"/>, not <c>GetKbArticleQuery</c>. The
+    /// latter reads any row regardless of published state and is the admin read; sending it from
+    /// here served drafts to the public while the list above showed published rows only.
+    /// </remarks>
     [HttpGet("{id:int}")]
     public async Task<ActionResult<KbArticleDto>> GetByIdAsync(int id, CancellationToken ct)
     {
-        var dto = await bus.InvokeAsync<KbArticleDto>(new GetKbArticleQuery(id), ct);
+        var dto = await bus.InvokeAsync<KbArticleDto>(new GetPublishedKbArticleQuery(id), ct);
         return Ok(dto);
     }
 }

--- a/backend/src/Innovayse.API/Support/PublishedAnnouncementsController.cs
+++ b/backend/src/Innovayse.API/Support/PublishedAnnouncementsController.cs
@@ -1,0 +1,48 @@
+namespace Innovayse.API.Support;
+
+using Innovayse.Application.Common;
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Application.Support.Queries.ListPublishedAnnouncements;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine;
+
+/// <summary>
+/// The announcements feed the client portal reads.
+/// </summary>
+/// <remarks>
+/// A separate controller rather than a relaxed <c>[Authorize]</c> on <c>AnnouncementsController</c>:
+/// that class is admin surface end to end -- create, update, delete, and a read that returns
+/// drafts -- and authorization there is declared once for the whole class. Loosening it, even for
+/// the one GET, would put a client-reachable action on the same type as the writes and leave the
+/// next person adding an action there to notice that the class attribute no longer means what it
+/// says. The knowledge base already splits this way (<c>KnowledgebaseController</c> beside
+/// <c>KnowledgebaseAdminController</c>), and this follows it.
+/// <para>
+/// Authenticated rather than anonymous. This is the portal's "Recent News" card, and published
+/// does not have to mean world-readable; opening the feed to the internet is a content decision
+/// nobody has taken, whereas letting a signed-in customer read it is exactly the defect.
+/// </para>
+/// </remarks>
+/// <param name="bus">Wolverine message bus.</param>
+[ApiController]
+[Route("api/announcements/published")]
+[Authorize]
+public sealed class PublishedAnnouncementsController(IMessageBus bus) : ControllerBase
+{
+    /// <summary>Returns a paginated list of published announcements, newest first.</summary>
+    /// <param name="page">1-based page number (default 1).</param>
+    /// <param name="pageSize">Items per page (default 20).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Paginated published announcements, without the editorial published flag.</returns>
+    [HttpGet]
+    public async Task<ActionResult<PagedResult<PublishedAnnouncementDto>>> GetPublishedAsync(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var result = await bus.InvokeAsync<PagedResult<PublishedAnnouncementDto>>(
+            new ListPublishedAnnouncementsQuery(page, pageSize), ct);
+        return Ok(result);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/DTOs/PublishedAnnouncementDto.cs
+++ b/backend/src/Innovayse.Application/Support/DTOs/PublishedAnnouncementDto.cs
@@ -1,0 +1,17 @@
+namespace Innovayse.Application.Support.DTOs;
+
+/// <summary>
+/// The announcement projection a client is allowed to see.
+/// </summary>
+/// <remarks>
+/// Deliberately not <see cref="AnnouncementDto"/>. That record carries <c>IsPublished</c>, which
+/// is an editorial fact about the row rather than news for a customer: on a client route it is
+/// either always <see langword="true"/> and therefore noise, or -- worse -- evidence that a
+/// draft pipeline exists. Only published rows reach this type, so the flag has nothing left to
+/// say and is left out rather than pinned to a constant.
+/// </remarks>
+/// <param name="Id">The announcement identifier.</param>
+/// <param name="Title">The announcement title.</param>
+/// <param name="Content">The full announcement body content.</param>
+/// <param name="PublishedAt">UTC timestamp the announcement was created, shown as its date.</param>
+public record PublishedAnnouncementDto(int Id, string Title, string Content, DateTimeOffset PublishedAt);

--- a/backend/src/Innovayse.Application/Support/Queries/GetPublishedKbArticle/GetPublishedKbArticleHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/GetPublishedKbArticle/GetPublishedKbArticleHandler.cs
@@ -1,0 +1,42 @@
+namespace Innovayse.Application.Support.Queries.GetPublishedKbArticle;
+
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Application.Support.Queries.GetKbArticle;
+using Innovayse.Domain.Support.Interfaces;
+using Wolverine;
+
+/// <summary>
+/// Returns a knowledge base article only while it is published.
+/// </summary>
+/// <remarks>
+/// The check lives here rather than at the endpoint so it travels with the message: nothing can
+/// read an article through <see cref="GetPublishedKbArticleQuery"/> without it having run. Once
+/// visibility is settled the projection is the read the admin route already performs, so this
+/// dispatches <see cref="GetKbArticleQuery"/> rather than growing a second copy of the mapping
+/// that could drift from it.
+/// </remarks>
+/// <param name="repo">Article persistence, used for the visibility check only.</param>
+/// <param name="bus">Wolverine bus, used to reach the shared read once visibility is settled.</param>
+public sealed class GetPublishedKbArticleHandler(IKbArticleRepository repo, IMessageBus bus)
+{
+    /// <summary>Handles <see cref="GetPublishedKbArticleQuery"/>.</summary>
+    /// <param name="query">The query naming the article to read.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching <see cref="KbArticleDto"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the article does not exist and when it exists but is unpublished -- with the
+    /// same wording for both. Ids here are sequential, and answering "exists but is a draft"
+    /// differently from "no such row" would let a visitor map the unpublished backlog by id.
+    /// </exception>
+    public async Task<KbArticleDto> HandleAsync(GetPublishedKbArticleQuery query, CancellationToken ct)
+    {
+        var article = await repo.FindByIdAsync(query.Id, ct);
+
+        if (article is null || !article.IsPublished)
+        {
+            throw new InvalidOperationException($"KbArticle {query.Id} not found.");
+        }
+
+        return await bus.InvokeAsync<KbArticleDto>(new GetKbArticleQuery(query.Id), ct);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Queries/GetPublishedKbArticle/GetPublishedKbArticleQuery.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/GetPublishedKbArticle/GetPublishedKbArticleQuery.cs
@@ -1,0 +1,12 @@
+namespace Innovayse.Application.Support.Queries.GetPublishedKbArticle;
+
+/// <summary>Query to retrieve a knowledge base article that is published.</summary>
+/// <remarks>
+/// The public knowledge base route used to dispatch <c>GetKbArticleQuery</c>, which reads a row
+/// by id and never looks at its published state -- so an unpublished draft was one guessed id
+/// away from any anonymous visitor, even though the list beside it showed published rows only.
+/// This message is the client-facing half of that split; <c>GetKbArticleQuery</c> stays as the
+/// admin read that may return a draft.
+/// </remarks>
+/// <param name="Id">The article primary key.</param>
+public record GetPublishedKbArticleQuery(int Id);

--- a/backend/src/Innovayse.Application/Support/Queries/ListPublishedAnnouncements/ListPublishedAnnouncementsHandler.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListPublishedAnnouncements/ListPublishedAnnouncementsHandler.cs
@@ -1,0 +1,38 @@
+namespace Innovayse.Application.Support.Queries.ListPublishedAnnouncements;
+
+using Innovayse.Application.Common;
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Domain.Support.Interfaces;
+
+/// <summary>
+/// Returns a paged list of published announcements, newest first, for the client portal.
+/// </summary>
+/// <remarks>
+/// The published filter is applied by the repository, inside the same query that pages, so the
+/// page numbers and <c>TotalCount</c> describe the rows a client can actually see. Filtering a
+/// page after it had been fetched would leave drafts occupying slots and make pages look short
+/// for no visible reason.
+/// </remarks>
+/// <param name="repo">Announcement persistence.</param>
+public sealed class ListPublishedAnnouncementsHandler(IAnnouncementRepository repo)
+{
+    /// <summary>Handles <see cref="ListPublishedAnnouncementsQuery"/>.</summary>
+    /// <param name="query">The query with pagination. It carries no visibility switch.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A paged result of published announcements.</returns>
+    public async Task<PagedResult<PublishedAnnouncementDto>> HandleAsync(
+        ListPublishedAnnouncementsQuery query,
+        CancellationToken ct)
+    {
+        var page = Math.Max(1, query.Page);
+        var pageSize = Math.Clamp(query.PageSize, 1, 100);
+
+        var (announcements, totalCount) = await repo.ListPublishedAsync(page, pageSize, ct);
+
+        var items = announcements
+            .Select(a => new PublishedAnnouncementDto(a.Id, a.Title, a.Content, a.CreatedAt))
+            .ToList();
+
+        return new PagedResult<PublishedAnnouncementDto>(items, totalCount, page, pageSize);
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Queries/ListPublishedAnnouncements/ListPublishedAnnouncementsQuery.cs
+++ b/backend/src/Innovayse.Application/Support/Queries/ListPublishedAnnouncements/ListPublishedAnnouncementsQuery.cs
@@ -1,0 +1,12 @@
+namespace Innovayse.Application.Support.Queries.ListPublishedAnnouncements;
+
+/// <summary>Query to retrieve a paginated list of the announcements clients may read.</summary>
+/// <remarks>
+/// Carries no "include unpublished" switch. Which rows are visible is settled by the message
+/// type itself, not by a flag a caller could flip, so nothing dispatched through here can widen
+/// its own result set. The admin read that returns every row, drafts included, is a separate use
+/// case: <c>ListAnnouncementsQuery</c>.
+/// </remarks>
+/// <param name="Page">1-based page number.</param>
+/// <param name="PageSize">Number of items per page.</param>
+public record ListPublishedAnnouncementsQuery(int Page, int PageSize);

--- a/backend/src/Innovayse.Domain/Support/Interfaces/IAnnouncementRepository.cs
+++ b/backend/src/Innovayse.Domain/Support/Interfaces/IAnnouncementRepository.cs
@@ -34,4 +34,20 @@ public interface IAnnouncementRepository
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A tuple of the paged items and the total count across all pages.</returns>
     Task<(IReadOnlyList<Announcement> Items, int TotalCount)> ListAsync(int page, int pageSize, CancellationToken ct);
+
+    /// <summary>
+    /// Returns a paginated list of <em>published</em> announcements ordered by creation date
+    /// descending — the rows a client is allowed to see.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="ListAsync"/> rather than a boolean on it: the filter has to be
+    /// inside the query that pages, so <c>TotalCount</c> and the page numbers count only visible
+    /// rows, and a client-facing caller cannot reach the unfiltered set by passing the wrong
+    /// argument.
+    /// </remarks>
+    /// <param name="page">1-based page number.</param>
+    /// <param name="pageSize">Number of items per page.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A tuple of the paged published items and the total count of published rows.</returns>
+    Task<(IReadOnlyList<Announcement> Items, int TotalCount)> ListPublishedAsync(int page, int pageSize, CancellationToken ct);
 }

--- a/backend/src/Innovayse.Infrastructure/Support/AnnouncementRepository.cs
+++ b/backend/src/Innovayse.Infrastructure/Support/AnnouncementRepository.cs
@@ -33,4 +33,23 @@ public sealed class AnnouncementRepository(AppDbContext db) : IAnnouncementRepos
 
         return (items, totalCount);
     }
+
+    /// <inheritdoc/>
+    public async Task<(IReadOnlyList<Announcement> Items, int TotalCount)> ListPublishedAsync(
+        int page, int pageSize, CancellationToken ct)
+    {
+        // Filter before Count/Skip/Take so the totals and page boundaries describe published rows
+        // only; filtering a fetched page would leave drafts occupying slots.
+        var query = db.Announcements
+            .Where(a => a.IsPublished)
+            .OrderByDescending(a => a.CreatedAt);
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
 }

--- a/backend/tests/Innovayse.Application.Tests/Support/PublishedContentVisibilityTests.cs
+++ b/backend/tests/Innovayse.Application.Tests/Support/PublishedContentVisibilityTests.cs
@@ -1,0 +1,160 @@
+namespace Innovayse.Application.Tests.Support;
+
+using Innovayse.Application.Support.DTOs;
+using Innovayse.Application.Support.Queries.GetKbArticle;
+using Innovayse.Application.Support.Queries.GetPublishedKbArticle;
+using Innovayse.Application.Support.Queries.ListPublishedAnnouncements;
+using Innovayse.Domain.Support;
+using Innovayse.Domain.Support.Interfaces;
+using Moq;
+using Wolverine;
+using Xunit;
+
+/// <summary>
+/// Proves the client-facing announcement and knowledge base reads show clients what they may see
+/// and nothing else.
+/// <para>
+/// Before this, the portal's "Recent News" card called an endpoint that was
+/// <c>[Authorize(Roles = Roles.Admin)]</c>, so every real customer got 403 and an empty card. The
+/// obvious repair -- pointing the portal at the admin read -- would have traded a 403 for a leak:
+/// that read returns unpublished rows and the editorial <c>IsPublished</c> flag. These tests
+/// assert both halves: a client can read published announcements, and the projection they receive
+/// has no way to carry a draft or say that drafts exist. The knowledge base's public by-id route
+/// had the mirror-image fault and is covered here too.
+/// </para>
+/// </summary>
+public sealed class PublishedContentVisibilityTests
+{
+    /// <summary>The article id every knowledge base probe asks for.</summary>
+    private const int ArticleId = 12;
+
+    /// <summary>
+    /// A client asking for announcements gets the published ones, through a repository call that
+    /// cannot return a draft.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ListPublishedAnnouncements_ReturnsPublishedRows()
+    {
+        var repo = new Mock<IAnnouncementRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.ListPublishedAsync(1, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Announcement> { Announcement.Create("Maintenance", "Sunday 02:00 UTC", true) }, 1));
+
+        var result = await new ListPublishedAnnouncementsHandler(repo.Object)
+            .HandleAsync(new ListPublishedAnnouncementsQuery(1, 10), CancellationToken.None);
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("Maintenance", Assert.Single(result.Items).Title);
+
+        // MockBehavior.Strict already fails on any unconfigured call; naming ListAsync explicitly
+        // states the point: the client read never reaches the admin, unfiltered listing.
+        repo.Verify(r => r.ListAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.VerifyAll();
+    }
+
+    /// <summary>
+    /// The client read asks the repository for published rows only, so an unpublished
+    /// announcement has no path to the portal even if one exists alongside it.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task ListPublishedAnnouncements_NeverSeesDrafts()
+    {
+        var published = Announcement.Create("Released", "Visible", true);
+        var draft = Announcement.Create("Embargoed price rise", "Do not tell them yet", false);
+
+        var repo = new Mock<IAnnouncementRepository>();
+
+        // The repository is the boundary the filter lives behind: ListPublishedAsync answers with
+        // the published row alone, while the admin ListAsync would have handed over both.
+        repo.Setup(r => r.ListPublishedAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Announcement> { published }, 1));
+        repo.Setup(r => r.ListAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Announcement> { published, draft }, 2));
+
+        var result = await new ListPublishedAnnouncementsHandler(repo.Object)
+            .HandleAsync(new ListPublishedAnnouncementsQuery(1, 20), CancellationToken.None);
+
+        Assert.DoesNotContain(result.Items, a => a.Title == draft.Title);
+        Assert.Equal(1, result.TotalCount);
+    }
+
+    /// <summary>
+    /// The projection handed to a client carries no published/draft flag, while the admin one
+    /// still does. Asserted over the type rather than an instance so re-adding the field to the
+    /// client DTO breaks here rather than in production.
+    /// </summary>
+    [Fact]
+    public void PublishedAnnouncementDto_CarriesNoEditorialFlag()
+    {
+        var clientFields = typeof(PublishedAnnouncementDto).GetProperties().Select(p => p.Name).ToList();
+
+        Assert.DoesNotContain("IsPublished", clientFields);
+        Assert.DoesNotContain(typeof(PublishedAnnouncementDto).GetProperties(), p => p.PropertyType == typeof(bool));
+
+        // The split is only meaningful if the admin projection really does expose more.
+        Assert.Contains("IsPublished", typeof(AnnouncementDto).GetProperties().Select(p => p.Name));
+    }
+
+    /// <summary>
+    /// The public knowledge base route refuses an unpublished article, and refuses it without
+    /// performing the read that would have projected it.
+    /// </summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task GetPublishedKbArticle_RefusesDraft()
+    {
+        var draft = KbArticle.Create("Internal runbook", "root password rotation", "Ops");
+        Assert.False(draft.IsPublished);
+
+        var repo = new Mock<IKbArticleRepository>();
+        repo.Setup(r => r.FindByIdAsync(ArticleId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        var bus = new Mock<IMessageBus>(MockBehavior.Strict);
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new GetPublishedKbArticleHandler(repo.Object, bus.Object)
+                .HandleAsync(new GetPublishedKbArticleQuery(ArticleId), CancellationToken.None));
+
+        // Strict and unconfigured: the shared projection is never dispatched for a draft.
+        bus.Verify(b => b.InvokeAsync<KbArticleDto>(It.Is<object>(m => m is GetKbArticleQuery), It.IsAny<CancellationToken>(), It.IsAny<TimeSpan?>()), Times.Never);
+
+        var missing = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new GetPublishedKbArticleHandler(MissingArticleRepo(), bus.Object)
+                .HandleAsync(new GetPublishedKbArticleQuery(ArticleId), CancellationToken.None));
+
+        // Same wording for "draft" and "no such row": ids are sequential and this route is
+        // anonymous, so a distinguishable refusal is an enumeration oracle.
+        Assert.Equal(missing.Message, refusal.Message);
+    }
+
+    /// <summary>A published article still reaches the public route, through the shared projection.</summary>
+    /// <returns>The running test.</returns>
+    [Fact]
+    public async Task GetPublishedKbArticle_ReturnsPublishedArticle()
+    {
+        var article = KbArticle.Create("How to reset your password", "Click reset.", "Accounts");
+        article.Publish();
+
+        var repo = new Mock<IKbArticleRepository>();
+        repo.Setup(r => r.FindByIdAsync(ArticleId, It.IsAny<CancellationToken>())).ReturnsAsync(article);
+
+        var expected = new KbArticleDto(ArticleId, article.Title, article.Content, article.Category, true);
+        var bus = new Mock<IMessageBus>();
+        bus.Setup(b => b.InvokeAsync<KbArticleDto>(It.Is<object>(m => m is GetKbArticleQuery), It.IsAny<CancellationToken>(), It.IsAny<TimeSpan?>()))
+            .ReturnsAsync(expected);
+
+        var dto = await new GetPublishedKbArticleHandler(repo.Object, bus.Object)
+            .HandleAsync(new GetPublishedKbArticleQuery(ArticleId), CancellationToken.None);
+
+        Assert.Equal(expected, dto);
+    }
+
+    /// <summary>Builds a repository that knows of no article at <see cref="ArticleId"/>.</summary>
+    /// <returns>A repository answering <see langword="null"/>.</returns>
+    private static IKbArticleRepository MissingArticleRepo()
+    {
+        var repo = new Mock<IKbArticleRepository>();
+        repo.Setup(r => r.FindByIdAsync(ArticleId, It.IsAny<CancellationToken>())).ReturnsAsync((KbArticle?)null);
+        return repo.Object;
+    }
+}

--- a/client/layouts/client.vue
+++ b/client/layouts/client.vue
@@ -153,7 +153,10 @@ function widgetReinit() {
 
 onMounted(async () => {
   init()
-  if (!store.userLoaded) await store.fetchUser()
+  // No `userLoaded` check: the store is the one authority on whether this needs a request,
+  // and the flag read here answered "not loaded yet" for a request that was already on the
+  // wire — which is how the same page load asked for the identity more than once.
+  await store.fetchUser()
   // Reinit widget after Vue renders the mount points.
   // Poll until InnoWidget is available (script may still be loading with async).
   await nextTick()

--- a/client/pages/client/dashboard.vue
+++ b/client/pages/client/dashboard.vue
@@ -309,7 +309,13 @@ const whmcsUrl = config.public.whmcsUrl
 const store = useClientStore()
 await useAsyncData('client-dashboard', () => store.fetchAll())
 
-/** Announcements from WHMCS (public endpoint) */
+/**
+ * Published announcements for the "Recent News" card.
+ *
+ * The server route behind this returns only published rows and only `{ id, title, date }` —
+ * no draft rows and no editorial `isPublished` flag. It answered 403 for every customer until
+ * it was pointed away from the admin announcements controller.
+ */
 const { data: announcementsRaw } = await useFetch<Array<{ id: number; date: string; title: string }>>(
   '/api/portal/public/announcements'
 )

--- a/client/server/api/portal/public/announcements.get.ts
+++ b/client/server/api/portal/public/announcements.get.ts
@@ -1,7 +1,63 @@
 /**
  * GET /api/portal/public/announcements
- * Returns recent announcements from the C# backend.
+ *
+ * The dashboard's "Recent News" card. Returns the ten most recent *published* announcements.
+ *
+ * This used to call `/announcements?limitnum=10`, which is the admin controller
+ * (`[Authorize(Roles = Roles.Admin)]`), so every signed-in customer got 403 and an empty card
+ * while admins saw content — which is why it went unnoticed. It now calls the client-facing
+ * `/announcements/published`, whose projection has no `isPublished` flag and never contains a
+ * draft. The `limitnum` parameter was WHMCS's spelling and no controller here ever read it; the
+ * backend pages with `page`/`pageSize`.
+ *
+ * The response is flattened to the `{ id, title, date }` shape the card renders, so the page
+ * does not have to know about the backend's paging envelope.
  */
-export default defineEventHandler(async (event) => {
-  return await internalApiCall<unknown[]>(event, '/announcements?limitnum=10')
+
+/** One published announcement as the backend returns it. */
+interface PublishedAnnouncement {
+  /** Announcement primary key. */
+  id: number
+  /** Announcement headline. */
+  title: string
+  /** Body content. Not rendered by the dashboard card, kept for callers that show detail. */
+  content: string
+  /** ISO-8601 UTC timestamp the announcement was published. */
+  publishedAt: string
+}
+
+/** The backend's paging envelope around a page of announcements. */
+interface PublishedAnnouncementPage {
+  /** The announcements on this page, newest first. */
+  items: PublishedAnnouncement[]
+  /** Total published announcements across all pages. */
+  totalCount: number
+  /** The 1-based page number this envelope describes. */
+  page: number
+  /** How many items a full page holds. */
+  pageSize: number
+}
+
+/** The shape the dashboard card consumes. */
+interface AnnouncementSummary {
+  /** Announcement primary key, used as the list key. */
+  id: number
+  /** Announcement headline. */
+  title: string
+  /** Publication date, already formatted as `YYYY-MM-DD` for display. */
+  date: string
+}
+
+export default defineEventHandler(async (event): Promise<AnnouncementSummary[]> => {
+  const result = await internalApiCall<PublishedAnnouncementPage>(
+    event,
+    '/announcements/published?page=1&pageSize=10'
+  )
+
+  return (result?.items ?? []).map(a => ({
+    id: a.id,
+    title: a.title,
+    // Date only: the card has one narrow line for it, and a full timestamp wraps.
+    date: a.publishedAt?.slice(0, 10) ?? '',
+  }))
 })

--- a/client/stores/auth.ts
+++ b/client/stores/auth.ts
@@ -17,7 +17,7 @@
 
 import { defineStore } from 'pinia'
 import { useAuthApi } from '~/composables/apis/useAuthApi'
-import { useClientApi } from '~/composables/apis/useClientApi'
+import { useClientStore } from '~/stores/client'
 import type { ClientUser } from '~/types/clientuser'
 import type { LoginResult } from '~/types/loginresult'
 import type { RegisterPayload } from '~/types/registerpayload'
@@ -46,15 +46,21 @@ export const useAuthStore = defineStore('auth', () => {
    * Fetch and cache current user data from the server.
    * Safe to call multiple times — skips if user is already loaded.
    *
-   * @returns Nothing; a failure leaves {@link user} null rather than throwing.
+   * Delegates to {@link useClientStore} rather than calling `/client/me` itself. Both stores
+   * wanted the same record and each fetched it separately, so a client-area page load asked
+   * for the identity once here and again there — `apiFetch` is `$fetch`-based and dedupes
+   * nothing. A store calling another store is the sanctioned direction; a second store
+   * calling the same API composable was the smell. The dedupe lives one layer down, in the
+   * store that owns the record.
+   *
+   * @returns Nothing; a failure leaves {@link user} null rather than throwing — the client
+   * store keeps the reason (or, for an identity with no client record, its own flag).
    */
   const fetchUser = async (): Promise<void> => {
     if (user.value) return
-    try {
-      user.value = await useClientApi().fetchMe()
-    } catch {
-      user.value = null
-    }
+    const clientStore = useClientStore()
+    await clientStore.fetchUser()
+    user.value = clientStore.user
   }
 
   /**
@@ -110,6 +116,10 @@ export const useAuthStore = defineStore('auth', () => {
       await api.logout()
     }
     user.value = null
+    // Local mode leaves the browser on the same SPA instance, so the client store's cached
+    // profile, services and invoices would otherwise outlive the session and greet whoever
+    // signs in next.
+    useClientStore().reset()
   }
 
   /**
@@ -135,6 +145,7 @@ export const useAuthStore = defineStore('auth', () => {
       await api.logout()
     } catch { /* the session ends on this side either way */ }
     user.value = null
+    useClientStore().reset()
 
     if ((config.public.authMode as string) !== 'sso') {
       await navigateTo('/client/login')
@@ -164,6 +175,7 @@ export const useAuthStore = defineStore('auth', () => {
    */
   const reset = (): void => {
     user.value = null
+    useClientStore().reset()
   }
 
   return {

--- a/client/stores/client.test.ts
+++ b/client/stores/client.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for the identity request in `stores/client.ts`.
+ *
+ * The store is the layer that decides when `/api/portal/client/me` is asked for, so it is the
+ * layer these assertions belong to. A client-area page load has three callers — the
+ * `client-auth` plugin (through `stores/auth.ts`), the `client` layout's `onMounted`, and the
+ * page's own fetch — and they all start before the first answer returns. Production served
+ * three identical `/me` requests per page load for exactly that reason. Without a test naming
+ * the invariant, the fourth caller someone adds brings the duplication straight back.
+ *
+ * @module stores/client.test
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+/** The mocked `/api/portal/client/me` call, re-created for every test. */
+const fetchMe = vi.fn()
+
+vi.mock('~/composables/apis/useClientApi', () => ({
+  /**
+   * Stands in for the real API composable so the store can be exercised without transport.
+   *
+   * @returns Only the endpoint functions these tests reach for.
+   */
+  useClientApi: () => ({ fetchMe }),
+}))
+
+const { useClientStore } = await import('~/stores/client')
+
+/**
+ * Builds a promise the test resolves or rejects by hand, so several callers can be observed
+ * while the request is still in flight.
+ *
+ * @returns The pending promise and the two functions that settle it.
+ */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+/** A minimal profile — only the fields the assertions read. */
+const profile = { id: 1, firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.com' }
+
+describe('useClientStore.fetchUser', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchMe.mockReset()
+  })
+
+  it('asks for the identity once when all three page-load callers ask at the same time', async () => {
+    const gate = deferred<typeof profile>()
+    fetchMe.mockReturnValue(gate.promise)
+
+    const store = useClientStore()
+
+    // The plugin, the layout and the page, all before the first answer comes back.
+    const callers = Promise.all([store.fetchUser(), store.fetchUser(), store.fetchUser()])
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+
+    gate.resolve(profile)
+    await callers
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+    expect(store.user).toEqual(profile)
+    expect(store.userLoaded).toBe(true)
+    expect(store.userLoading).toBe(false)
+  })
+
+  it('every concurrent caller waits for the answer rather than returning early and empty', async () => {
+    const gate = deferred<typeof profile>()
+    fetchMe.mockReturnValue(gate.promise)
+
+    const store = useClientStore()
+    const seen: Array<typeof profile | null> = []
+    const callers = Promise.all([
+      store.fetchUser().then(() => { seen.push(store.user) }),
+      store.fetchUser().then(() => { seen.push(store.user) }),
+    ])
+
+    gate.resolve(profile)
+    await callers
+
+    expect(seen).toEqual([profile, profile])
+  })
+
+  it('does not ask again once the identity is loaded', async () => {
+    fetchMe.mockResolvedValue(profile)
+    const store = useClientStore()
+
+    await store.fetchUser()
+    await store.fetchUser()
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks again when a caller forces a refresh after saving the profile', async () => {
+    fetchMe.mockResolvedValue(profile)
+    const store = useClientStore()
+
+    await store.fetchUser()
+    await store.fetchUser(true)
+
+    expect(fetchMe).toHaveBeenCalledTimes(2)
+  })
+
+  it('asks once, not three times, for a staff identity with no client record', async () => {
+    const gate = deferred<typeof profile>()
+    fetchMe.mockReturnValue(gate.promise)
+
+    const store = useClientStore()
+    const callers = Promise.all([store.fetchUser(), store.fetchUser(), store.fetchUser()])
+
+    gate.reject({ data: { code: 'CLIENT_PROFILE_NOT_FOUND' } })
+    await callers
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+    expect(store.clientProfileMissing).toBe(true)
+    // Not a fault, so nothing renders it in red.
+    expect(store.userError).toBeNull()
+    // And not remembered as loaded either: a later navigation may ask again, so the answer
+    // is never cached as a permanent "no".
+    expect(store.userLoaded).toBe(false)
+  })
+
+  it('does not let a signed-out session’s answer land on the next visitor', async () => {
+    const gate = deferred<typeof profile>()
+    fetchMe.mockReturnValue(gate.promise)
+
+    const store = useClientStore()
+    const pending = store.fetchUser()
+
+    // Signing out while the identity request is still on the wire.
+    store.reset()
+
+    gate.resolve(profile)
+    await pending
+
+    expect(store.user).toBeNull()
+    expect(store.userLoaded).toBe(false)
+    expect(store.userLoading).toBe(false)
+  })
+
+  it('lets the next sign-in fetch a fresh identity rather than joining the old request', async () => {
+    const first = deferred<typeof profile>()
+    fetchMe.mockReturnValueOnce(first.promise)
+
+    const store = useClientStore()
+    const stale = store.fetchUser()
+    store.reset()
+
+    const next = { ...profile, id: 2, firstname: 'Grace', email: 'grace@example.com' }
+    fetchMe.mockResolvedValueOnce(next)
+    await store.fetchUser()
+
+    first.resolve(profile)
+    await stale
+
+    expect(fetchMe).toHaveBeenCalledTimes(2)
+    expect(store.user).toEqual(next)
+  })
+})

--- a/client/stores/client.ts
+++ b/client/stores/client.ts
@@ -70,6 +70,19 @@ export const useClientStore = defineStore('client', {
     userLoaded: false,
     userError: null as string | null,
 
+    // The identity request currently on the wire, or null when none is. Not data — the
+    // request itself — so that the several callers who all ask for the identity at once
+    // share one round trip instead of racing. Vue leaves a Promise in reactive state
+    // untouched (`reactive()` only proxies Object/Array/Map/Set), so this is a plain
+    // reference, not a proxied thenable. See {@link useClientStore.fetchUser}.
+    userInflight: null as Promise<void> | null,
+
+    // Bumped by {@link useClientStore.reset}. An identity request captures it when it starts
+    // and refuses to write its answer if it has moved on since — otherwise a sign-out during
+    // a request in flight would be undone by that request landing a moment later, and the
+    // next sign-in would open on the previous customer's name.
+    userEpoch: 0,
+
     // ── Services ──────────────────────────────────────────────────────────
     services: [] as ClientService[],
     servicesLoading: false,
@@ -127,28 +140,58 @@ export const useClientStore = defineStore('client', {
 
     /**
      * Fetch the authenticated client's profile from WHMCS.
-     * No-ops if already loaded unless `force` is true.
      *
-     * @param force - Set true to bypass the loaded cache
+     * No-ops if already loaded unless `force` is true, and — the part `userLoaded` alone
+     * cannot do — collapses *concurrent* callers onto a single request. Three layers ask for
+     * the identity on one client-area page load: the `client-auth` plugin (through
+     * {@link useAuthStore.fetchUser}, which delegates here), the `client` layout's
+     * `onMounted`, and the page's own fetch. All three start before the first answer comes
+     * back, so `userLoaded` is still false for every one of them and the flag stops nothing.
+     * Holding the in-flight promise is what turns three round trips into one.
+     *
+     * What is held is the request, not a cached result: the promise is dropped as soon as it
+     * settles. So the 404 a staff identity gets for having no client record is neither asked
+     * for three times over nor remembered forever — a later navigation is free to ask again.
+     *
+     * @param force - Set true to bypass the loaded cache. A forced call also refuses to join
+     * a request already in flight: it is asking for data newer than that request can carry.
+     * @returns Promise that resolves once {@link user} reflects the server's answer.
      */
-    async fetchUser(force = false) {
+    async fetchUser(force = false): Promise<void> {
       if (this.userLoaded && !force) return
-      this.userLoading = true
-      this.userError = null
-      try {
-        this.user = await useClientApi().fetchMe()
-        this.userLoaded = true
-      } catch (err) {
-        // "Not a customer account" is a state, not a fault — it gets its own flag and no
-        // error string, so nothing renders it in red. Anything else is kept, not swallowed:
-        // the screens read it to say the section failed instead of rendering it as empty.
-        if (isClientProfileMissing(err)) {
-          this.clientProfileMissing = true
-        } else {
-          this.userError = apiErrorMessage(err)
+      if (this.userInflight && !force) return this.userInflight
+
+      const epoch = this.userEpoch
+      const request = (async (): Promise<void> => {
+        this.userLoading = true
+        this.userError = null
+        try {
+          const me = await useClientApi().fetchMe()
+          if (this.userEpoch !== epoch) return
+          this.user = me
+          this.userLoaded = true
+        } catch (err) {
+          if (this.userEpoch !== epoch) return
+          // "Not a customer account" is a state, not a fault — it gets its own flag and no
+          // error string, so nothing renders it in red. Anything else is kept, not swallowed:
+          // the screens read it to say the section failed instead of rendering it as empty.
+          if (isClientProfileMissing(err)) {
+            this.clientProfileMissing = true
+          } else {
+            this.userError = apiErrorMessage(err)
+          }
+        } finally {
+          if (this.userEpoch === epoch) this.userLoading = false
         }
+      })()
+
+      this.userInflight = request
+      try {
+        await request
       } finally {
-        this.userLoading = false
+        // Only clear the slot if a forced call has not already claimed it for a newer
+        // request — otherwise the older one finishing would hide the newer one from joiners.
+        if (this.userInflight === request) this.userInflight = null
       }
     },
 
@@ -292,6 +335,13 @@ export const useClientStore = defineStore('client', {
       this.user = null
       this.userLoaded = false
       this.userError = null
+      // Dropped, not awaited: a sign-out must not leave the previous session's identity
+      // request as something the next sign-in's callers can join and adopt the answer of.
+      // Bumping the epoch disowns its answer too, for the case where it is already on the
+      // wire and lands after this returns.
+      this.userInflight = null
+      this.userEpoch += 1
+      this.userLoading = false
       this.services = []
       this.servicesLoaded = false
       this.servicesError = null

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -128,7 +128,7 @@ services:
         # (see client.Dockerfile) — the runtime env var below only affects
         # useRuntimeConfig() reads, not that static tag, so it must be
         # repeated here as a build arg for the widget to actually appear.
-        NUXT_PUBLIC_MAIN_URL: ${NUXT_PUBLIC_MAIN_URL}
+        NUXT_PUBLIC_MAIN_URL: ${MAIN_APP_URL}
     environment:
       # Nitro/Nuxt production builds freeze runtimeConfig defaults at build
       # time (nuxt.config.ts isn't re-evaluated at container start like it is
@@ -143,7 +143,7 @@ services:
       # The app-launcher widget script is injected over whatever origin this
       # points at — must be HTTPS on an HTTPS deployment or browsers block it
       # as mixed content, which hangs the client dashboard's hydration.
-      NUXT_PUBLIC_MAIN_URL: ${NUXT_PUBLIC_MAIN_URL}
+      NUXT_PUBLIC_MAIN_URL: ${MAIN_APP_URL}
       NUXT_SSO_URL: ${SSO_URL}
       NUXT_SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
       NUXT_PUBLIC_SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       # backends, and not the container name, which changes with the project.
       API_URL: http://hostpanel-api:5148
       NUXT_PUBLIC_BASE_URL: ${NUXT_PUBLIC_BASE_URL}
-      NUXT_PUBLIC_MAIN_URL: ${NUXT_PUBLIC_MAIN_URL}
+      NUXT_PUBLIC_MAIN_URL: ${MAIN_APP_URL}
       SSO_URL: http://sso-api:8080
       SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
       NUXT_PUBLIC_TASKS_URL: ${NUXT_PUBLIC_TASKS_URL}


### PR DESCRIPTION
Four fixes verified against one build (0 warnings; Application 86, Domain 84, Infrastructure 40; vitest 83/83).

**Announcements answered 403 to every real customer** — the BFF fronted an admin-only controller; admins got 200, which is why it went unnoticed. New `PublishedAnnouncementsController` with its own DTO that carries no `IsPublished` flag; a test asserts over the DTO's *type* that the field cannot quietly return.

**The knowledgebase had the worse version**: the public, anonymous article route dispatched the admin read, so a sequential id straight to the detail route served *drafts*. Now a draft and a nonexistent id answer identically — the route cannot enumerate the unpublished backlog.

**Wolverine ERR noise**: "Invocation failed!" + stack trace for every staff dashboard load. No knob in WolverineFx 5.31.0 (verified); a Serilog `ILogEventFilter` drops exactly that line for exactly the three refusal exceptions. Genuine failures still log at Error.

**`/me` fetched three times per page load** — the store now shares one in-flight promise; a gated test proves three concurrent callers → one request.

Plus the compose-side rename to `MAIN_APP_URL` (container-side names unchanged — Nitro needs the exact prefix).