### PR TITLE
Branding uploads, admin i18n, and a translation fix

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -22,6 +22,7 @@
         "tailwindcss": "^4.2.2",
         "vue": "^3.5.31",
         "vue-chartjs": "^5.3.3",
+        "vue-i18n": "^11.4.10",
         "vue-router": "^5.0.4",
         "vue-svg-map": "^2.0.0-beta.1",
         "vuedraggable": "^4.1.0"
@@ -1217,6 +1218,67 @@
       "resolved": "https://registry.npmjs.org/@innovayse/geo-atlas/-/geo-atlas-2.0.2.tgz",
       "integrity": "sha512-gGe9B4vu+vBu5Z0ATWJI5I7SQHKvitUP6hVgwumxPnVwama9iO4Dq14ZLWEXqjbFHHUXCEe/BR6D5qy6Kwd0ww==",
       "license": "MIT"
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "11.4.10",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.10.tgz",
+      "integrity": "sha512-+yJ74JRWVJokdgG9zYNMyTSzeNV3O9T4vVxk8PvLFHmI+R/BYA//cITh7vhRK37hWLZ4/kTcKcUz1dlWOpypIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/devtools-types": "11.4.10",
+        "@intlify/message-compiler": "11.4.10",
+        "@intlify/shared": "11.4.10"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.10",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.10.tgz",
+      "integrity": "sha512-xZxzZsAuu6/0zoLRVQWdpXWe5Kjl0LnWpjlQA3r9u9FbLYMhapqt7IwkgQyn0Tm2GUNAqhj9eZiUmYOrB024BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.10",
+        "@intlify/shared": "11.4.10"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.4.10",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.10.tgz",
+      "integrity": "sha512-oUB/scz2EJENXDiUJ7JjZffOrH8UIZ1BuZeHvonbi5fWLavLt04aivuk2OIByOZA0tsci1bkeeQRmwhb5M8Imw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.4.10",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.4.10",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.10.tgz",
+      "integrity": "sha512-FeImVdPeoSHTm3NBFFZHv0eRP9gQ3F4lj2puDBX5Kw7iiM1uJW6JTf39ian0K/17pbXCI3ef5i9RVsRrALqI6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -6421,6 +6483,33 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.4.10",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.10.tgz",
+      "integrity": "sha512-Lp+BjOxqzOY87DS6Z8KrQrpiTr9IN/Lt4kZEilwyXG2Wrx+AcU6IVsAW92HNXtVcn1HFFPV6ty41p9e/qDpyvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.10",
+        "@intlify/devtools-types": "11.4.10",
+        "@intlify/shared": "11.4.10",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-i18n/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "5.0.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -28,6 +28,7 @@
     "tailwindcss": "^4.2.2",
     "vue": "^3.5.31",
     "vue-chartjs": "^5.3.3",
+    "vue-i18n": "^11.4.10",
     "vue-router": "^5.0.4",
     "vue-svg-map": "^2.0.0-beta.1",
     "vuedraggable": "^4.1.0"

--- a/admin/src/components/layout/AppSidebar.vue
+++ b/admin/src/components/layout/AppSidebar.vue
@@ -9,6 +9,7 @@
  */
 import { ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '../../modules/auth/stores/authStore'
 import { useRouter } from 'vue-router'
 
@@ -18,11 +19,12 @@ const emit = defineEmits<{
   navigate: []
 }>()
 
+const { t } = useI18n()
 const authStore = useAuthStore()
 const router = useRouter()
 const route = useRoute()
 
-/** Set of expanded parent item labels. */
+/** Set of expanded parent item routes (keyed by `to`, stable across locales). */
 const expanded = ref<Set<string>>(new Set())
 
 /**
@@ -39,16 +41,16 @@ async function handleLogout(): Promise<void> {
 interface NavChild {
   /** Route path. */
   to: string
-  /** Display label. */
-  label: string
+  /** i18n key for the display label. */
+  labelKey: string
 }
 
 /** A top-level navigation item, optionally with children. */
 interface NavItem {
   /** Route path (used when no children). */
   to: string
-  /** Display label. */
-  label: string
+  /** i18n key for the display label. */
+  labelKey: string
   /** SVG path data for the icon. */
   icon: string
   /** Optional sub-menu items. */
@@ -58,87 +60,87 @@ interface NavItem {
 /** Top-level navigation items with SVG path icons. */
 const navItems: NavItem[] = [
   {
-    to: '/dashboard', label: 'Dashboard',
+    to: '/dashboard', labelKey: 'nav.dashboard',
     icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
   },
   {
-    to: '/clients', label: 'Clients',
+    to: '/clients', labelKey: 'nav.clients',
     icon: 'M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zm12 2v2m0 0v2m0-2h2m-2 0h-2',
     children: [
-      { to: '/clients', label: 'View/Search Clients' },
-      { to: '/clients/users', label: 'Manage Users' },
-      { to: '/clients/shared-hostings', label: 'Shared Hostings' },
-      { to: '/clients/addons', label: 'Service Addons' },
-      { to: '/clients/domain-registrations', label: 'Domain Registrations' },
-      { to: '/clients/cancellations', label: 'Cancellation Requests' },
-      { to: '/clients/affiliates', label: 'Manage Affiliates' },
+      { to: '/clients', labelKey: 'nav.clientsChildren.view' },
+      { to: '/clients/users', labelKey: 'nav.clientsChildren.users' },
+      { to: '/clients/shared-hostings', labelKey: 'nav.clientsChildren.sharedHostings' },
+      { to: '/clients/addons', labelKey: 'nav.clientsChildren.addons' },
+      { to: '/clients/domain-registrations', labelKey: 'nav.clientsChildren.domainRegistrations' },
+      { to: '/clients/cancellations', labelKey: 'nav.clientsChildren.cancellations' },
+      { to: '/clients/affiliates', labelKey: 'nav.clientsChildren.affiliates' },
     ],
   },
   {
-    to: '/billing', label: 'Billing',
+    to: '/billing', labelKey: 'nav.billing',
     icon: 'M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z',
     children: [
-      { to: '/billing/transactions', label: 'Transactions List' },
-      { to: '/billing/invoices', label: 'Invoices' },
-      { to: '/billing/billable-items', label: 'Billable Items' },
-      { to: '/billing/quotes', label: 'Quotes' },
-      { to: '/billing/offline-cc', label: 'Offline CC Processing' },
-      { to: '/billing/disputes', label: 'Disputes' },
-      { to: '/billing/gateway-log', label: 'Gateway Log' },
+      { to: '/billing/transactions', labelKey: 'nav.billingChildren.transactions' },
+      { to: '/billing/invoices', labelKey: 'nav.billingChildren.invoices' },
+      { to: '/billing/billable-items', labelKey: 'nav.billingChildren.billableItems' },
+      { to: '/billing/quotes', labelKey: 'nav.billingChildren.quotes' },
+      { to: '/billing/offline-cc', labelKey: 'nav.billingChildren.offlineCc' },
+      { to: '/billing/disputes', labelKey: 'nav.billingChildren.disputes' },
+      { to: '/billing/gateway-log', labelKey: 'nav.billingChildren.gatewayLog' },
     ],
   },
   {
-    to: '/reports', label: 'Reports',
+    to: '/reports', labelKey: 'nav.reports',
     icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
   },
   {
-    to: '/orders', label: 'Orders',
+    to: '/orders', labelKey: 'nav.orders',
     icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 7h6m-6 4h4',
   },
   {
-    to: '/domains', label: 'Domains',
+    to: '/domains', labelKey: 'nav.domains',
     icon: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9',
   },
   {
-    to: '/support', label: 'Support',
+    to: '/support', labelKey: 'nav.support',
     icon: 'M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z',
     children: [
-      { to: '/support/overview', label: 'Support Overview' },
-      { to: '/support/tickets', label: 'Support Tickets' },
-      { to: '/support/tickets/new', label: 'Open New Ticket' },
-      { to: '/support/predefined-replies', label: 'Predefined Replies' },
-      { to: '/support/announcements', label: 'Announcements' },
-      { to: '/support/downloads', label: 'Downloads' },
-      { to: '/support/knowledgebase', label: 'Knowledgebase' },
-      { to: '/support/network-issues', label: 'Network Issues' },
+      { to: '/support/overview', labelKey: 'nav.supportChildren.overview' },
+      { to: '/support/tickets', labelKey: 'nav.supportChildren.tickets' },
+      { to: '/support/tickets/new', labelKey: 'nav.supportChildren.newTicket' },
+      { to: '/support/predefined-replies', labelKey: 'nav.supportChildren.predefinedReplies' },
+      { to: '/support/announcements', labelKey: 'nav.supportChildren.announcements' },
+      { to: '/support/downloads', labelKey: 'nav.supportChildren.downloads' },
+      { to: '/support/knowledgebase', labelKey: 'nav.supportChildren.knowledgebase' },
+      { to: '/support/network-issues', labelKey: 'nav.supportChildren.networkIssues' },
     ],
   },
   {
-    to: '/plugins', label: 'Plugins',
+    to: '/plugins', labelKey: 'nav.plugins',
     icon: 'M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4',
   },
   {
-    to: '/servers', label: 'Servers',
+    to: '/servers', labelKey: 'nav.servers',
     icon: 'M5 12H3a2 2 0 00-2 2v4a2 2 0 002 2h18a2 2 0 002-2v-4a2 2 0 00-2-2h-2M5 12V8a2 2 0 012-2h10a2 2 0 012 2v4M5 12h14M8 20h.01M12 20h.01M16 20h.01',
   },
   {
-    to: '/integrations', label: 'Integrations',
+    to: '/integrations', labelKey: 'nav.integrations',
     icon: 'M13 10V3L4 14h7v7l9-11h-7z',
   },
   {
-    to: '/migration', label: 'Migration',
+    to: '/migration', labelKey: 'nav.migration',
     icon: 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12',
   },
   {
-    to: '/settings', label: 'Settings',
+    to: '/settings', labelKey: 'nav.settings',
     icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
     children: [
-      { to: '/settings', label: 'General' },
-      { to: '/settings/products', label: 'Products' },
-      { to: '/settings/tld-pricing', label: 'TLD Pricing' },
-      { to: '/settings/slides', label: 'Slides' },
-      { to: '/settings/email-templates', label: 'Email Templates' },
-      { to: '/settings/gateways', label: 'Payment Gateways' },
+      { to: '/settings', labelKey: 'nav.settingsChildren.general' },
+      { to: '/settings/products', labelKey: 'nav.settingsChildren.products' },
+      { to: '/settings/tld-pricing', labelKey: 'nav.settingsChildren.tldPricing' },
+      { to: '/settings/slides', labelKey: 'nav.settingsChildren.slides' },
+      { to: '/settings/email-templates', labelKey: 'nav.settingsChildren.emailTemplates' },
+      { to: '/settings/gateways', labelKey: 'nav.settingsChildren.gateways' },
     ],
   },
 ]
@@ -168,12 +170,12 @@ function isChildActive(to: string): boolean {
 /**
  * Toggles the expanded state of a parent nav item.
  *
- * @param label - The label of the item to toggle.
+ * @param to - The route path of the item to toggle.
  */
-function toggleExpand(label: string): void {
+function toggleExpand(to: string): void {
   const next = new Set(expanded.value)
-  if (next.has(label)) next.delete(label)
-  else next.add(label)
+  if (next.has(to)) next.delete(to)
+  else next.add(to)
   expanded.value = next
 }
 
@@ -185,7 +187,7 @@ function toggleExpand(label: string): void {
  * @returns True if expanded.
  */
 function isExpanded(item: NavItem): boolean {
-  if (expanded.value.has(item.label)) return true
+  if (expanded.value.has(item.to)) return true
   if (item.children && isActive(item)) return true
   return false
 }
@@ -210,7 +212,7 @@ function isExpanded(item: NavItem): boolean {
             :class="isActive(item)
               ? 'text-text-primary bg-primary-500/8'
               : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.04]'"
-            @click="toggleExpand(item.label)"
+            @click="toggleExpand(item.to)"
           >
             <span
               v-if="isActive(item)"
@@ -226,7 +228,7 @@ function isExpanded(item: NavItem): boolean {
               <path :d="item.icon"/>
             </svg>
 
-            <span class="flex-1">{{ item.label }}</span>
+            <span class="flex-1">{{ t(item.labelKey) }}</span>
 
             <!-- Chevron -->
             <svg
@@ -258,7 +260,7 @@ function isExpanded(item: NavItem): boolean {
                 class="w-1 h-1 rounded-full shrink-0"
                 :class="isChildActive(child.to) ? 'bg-primary-400' : 'bg-text-muted/40'"
               />
-              {{ child.label }}
+              {{ t(child.labelKey) }}
             </RouterLink>
           </div>
         </template>
@@ -287,7 +289,7 @@ function isExpanded(item: NavItem): boolean {
             <path :d="item.icon"/>
           </svg>
 
-          <span>{{ item.label }}</span>
+          <span>{{ t(item.labelKey) }}</span>
         </RouterLink>
 
       </template>
@@ -299,12 +301,12 @@ function isExpanded(item: NavItem): boolean {
         <div class="flex items-center justify-center w-7 h-7 rounded-[7px] gradient-brand text-white text-[0.7rem] font-bold font-display shrink-0">
           A
         </div>
-        <span class="text-[0.8rem] text-text-secondary font-medium">Admin</span>
+        <span class="text-[0.8rem] text-text-secondary font-medium">{{ t('common.admin') }}</span>
       </div>
 
       <button
         @click="handleLogout"
-        title="Sign out"
+        :title="t('common.signOut')"
         class="flex items-center justify-center w-7 h-7 rounded-[7px] border border-border bg-transparent text-text-muted cursor-pointer transition-all duration-150 hover:text-status-red hover:border-status-red/30 hover:bg-status-red/6"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/admin/src/components/layout/AppTopbar.vue
+++ b/admin/src/components/layout/AppTopbar.vue
@@ -7,6 +7,8 @@
  */
 import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { SUPPORTED_LOCALES, setLocale, type SupportedLocale } from '../../i18n'
 
 /** Emitted when the hamburger button is clicked on mobile. */
 const emit = defineEmits<{
@@ -15,28 +17,45 @@ const emit = defineEmits<{
 }>()
 
 const route = useRoute()
+const { t, locale } = useI18n()
 
-/** Maps route paths to human-readable page titles. */
-const titles: Record<string, string> = {
-  '/dashboard':   'Dashboard',
-  '/clients':     'Clients',
-  '/billing':     'Billing',
-  '/services':    'Services',
-  '/domains':     'Domains',
-  '/support':     'Support',
-  '/plugins':     'Plugin Manager',
-  '/servers':     'Servers',
-  '/integrations':'Integrations',
-  '/settings':    'Settings',
-  '/reports':     'Reports',
-  '/orders':      'Orders',
+/** Maps route paths to i18n keys for the page title. */
+const titleKeys: Record<string, string> = {
+  '/dashboard':   'nav.dashboard',
+  '/clients':     'nav.clients',
+  '/billing':     'nav.billing',
+  '/services':    'nav.servicesTitle',
+  '/domains':     'nav.domains',
+  '/support':     'nav.support',
+  '/plugins':     'nav.pluginManager',
+  '/servers':     'nav.servers',
+  '/integrations':'nav.integrations',
+  '/settings':    'nav.settings',
+  '/reports':     'nav.reports',
+  '/orders':      'nav.orders',
 }
 
 /** Current page title derived from the active route. */
 const pageTitle = computed(() => {
-  const match = Object.keys(titles).find(k => route.path === k || route.path.startsWith(k + '/'))
-  return match ? titles[match] : 'Admin'
+  const match = Object.entries(titleKeys).find(([k]) => route.path === k || route.path.startsWith(k + '/'))
+  return match ? t(match[1]) : t('common.admin')
 })
+
+/** Controls the language menu visibility. */
+const showLanguageMenu = ref(false)
+
+/** Display labels for the language switcher button/menu. */
+const localeLabels: Record<SupportedLocale, string> = { en: 'EN', hy: 'ՀՅ', ru: 'РУ' }
+
+/**
+ * Switches the active locale and closes the menu.
+ *
+ * @param code - The locale to switch to.
+ */
+function chooseLocale(code: SupportedLocale): void {
+  setLocale(code)
+  showLanguageMenu.value = false
+}
 
 /** Controls the notification popover visibility. */
 const showNotifications = ref(false)
@@ -59,7 +78,7 @@ function toggleNotifications(): void {
       <button
         class="flex lg:hidden items-center justify-center w-8 h-8 rounded-lg text-text-secondary hover:text-text-primary hover:bg-white/[0.05] transition-all"
         @click="emit('toggle-sidebar')"
-        aria-label="Toggle sidebar"
+        :aria-label="t('common.toggleSidebar')"
       >
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
           <line x1="3" y1="6" x2="21" y2="6"/>
@@ -82,8 +101,35 @@ function toggleNotifications(): void {
         <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
         </svg>
-        <span class="flex-1">Search…</span>
+        <span class="flex-1">{{ t('common.search') }}</span>
         <kbd class="text-[0.65rem] px-1 py-0.5 rounded bg-white/[0.06] border border-border font-mono text-text-muted group-hover:border-primary-500/20">⌘K</kbd>
+      </div>
+
+      <!-- Language switcher -->
+      <div class="relative">
+        <button
+          class="flex items-center gap-1 h-8 px-2.5 rounded-lg text-text-secondary text-[0.8rem] font-medium hover:text-text-primary hover:bg-white/[0.05] transition-all"
+          @click="showLanguageMenu = !showLanguageMenu"
+        >
+          {{ localeLabels[locale as SupportedLocale] }}
+        </button>
+
+        <div
+          v-if="showLanguageMenu"
+          class="absolute right-0 top-full mt-2 w-28 bg-surface-elevated border border-border rounded-xl shadow-2xl z-50 overflow-hidden"
+        >
+          <button
+            v-for="code in SUPPORTED_LOCALES"
+            :key="code"
+            class="flex w-full items-center px-3 py-2 text-[0.8rem] text-left transition-colors"
+            :class="locale === code ? 'text-primary-400 bg-primary-500/8' : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.04]'"
+            @click="chooseLocale(code)"
+          >
+            {{ localeLabels[code] }}
+          </button>
+        </div>
+
+        <div v-if="showLanguageMenu" class="fixed inset-0 z-40" @click="showLanguageMenu = false" />
       </div>
 
       <!-- Notifications -->
@@ -91,7 +137,7 @@ function toggleNotifications(): void {
         <button
           class="relative flex items-center justify-center w-8 h-8 rounded-lg text-text-secondary hover:text-text-primary hover:bg-white/[0.05] transition-all"
           @click="toggleNotifications"
-          aria-label="Notifications"
+          :aria-label="t('common.notifications')"
         >
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
             <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 01-3.46 0"/>
@@ -109,8 +155,8 @@ function toggleNotifications(): void {
           class="absolute right-0 top-full mt-2 w-72 bg-surface-elevated border border-border rounded-xl shadow-2xl z-50 overflow-hidden"
         >
           <div class="flex items-center justify-between px-4 py-3 border-b border-border">
-            <span class="text-[0.8rem] font-semibold font-display text-text-primary">Notifications</span>
-            <span class="text-[0.65rem] font-medium text-primary-400 bg-primary-500/10 border border-primary-500/20 rounded-full px-2 py-0.5">{{ notificationCount }} new</span>
+            <span class="text-[0.8rem] font-semibold font-display text-text-primary">{{ t('common.notifications') }}</span>
+            <span class="text-[0.65rem] font-medium text-primary-400 bg-primary-500/10 border border-primary-500/20 rounded-full px-2 py-0.5">{{ t('common.newCount', { count: notificationCount }) }}</span>
           </div>
           <div class="divide-y divide-border">
             <div class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
@@ -127,7 +173,7 @@ function toggleNotifications(): void {
             </div>
           </div>
           <div class="px-4 py-2.5 border-t border-border">
-            <button class="text-[0.75rem] text-primary-400 hover:text-primary-300 transition-colors">View all notifications</button>
+            <button class="text-[0.75rem] text-primary-400 hover:text-primary-300 transition-colors">{{ t('common.viewAllNotifications') }}</button>
           </div>
         </div>
 
@@ -143,7 +189,7 @@ function toggleNotifications(): void {
         <div class="flex items-center justify-center w-7 h-7 rounded-lg gradient-brand text-white text-[0.7rem] font-bold font-display shrink-0">
           A
         </div>
-        <span class="hidden sm:block text-[0.8rem] font-medium text-text-secondary group-hover:text-text-primary transition-colors">Admin</span>
+        <span class="hidden sm:block text-[0.8rem] font-medium text-text-secondary group-hover:text-text-primary transition-colors">{{ t('common.admin') }}</span>
         <svg class="hidden sm:block w-3.5 h-3.5 text-text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <polyline points="6 9 12 15 18 9"/>
         </svg>

--- a/admin/src/i18n.ts
+++ b/admin/src/i18n.ts
@@ -1,0 +1,51 @@
+/**
+ * Admin panel i18n setup.
+ *
+ * Only the static shell (nav, dashboard, the settings page's own chrome) is
+ * translated here. Settings `key`/`description` values come from the backend
+ * as plain strings — they are configuration identifiers and operator-facing
+ * copy stored in the database, not frontend messages, so they are out of
+ * scope for this catalogue and stay in English regardless of locale.
+ */
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import hy from './locales/hy.json'
+import ru from './locales/ru.json'
+
+/** Locale codes the admin panel ships. */
+export const SUPPORTED_LOCALES = ['en', 'hy', 'ru'] as const
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+const STORAGE_KEY = 'admin.locale'
+
+/**
+ * Reads the operator's saved locale preference, falling back to English for
+ * an unseen visitor or a value the panel no longer ships.
+ *
+ * @returns A supported locale code.
+ */
+function initialLocale(): SupportedLocale {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
+    return stored as SupportedLocale
+  }
+  return 'en'
+}
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: initialLocale(),
+  fallbackLocale: 'en',
+  messages: { en, hy, ru },
+})
+
+/**
+ * Switches the active locale and persists the choice.
+ *
+ * @param locale - The locale to switch to.
+ */
+export function setLocale(locale: SupportedLocale): void {
+  i18n.global.locale.value = locale
+  localStorage.setItem(STORAGE_KEY, locale)
+}

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -1,0 +1,109 @@
+{
+  "common": {
+    "loading": "Loading...",
+    "save": "Save",
+    "saving": "Saving…",
+    "signOut": "Sign out",
+    "admin": "Admin",
+    "search": "Search…",
+    "notifications": "Notifications",
+    "toggleSidebar": "Toggle sidebar",
+    "viewAllNotifications": "View all notifications",
+    "newCount": "{count} new"
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "clients": "Clients",
+    "clientsChildren": {
+      "view": "View/Search Clients",
+      "users": "Manage Users",
+      "sharedHostings": "Shared Hostings",
+      "addons": "Service Addons",
+      "domainRegistrations": "Domain Registrations",
+      "cancellations": "Cancellation Requests",
+      "affiliates": "Manage Affiliates"
+    },
+    "billing": "Billing",
+    "billingChildren": {
+      "transactions": "Transactions List",
+      "invoices": "Invoices",
+      "billableItems": "Billable Items",
+      "quotes": "Quotes",
+      "offlineCc": "Offline CC Processing",
+      "disputes": "Disputes",
+      "gatewayLog": "Gateway Log"
+    },
+    "reports": "Reports",
+    "orders": "Orders",
+    "domains": "Domains",
+    "support": "Support",
+    "supportChildren": {
+      "overview": "Support Overview",
+      "tickets": "Support Tickets",
+      "newTicket": "Open New Ticket",
+      "predefinedReplies": "Predefined Replies",
+      "announcements": "Announcements",
+      "downloads": "Downloads",
+      "knowledgebase": "Knowledgebase",
+      "networkIssues": "Network Issues"
+    },
+    "plugins": "Plugins",
+    "pluginManager": "Plugin Manager",
+    "servers": "Servers",
+    "integrations": "Integrations",
+    "migration": "Migration",
+    "settings": "Settings",
+    "settingsChildren": {
+      "general": "General",
+      "products": "Products",
+      "tldPricing": "TLD Pricing",
+      "slides": "Slides",
+      "emailTemplates": "Email Templates",
+      "gateways": "Payment Gateways"
+    },
+    "servicesTitle": "Services"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Welcome back — here's what's happening",
+    "live": "Live",
+    "loadingMetrics": "Loading metrics…",
+    "stats": {
+      "totalRevenue": "Total Revenue",
+      "monthlyRevenue": "Monthly Revenue",
+      "activeServices": "Active Services",
+      "overdueInvoices": "Overdue Invoices",
+      "openTickets": "Open Tickets",
+      "totalClients": "Total Clients"
+    }
+  },
+  "settings": {
+    "systemSettings": "System Settings",
+    "table": {
+      "key": "Key",
+      "value": "Value",
+      "description": "Description",
+      "noSettings": "No settings found."
+    },
+    "portalAppearance": {
+      "title": "Portal appearance",
+      "description": "Which template the public storefront renders. Changes take effect on the next page load.",
+      "template": "Template",
+      "notSeeded": "The <code>{key}</code> setting has not been seeded yet, so it cannot be changed here. Until it exists the portal uses its <code>{env}</code> environment variable.",
+      "templates": {
+        "aurora": { "label": "Aurora", "hint": "Current default — dark/light, Armenian typography" },
+        "classic": { "label": "Classic", "hint": "The original storefront design" }
+      }
+    },
+    "branding": {
+      "title": "Branding",
+      "description": "The storefront's logo and browser tab icon. Changes take effect on the next page load.",
+      "uploading": "Uploading...",
+      "dropOrBrowsePrefix": "Drop image or",
+      "browse": "browse",
+      "pasteUrl": "Or paste image URL...",
+      "logo": { "label": "Logo", "hint": "JPEG, PNG, WebP, SVG — max 5MB" },
+      "favicon": { "label": "Favicon", "hint": "PNG, SVG, ICO — max 5MB" }
+    }
+  }
+}

--- a/admin/src/locales/hy.json
+++ b/admin/src/locales/hy.json
@@ -1,0 +1,109 @@
+{
+  "common": {
+    "loading": "Բեռնվում է...",
+    "save": "Պահպանել",
+    "saving": "Պահպանվում է…",
+    "signOut": "Դուրս գալ",
+    "admin": "Ադմին",
+    "search": "Որոնել…",
+    "notifications": "Ծանուցումներ",
+    "toggleSidebar": "Ցույց տալ/թաքցնել մենյուն",
+    "viewAllNotifications": "Դիտել բոլոր ծանուցումները",
+    "newCount": "{count} նոր"
+  },
+  "nav": {
+    "dashboard": "Ամփոփագիր",
+    "clients": "Հաճախորդներ",
+    "clientsChildren": {
+      "view": "Դիտել/Փնտրել հաճախորդներին",
+      "users": "Կառավարել օգտատերերին",
+      "sharedHostings": "Ընդհանուր հոսթինգներ",
+      "addons": "Ծառայության հավելումներ",
+      "domainRegistrations": "Դոմենի գրանցումներ",
+      "cancellations": "Չեղարկման հայտեր",
+      "affiliates": "Կառավարել գործընկերներին"
+    },
+    "billing": "Հաշվարկներ",
+    "billingChildren": {
+      "transactions": "Գործարքների ցանկ",
+      "invoices": "Հաշիվ-ապրանքագրեր",
+      "billableItems": "Վճարովի կետեր",
+      "quotes": "Գնառաջարկներ",
+      "offlineCc": "Offline քարտային վճարումներ",
+      "disputes": "Վեճեր",
+      "gatewayLog": "Վճարային համակարգի լոգ"
+    },
+    "reports": "Հաշվետվություններ",
+    "orders": "Պատվերներ",
+    "domains": "Դոմեններ",
+    "support": "Աջակցություն",
+    "supportChildren": {
+      "overview": "Աջակցության ամփոփում",
+      "tickets": "Աջակցության հայտեր",
+      "newTicket": "Բացել նոր հայտ",
+      "predefinedReplies": "Պատրաստի պատասխաններ",
+      "announcements": "Հայտարարություններ",
+      "downloads": "Ներբեռնումներ",
+      "knowledgebase": "Գիտելիքների բազա",
+      "networkIssues": "Ցանցային խնդիրներ"
+    },
+    "plugins": "Հավելումներ",
+    "pluginManager": "Հավելումների կառավարիչ",
+    "servers": "Սերվերներ",
+    "integrations": "Ինտեգրացիաներ",
+    "migration": "Միգրացիա",
+    "settings": "Կարգավորումներ",
+    "settingsChildren": {
+      "general": "Ընդհանուր",
+      "products": "Ապրանքներ",
+      "tldPricing": "TLD գնացուցակ",
+      "slides": "Սլայդներ",
+      "emailTemplates": "Նամակների ձևանմուշներ",
+      "gateways": "Վճարային համակարգեր"
+    },
+    "servicesTitle": "Ծառայություններ"
+  },
+  "dashboard": {
+    "title": "Ամփոփագիր",
+    "subtitle": "Բարի վերադարձ — ահա թե ինչ է կատարվում",
+    "live": "Ուղիղ եթեր",
+    "loadingMetrics": "Ցուցանիշները բեռնվում են…",
+    "stats": {
+      "totalRevenue": "Ընդհանուր եկամուտ",
+      "monthlyRevenue": "Ամսական եկամուտ",
+      "activeServices": "Ակտիվ ծառայություններ",
+      "overdueInvoices": "Ուշացած հաշիվ-ապրանքագրեր",
+      "openTickets": "Բաց հայտեր",
+      "totalClients": "Հաճախորդների ընդհանուր թիվ"
+    }
+  },
+  "settings": {
+    "systemSettings": "Համակարգային կարգավորումներ",
+    "table": {
+      "key": "Բանալի",
+      "value": "Արժեք",
+      "description": "Նկարագրություն",
+      "noSettings": "Կարգավորումներ չեն գտնվել։"
+    },
+    "portalAppearance": {
+      "title": "Պորտալի տեսք",
+      "description": "Ո՛ր ձևանմուշն է կիրառում հանրային կայքը։ Փոփոխությունները կիրառվում են հաջորդ էջի բեռնումից։",
+      "template": "Ձևանմուշ",
+      "notSeeded": "<code>{key}</code> կարգավորումը դեռ սերմանված (seed) չէ, ուստի այստեղից փոփոխել հնարավոր չէ։ Մինչև այն կստեղծվի, պորտալն օգտագործում է իր <code>{env}</code> environment փոփոխականը։",
+      "templates": {
+        "aurora": { "label": "Aurora", "hint": "Ընթացիկ լռելյայն ձևանմուշ — մուգ/բաց թեմա, հայկական տառատեսակ" },
+        "classic": { "label": "Classic", "hint": "Սկզբնական կայքի ձևավորումը" }
+      }
+    },
+    "branding": {
+      "title": "Բրենդինգ",
+      "description": "Հանրային կայքի logo-ն և browser tab-ի icon-ը։ Փոփոխությունները կիրառվում են հաջորդ էջի բեռնումից։",
+      "uploading": "Վերբեռնվում է...",
+      "dropOrBrowsePrefix": "Թողեք նկարը կամ",
+      "browse": "ընտրեք ֆայլ",
+      "pasteUrl": "Կամ տեղադրեք նկարի URL...",
+      "logo": { "label": "Logo", "hint": "JPEG, PNG, WebP, SVG — մինչև 5ՄԲ" },
+      "favicon": { "label": "Favicon", "hint": "PNG, SVG, ICO — մինչև 5ՄԲ" }
+    }
+  }
+}

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -1,0 +1,109 @@
+{
+  "common": {
+    "loading": "Загрузка...",
+    "save": "Сохранить",
+    "saving": "Сохранение…",
+    "signOut": "Выйти",
+    "admin": "Админ",
+    "search": "Поиск…",
+    "notifications": "Уведомления",
+    "toggleSidebar": "Показать/скрыть меню",
+    "viewAllNotifications": "Смотреть все уведомления",
+    "newCount": "{count} новых"
+  },
+  "nav": {
+    "dashboard": "Панель управления",
+    "clients": "Клиенты",
+    "clientsChildren": {
+      "view": "Просмотр/поиск клиентов",
+      "users": "Управление пользователями",
+      "sharedHostings": "Общий хостинг",
+      "addons": "Дополнения к услугам",
+      "domainRegistrations": "Регистрации доменов",
+      "cancellations": "Заявки на отмену",
+      "affiliates": "Управление партнёрами"
+    },
+    "billing": "Биллинг",
+    "billingChildren": {
+      "transactions": "Список транзакций",
+      "invoices": "Счета",
+      "billableItems": "Оплачиваемые позиции",
+      "quotes": "Коммерческие предложения",
+      "offlineCc": "Оффлайн-обработка карт",
+      "disputes": "Споры",
+      "gatewayLog": "Лог платёжного шлюза"
+    },
+    "reports": "Отчёты",
+    "orders": "Заказы",
+    "domains": "Домены",
+    "support": "Поддержка",
+    "supportChildren": {
+      "overview": "Обзор поддержки",
+      "tickets": "Тикеты поддержки",
+      "newTicket": "Открыть новый тикет",
+      "predefinedReplies": "Готовые ответы",
+      "announcements": "Объявления",
+      "downloads": "Загрузки",
+      "knowledgebase": "База знаний",
+      "networkIssues": "Сетевые проблемы"
+    },
+    "plugins": "Плагины",
+    "pluginManager": "Менеджер плагинов",
+    "servers": "Серверы",
+    "integrations": "Интеграции",
+    "migration": "Миграция",
+    "settings": "Настройки",
+    "settingsChildren": {
+      "general": "Общее",
+      "products": "Продукты",
+      "tldPricing": "Цены на TLD",
+      "slides": "Слайды",
+      "emailTemplates": "Шаблоны писем",
+      "gateways": "Платёжные шлюзы"
+    },
+    "servicesTitle": "Услуги"
+  },
+  "dashboard": {
+    "title": "Панель управления",
+    "subtitle": "С возвращением — вот что сейчас происходит",
+    "live": "В реальном времени",
+    "loadingMetrics": "Загрузка показателей…",
+    "stats": {
+      "totalRevenue": "Общий доход",
+      "monthlyRevenue": "Доход за месяц",
+      "activeServices": "Активные услуги",
+      "overdueInvoices": "Просроченные счета",
+      "openTickets": "Открытые тикеты",
+      "totalClients": "Всего клиентов"
+    }
+  },
+  "settings": {
+    "systemSettings": "Системные настройки",
+    "table": {
+      "key": "Ключ",
+      "value": "Значение",
+      "description": "Описание",
+      "noSettings": "Настройки не найдены."
+    },
+    "portalAppearance": {
+      "title": "Оформление портала",
+      "description": "Какой шаблон использует публичная витрина. Изменения вступают в силу при следующей загрузке страницы.",
+      "template": "Шаблон",
+      "notSeeded": "Настройка <code>{key}</code> ещё не заполнена (seed), поэтому изменить её здесь нельзя. Пока она не создана, портал использует переменную окружения <code>{env}</code>.",
+      "templates": {
+        "aurora": { "label": "Aurora", "hint": "Текущий шаблон по умолчанию — тёмная/светлая тема, армянская типографика" },
+        "classic": { "label": "Classic", "hint": "Оригинальный дизайн витрины" }
+      }
+    },
+    "branding": {
+      "title": "Брендинг",
+      "description": "Логотип витрины и иконка вкладки браузера. Изменения вступают в силу при следующей загрузке страницы.",
+      "uploading": "Загрузка...",
+      "dropOrBrowsePrefix": "Перетащите изображение или",
+      "browse": "выберите файл",
+      "pasteUrl": "Или вставьте URL изображения...",
+      "logo": { "label": "Логотип", "hint": "JPEG, PNG, WebP, SVG — до 5МБ" },
+      "favicon": { "label": "Favicon", "hint": "PNG, SVG, ICO — до 5МБ" }
+    }
+  }
+}

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -2,9 +2,11 @@ import { createApp } from 'vue'
 import { pinia } from './pinia'
 import App from './App.vue'
 import router from './router'
+import { i18n } from './i18n'
 import './assets/main.css'
 
 const app = createApp(App)
 app.use(pinia)
 app.use(router)
+app.use(i18n)
 app.mount('#app')

--- a/admin/src/modules/dashboard/views/DashboardView.vue
+++ b/admin/src/modules/dashboard/views/DashboardView.vue
@@ -3,9 +3,11 @@
  * Admin dashboard — displays high-level system statistics.
  */
 import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useDashboardStore } from '../stores/dashboardStore'
 
 const store = useDashboardStore()
+const { t } = useI18n()
 
 onMounted(store.fetchStats)
 
@@ -13,7 +15,7 @@ onMounted(store.fetchStats)
 const statConfig = [
   {
     key: 'totalRevenue' as const,
-    label: 'Total Revenue',
+    labelKey: 'dashboard.stats.totalRevenue',
     format: (v: number) => `$${v.toLocaleString()}`,
     color: 'text-text-primary',
     glow: true,
@@ -21,7 +23,7 @@ const statConfig = [
   },
   {
     key: 'monthlyRevenue' as const,
-    label: 'Monthly Revenue',
+    labelKey: 'dashboard.stats.monthlyRevenue',
     format: (v: number) => `$${v.toLocaleString()}`,
     color: 'text-text-primary',
     glow: false,
@@ -29,7 +31,7 @@ const statConfig = [
   },
   {
     key: 'activeServices' as const,
-    label: 'Active Services',
+    labelKey: 'dashboard.stats.activeServices',
     format: (v: number) => v.toString(),
     color: 'text-status-green',
     glow: false,
@@ -37,7 +39,7 @@ const statConfig = [
   },
   {
     key: 'overdueInvoices' as const,
-    label: 'Overdue Invoices',
+    labelKey: 'dashboard.stats.overdueInvoices',
     format: (v: number) => v.toString(),
     color: 'text-status-red',
     glow: false,
@@ -45,7 +47,7 @@ const statConfig = [
   },
   {
     key: 'openTickets' as const,
-    label: 'Open Tickets',
+    labelKey: 'dashboard.stats.openTickets',
     format: (v: number) => v.toString(),
     color: 'text-status-yellow',
     glow: false,
@@ -53,7 +55,7 @@ const statConfig = [
   },
   {
     key: 'totalClients' as const,
-    label: 'Total Clients',
+    labelKey: 'dashboard.stats.totalClients',
     format: (v: number) => v.toString(),
     color: 'text-text-primary',
     glow: false,
@@ -68,21 +70,21 @@ const statConfig = [
     <!-- Page header -->
     <div class="flex items-start justify-between mb-8">
       <div>
-        <h1 class="font-display text-[1.75rem] font-bold text-text-primary tracking-tight leading-none mb-1.5">Dashboard</h1>
-        <p class="text-sm text-text-secondary">Welcome back — here's what's happening</p>
+        <h1 class="font-display text-[1.75rem] font-bold text-text-primary tracking-tight leading-none mb-1.5">{{ t('dashboard.title') }}</h1>
+        <p class="text-sm text-text-secondary">{{ t('dashboard.subtitle') }}</p>
       </div>
 
       <!-- Live badge -->
       <div class="flex items-center gap-2 text-[0.68rem] font-semibold uppercase tracking-widest text-status-green bg-status-green/8 border border-status-green/20 rounded-full px-3 py-1.5">
         <span class="w-1.5 h-1.5 rounded-full bg-status-green animate-pulse shrink-0"/>
-        Live
+        {{ t('dashboard.live') }}
       </div>
     </div>
 
     <!-- Loading -->
     <div v-if="store.loading" class="flex items-center gap-3 text-text-secondary text-sm">
       <span class="w-4 h-4 rounded-full border-2 border-primary-500/20 border-t-primary-500 animate-spin" />
-      Loading metrics…
+      {{ t('dashboard.loadingMetrics') }}
     </div>
 
     <!-- Error -->
@@ -105,7 +107,7 @@ const statConfig = [
           style="background: radial-gradient(circle at 100% 0%, #0ea5e9, transparent 60%);"
         />
 
-        <p class="text-[0.72rem] font-semibold uppercase tracking-[0.07em] text-text-muted mb-3">{{ stat.label }}</p>
+        <p class="text-[0.72rem] font-semibold uppercase tracking-[0.07em] text-text-muted mb-3">{{ t(stat.labelKey) }}</p>
 
         <p class="font-display text-[2rem] font-bold tracking-tight leading-none" :class="stat.color">
           {{ stat.format(store.stats[stat.key]) }}

--- a/admin/src/modules/settings/components/BrandingCard.vue
+++ b/admin/src/modules/settings/components/BrandingCard.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+/**
+ * Branding card — uploads the storefront's logo and favicon.
+ *
+ * Mirrors the slide image uploader (`SlideFormView.vue`): drag-and-drop or
+ * browse, uploaded straight to disk via a dedicated endpoint that returns a
+ * URL, which is what actually gets saved to the setting. The setting itself
+ * still accepts a pasted URL too, for an operator who already hosts the file
+ * elsewhere and would rather not upload a copy.
+ */
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { Setting } from '../../../types/models'
+
+const props = defineProps<{
+  /** All system settings, as loaded from the backend. */
+  settings: Setting[]
+  /** True while a save is in flight. */
+  saving?: boolean
+}>()
+
+const emit = defineEmits<{ save: [id: number, value: string] }>()
+
+const { t } = useI18n()
+
+/** One branding image field: which setting key it saves to, and upload constraints. */
+interface BrandingField {
+  key: string
+  kind: 'logo' | 'favicon'
+  labelKey: string
+  hintKey: string
+  accept: string
+  /** Preview box size — the favicon is square and small, the logo wide and short. */
+  previewClass: string
+}
+
+const FIELDS: BrandingField[] = [
+  {
+    key: 'portal.logo',
+    kind: 'logo',
+    labelKey: 'settings.branding.logo.label',
+    hintKey: 'settings.branding.logo.hint',
+    accept: 'image/jpeg,image/png,image/webp,image/gif,image/svg+xml',
+    previewClass: 'w-32 h-14',
+  },
+  {
+    key: 'portal.favicon',
+    kind: 'favicon',
+    labelKey: 'settings.branding.favicon.label',
+    hintKey: 'settings.branding.favicon.hint',
+    accept: 'image/png,image/svg+xml,image/x-icon',
+    previewClass: 'w-10 h-10',
+  },
+]
+
+/** Per-field UI state, keyed by setting key. */
+const draft = ref<Record<string, string>>({})
+const uploading = ref<Record<string, boolean>>({})
+const dragging = ref<Record<string, boolean>>({})
+const uploadError = ref<Record<string, string | null>>({})
+
+/**
+ * The stored setting row for a field, if it has been seeded.
+ *
+ * @param field - The branding field.
+ */
+function settingOf(field: BrandingField): Setting | undefined {
+  return props.settings.find(s => s.key === field.key)
+}
+
+/**
+ * Current value shown for a field: the operator's unsaved edit, or what is stored.
+ *
+ * @param field - The branding field.
+ */
+function valueOf(field: BrandingField): string {
+  return draft.value[field.key] ?? settingOf(field)?.value ?? ''
+}
+
+/**
+ * Whether a field has an edit worth saving.
+ *
+ * @param field - The branding field.
+ */
+function isDirty(field: BrandingField): boolean {
+  return field.key in draft.value && draft.value[field.key] !== (settingOf(field)?.value ?? '')
+}
+
+/**
+ * Saves one field. No-op when the setting row does not exist yet or nothing changed.
+ *
+ * @param field - The branding field.
+ */
+function save(field: BrandingField): void {
+  const setting = settingOf(field)
+  if (!setting || !isDirty(field)) return
+  // isDirty confirmed field.key is a present, defined entry in draft.
+  emit('save', setting.id, draft.value[field.key]!)
+}
+
+/**
+ * Uploads a file for one field and stages the returned URL as its draft.
+ *
+ * Raw fetch rather than the JSON-only API helper: a FormData body needs the
+ * browser to set its own multipart boundary, which a fixed
+ * `Content-Type: application/json` header would break.
+ *
+ * @param field - The branding field being uploaded for.
+ * @param file - The image file to upload.
+ */
+async function uploadFile(field: BrandingField, file: File): Promise<void> {
+  uploadError.value[field.key] = null
+  uploading.value[field.key] = true
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    const response = await fetch(`/api/admin/settings/branding/${field.kind}`, {
+      method: 'POST',
+      body: formData,
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    })
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null)
+      throw new Error(body?.error ?? `Upload failed (${response.status})`)
+    }
+
+    const result: { url: string } = await response.json()
+    draft.value[field.key] = result.url
+  } catch (err) {
+    uploadError.value[field.key] = err instanceof Error ? err.message : 'Upload failed'
+  } finally {
+    uploading.value[field.key] = false
+  }
+}
+
+/**
+ * Handles a file picked via the hidden input.
+ *
+ * @param field - The branding field.
+ * @param e - The input change event.
+ */
+function onFileSelect(field: BrandingField, e: Event): void {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (file) void uploadFile(field, file)
+  input.value = ''
+}
+
+/**
+ * Handles a file dropped on the drop zone.
+ *
+ * @param field - The branding field.
+ * @param e - The drag event.
+ */
+function onFileDrop(field: BrandingField, e: DragEvent): void {
+  dragging.value[field.key] = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file) void uploadFile(field, file)
+}
+</script>
+
+<template>
+  <section class="bg-surface-card border border-border rounded-2xl p-6 mb-6">
+    <h2 class="font-display text-lg font-bold text-text-primary">{{ t('settings.branding.title') }}</h2>
+    <p class="text-sm text-text-secondary mt-1">{{ t('settings.branding.description') }}</p>
+
+    <div class="mt-5 flex flex-col gap-6">
+      <div v-for="field in FIELDS" :key="field.key">
+        <label class="block text-sm font-medium text-text-secondary mb-1.5">{{ t(field.labelKey) }}</label>
+
+        <div class="flex items-start gap-4">
+          <!-- Preview -->
+          <div
+            v-if="valueOf(field)"
+            class="relative rounded-lg border border-border overflow-hidden shrink-0 bg-[#1a1a2e] flex items-center justify-center group"
+            :class="field.previewClass"
+          >
+            <img :src="valueOf(field)" :alt="t(field.labelKey)" class="max-w-full max-h-full object-contain" />
+            <button
+              type="button"
+              class="absolute top-1 right-1 w-5 h-5 flex items-center justify-center rounded-full bg-black/60 text-white/80 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
+              @click="draft[field.key] = ''"
+            >
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+            </button>
+          </div>
+
+          <div class="flex-1 min-w-[220px]">
+            <!-- Drop zone -->
+            <label
+              class="flex flex-col items-center justify-center w-full h-20 border-2 border-dashed rounded-lg cursor-pointer transition-colors"
+              :class="dragging[field.key]
+                ? 'border-primary-500 bg-primary-500/5'
+                : 'border-border hover:border-white/20 bg-[#1a1a2e]'"
+              @dragover.prevent="dragging[field.key] = true"
+              @dragleave.prevent="dragging[field.key] = false"
+              @drop.prevent="onFileDrop(field, $event)"
+            >
+              <div v-if="uploading[field.key]" class="flex items-center gap-2 text-sm text-text-muted">
+                <span class="w-4 h-4 rounded-full border-2 border-primary-500/20 border-t-primary-500 animate-spin" />
+                {{ t('settings.branding.uploading') }}
+              </div>
+              <div v-else class="flex flex-col items-center gap-1">
+                <svg class="w-5 h-5 text-text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/></svg>
+                <span class="text-xs text-text-muted">{{ t('settings.branding.dropOrBrowsePrefix') }} <span class="text-primary-400">{{ t('settings.branding.browse') }}</span></span>
+                <span class="text-[0.65rem] text-text-muted/60">{{ t(field.hintKey) }}</span>
+              </div>
+              <input
+                type="file"
+                :accept="field.accept"
+                class="hidden"
+                @change="onFileSelect(field, $event)"
+              />
+            </label>
+
+            <div class="flex items-center gap-2 mt-2">
+              <input
+                :value="valueOf(field)"
+                type="text"
+                :placeholder="t('settings.branding.pasteUrl')"
+                class="flex-1 bg-[#1a1a2e] border border-border rounded-lg px-3 py-1.5 text-xs text-text-primary placeholder-text-muted focus:outline-none focus:border-primary-500/50 transition-colors"
+                @input="draft[field.key] = ($event.target as HTMLInputElement).value"
+              />
+              <button
+                v-if="isDirty(field)"
+                type="button"
+                :disabled="saving"
+                class="shrink-0 rounded-lg bg-status-green/15 border border-status-green/40 px-3 py-1.5 text-xs font-semibold text-status-green transition-colors hover:bg-status-green/25 disabled:cursor-not-allowed disabled:opacity-40"
+                @click="save(field)"
+              >
+                {{ saving ? t('common.saving') : t('common.save') }}
+              </button>
+            </div>
+            <p v-if="uploadError[field.key]" class="text-xs text-status-red mt-1">{{ uploadError[field.key] }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/admin/src/modules/settings/components/PortalAppearanceCard.vue
+++ b/admin/src/modules/settings/components/PortalAppearanceCard.vue
@@ -8,6 +8,7 @@
  * indication why. Constraining the input removes the failure entirely.
  */
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { Setting } from '../../../types/models'
 
 const props = defineProps<{
@@ -19,10 +20,12 @@ const props = defineProps<{
 
 const emit = defineEmits<{ save: [id: number, value: string] }>()
 
+const { t } = useI18n()
+
 /** Templates the portal ships. Mirrors client/templates/types.ts. */
 const TEMPLATES = [
-  { value: 'aurora', label: 'Aurora', hint: 'Current default — dark/light, Armenian typography' },
-  { value: 'classic', label: 'Classic', hint: 'The original storefront design' },
+  { value: 'aurora', labelKey: 'settings.portalAppearance.templates.aurora.label', hintKey: 'settings.portalAppearance.templates.aurora.hint' },
+  { value: 'classic', labelKey: 'settings.portalAppearance.templates.classic.label', hintKey: 'settings.portalAppearance.templates.classic.hint' },
 ]
 
 const KEY = 'portal.template'
@@ -57,9 +60,9 @@ watch(() => setting.value?.value, (stored) => {
 
 <template>
   <section class="bg-surface-card border border-border rounded-2xl p-6 mb-6">
-    <h2 class="font-display text-lg font-bold text-text-primary">Portal appearance</h2>
+    <h2 class="font-display text-lg font-bold text-text-primary">{{ t('settings.portalAppearance.title') }}</h2>
     <p class="text-sm text-text-secondary mt-1">
-      Which template the public storefront renders. Changes take effect on the next page load.
+      {{ t('settings.portalAppearance.description') }}
     </p>
 
     <!--
@@ -70,21 +73,18 @@ watch(() => setting.value?.value, (stored) => {
     <div
       v-if="!setting"
       class="mt-4 rounded-xl border border-status-yellow/30 bg-status-yellow/10 p-4 text-sm text-status-yellow"
-    >
-      The <code class="font-mono">{{ KEY }}</code> setting has not been seeded yet, so it cannot be
-      changed here. Until it exists the portal uses its
-      <code class="font-mono">NUXT_PUBLIC_PORTAL_TEMPLATE</code> environment variable.
-    </div>
+      v-html="t('settings.portalAppearance.notSeeded', { key: KEY, env: 'NUXT_PUBLIC_PORTAL_TEMPLATE' })"
+    />
 
     <div v-else class="mt-5 flex flex-wrap items-end gap-4">
       <label class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium text-text-secondary">Template</span>
+        <span class="text-sm font-medium text-text-secondary">{{ t('settings.portalAppearance.template') }}</span>
         <select
           v-model="selected"
           class="min-w-[220px] rounded-xl border border-border bg-surface-elevated px-3 py-2 text-sm text-text-primary focus:border-text-secondary focus:outline-none"
         >
           <option v-for="template in TEMPLATES" :key="template.value" :value="template.value">
-            {{ template.label }}
+            {{ t(template.labelKey) }}
           </option>
         </select>
       </label>
@@ -95,11 +95,11 @@ watch(() => setting.value?.value, (stored) => {
         :disabled="!dirty || saving"
         @click="save"
       >
-        {{ saving ? 'Saving…' : 'Save' }}
+        {{ saving ? t('common.saving') : t('common.save') }}
       </button>
 
       <p class="text-sm text-text-muted">
-        {{ TEMPLATES.find(t => t.value === selected)?.hint }}
+        {{ t(TEMPLATES.find(tpl => tpl.value === selected)?.hintKey ?? '') }}
       </p>
     </div>
   </section>

--- a/admin/src/modules/settings/views/SystemSettingsView.vue
+++ b/admin/src/modules/settings/views/SystemSettingsView.vue
@@ -4,12 +4,15 @@
  * control for the storefront template.
  */
 import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '../stores/settingsStore'
 import PortalAppearanceCard from '../components/PortalAppearanceCard.vue'
+import BrandingCard from '../components/BrandingCard.vue'
 import type { Setting } from '../../../types/models'
 
 const store = useSettingsStore()
 const saving = ref(false)
+const { t } = useI18n()
 
 onMounted(store.fetchSettings)
 
@@ -87,10 +90,10 @@ async function saveRow(setting: Setting) {
       the same tokens the rest of the panel uses.
     -->
     <h1 class="font-display text-[1.75rem] font-bold text-text-primary tracking-tight leading-none mb-6">
-      System Settings
+      {{ t('settings.systemSettings') }}
     </h1>
 
-    <div v-if="store.loading" class="text-text-secondary">Loading...</div>
+    <div v-if="store.loading" class="text-text-secondary">{{ t('common.loading') }}</div>
     <template v-else>
       <div
         v-if="store.error"
@@ -100,14 +103,15 @@ async function saveRow(setting: Setting) {
       </div>
 
       <PortalAppearanceCard :settings="store.settings" :saving="saving" @save="onSave" />
+      <BrandingCard :settings="store.settings" :saving="saving" @save="onSave" />
 
       <div class="bg-surface-card border border-border rounded-2xl overflow-hidden overflow-x-auto">
         <table class="w-full text-sm">
           <thead class="bg-surface-elevated text-text-secondary uppercase text-xs">
             <tr>
-              <th class="px-4 py-3 text-left font-semibold">Key</th>
-              <th class="px-4 py-3 text-left font-semibold">Value</th>
-              <th class="px-4 py-3 text-left font-semibold">Description</th>
+              <th class="px-4 py-3 text-left font-semibold">{{ t('settings.table.key') }}</th>
+              <th class="px-4 py-3 text-left font-semibold">{{ t('settings.table.value') }}</th>
+              <th class="px-4 py-3 text-left font-semibold">{{ t('settings.table.description') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-border">
@@ -129,14 +133,14 @@ async function saveRow(setting: Setting) {
                     class="shrink-0 rounded-lg bg-text-primary px-3 py-1.5 text-sm font-medium text-surface-card disabled:opacity-50"
                     @click="saveRow(setting)"
                   >
-                    {{ saving ? 'Saving…' : 'Save' }}
+                    {{ saving ? t('common.saving') : t('common.save') }}
                   </button>
                 </div>
               </td>
               <td class="px-4 py-3 text-text-secondary">{{ setting.description ?? '—' }}</td>
             </tr>
             <tr v-if="store.settings.length === 0">
-              <td colspan="3" class="px-4 py-6 text-center text-text-muted">No settings found.</td>
+              <td colspan="3" class="px-4 py-6 text-center text-text-muted">{{ t('settings.table.noSettings') }}</td>
             </tr>
           </tbody>
         </table>

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -746,6 +746,36 @@
   resolved "https://registry.npmjs.org/@innovayse/geo-atlas/-/geo-atlas-2.0.2.tgz"
   integrity sha512-gGe9B4vu+vBu5Z0ATWJI5I7SQHKvitUP6hVgwumxPnVwama9iO4Dq14ZLWEXqjbFHHUXCEe/BR6D5qy6Kwd0ww==
 
+"@intlify/core-base@11.4.10":
+  version "11.4.10"
+  resolved "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.10.tgz"
+  integrity sha512-+yJ74JRWVJokdgG9zYNMyTSzeNV3O9T4vVxk8PvLFHmI+R/BYA//cITh7vhRK37hWLZ4/kTcKcUz1dlWOpypIg==
+  dependencies:
+    "@intlify/devtools-types" "11.4.10"
+    "@intlify/message-compiler" "11.4.10"
+    "@intlify/shared" "11.4.10"
+
+"@intlify/devtools-types@11.4.10":
+  version "11.4.10"
+  resolved "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.10.tgz"
+  integrity sha512-xZxzZsAuu6/0zoLRVQWdpXWe5Kjl0LnWpjlQA3r9u9FbLYMhapqt7IwkgQyn0Tm2GUNAqhj9eZiUmYOrB024BQ==
+  dependencies:
+    "@intlify/core-base" "11.4.10"
+    "@intlify/shared" "11.4.10"
+
+"@intlify/message-compiler@11.4.10":
+  version "11.4.10"
+  resolved "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.10.tgz"
+  integrity sha512-oUB/scz2EJENXDiUJ7JjZffOrH8UIZ1BuZeHvonbi5fWLavLt04aivuk2OIByOZA0tsci1bkeeQRmwhb5M8Imw==
+  dependencies:
+    "@intlify/shared" "11.4.10"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.4.10":
+  version "11.4.10"
+  resolved "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.10.tgz"
+  integrity sha512-FeImVdPeoSHTm3NBFFZHv0eRP9gQ3F4lj2puDBX5Kw7iiM1uJW6JTf39ian0K/17pbXCI3ef5i9RVsRrALqI6Q==
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
@@ -1329,6 +1359,11 @@
   dependencies:
     "@vue/compiler-dom" "3.5.32"
     "@vue/shared" "3.5.32"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/devtools-api@^7.7.7":
   version "7.7.9"
@@ -2826,7 +2861,7 @@ sortablejs@1.14.0:
   resolved "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz"
   integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
 
-source-map-js@^1.2.1:
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -3056,6 +3091,16 @@ vue-eslint-parser@^10.0.0, vue-eslint-parser@^10.4.0:
     espree "^10.3.0 || ^11.0.0"
     esquery "^1.6.0"
     semver "^7.6.3"
+
+vue-i18n@^11.4.10:
+  version "11.4.10"
+  resolved "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.10.tgz"
+  integrity sha512-Lp+BjOxqzOY87DS6Z8KrQrpiTr9IN/Lt4kZEilwyXG2Wrx+AcU6IVsAW92HNXtVcn1HFFPV6ty41p9e/qDpyvg==
+  dependencies:
+    "@intlify/core-base" "11.4.10"
+    "@intlify/devtools-types" "11.4.10"
+    "@intlify/shared" "11.4.10"
+    "@vue/devtools-api" "^6.5.0"
 
 vue-router@^5.0.4:
   version "5.0.4"

--- a/backend/src/Innovayse.API/Admin/SettingsController.cs
+++ b/backend/src/Innovayse.API/Admin/SettingsController.cs
@@ -14,10 +14,11 @@ using Wolverine;
 /// Admin endpoints for managing system configuration settings.
 /// </summary>
 /// <param name="bus">Wolverine message bus.</param>
+/// <param name="env">Web host environment for resolving file paths.</param>
 [ApiController]
 [Route("api/admin/settings")]
 [Authorize(Roles = Roles.Admin)]
-public sealed class SettingsController(IMessageBus bus) : ControllerBase
+public sealed class SettingsController(IMessageBus bus, IWebHostEnvironment env) : ControllerBase
 {
     /// <summary>Returns all configuration settings.</summary>
     /// <param name="ct">Cancellation token.</param>
@@ -50,5 +51,64 @@ public sealed class SettingsController(IMessageBus bus) : ControllerBase
     {
         await bus.InvokeAsync(new UpdateSettingCommand(id, request.Value), ct);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Favicon allows a narrower set than the logo: browsers render an SVG or PNG tab
+    /// icon directly, and .ico stays accepted for operators who already have one, but a
+    /// JPEG/WebP/GIF favicon renders as an opaque square with no transparency —
+    /// technically valid, visually wrong for what this field is for.
+    /// </summary>
+    private static readonly HashSet<string> _allowedLogoTypes =
+        ["image/jpeg", "image/png", "image/webp", "image/gif", "image/svg+xml"];
+
+    private static readonly HashSet<string> _allowedFaviconTypes =
+        ["image/png", "image/svg+xml", "image/x-icon", "image/vnd.microsoft.icon"];
+
+    /// <summary>
+    /// Uploads a storefront branding image (logo or favicon) and returns its URL.
+    /// </summary>
+    /// <param name="kind">Which branding image this is: <c>logo</c> or <c>favicon</c>.</param>
+    /// <param name="file">The image file to upload.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The relative URL path to the uploaded image.</returns>
+    [HttpPost("branding/{kind}")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> UploadBrandingImageAsync(string kind, IFormFile file, CancellationToken ct)
+    {
+        if (kind is not ("logo" or "favicon"))
+        {
+            return BadRequest(new { error = "kind must be 'logo' or 'favicon'." });
+        }
+
+        if (file is null || file.Length == 0)
+        {
+            return BadRequest(new { error = "No file provided." });
+        }
+
+        var allowedTypes = kind == "favicon" ? _allowedFaviconTypes : _allowedLogoTypes;
+        if (!allowedTypes.Contains(file.ContentType))
+        {
+            return BadRequest(new { error = $"Invalid file type for {kind}." });
+        }
+
+        if (file.Length > 5 * 1024 * 1024)
+        {
+            return BadRequest(new { error = "File too large. Maximum 5MB." });
+        }
+
+        var webRoot = env.WebRootPath ?? Path.Combine(env.ContentRootPath, "wwwroot");
+        var uploadsDir = Path.Combine(webRoot, "uploads", "branding");
+        Directory.CreateDirectory(uploadsDir);
+
+        var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+        var fileName = $"{kind}-{Guid.NewGuid()}{ext}";
+        var filePath = Path.Combine(uploadsDir, fileName);
+
+        await using var stream = new FileStream(filePath, FileMode.Create);
+        await file.CopyToAsync(stream, ct);
+
+        return Ok(new { url = $"/uploads/branding/{fileName}" });
     }
 }

--- a/backend/src/Innovayse.Application/Admin/Queries/GetPublicSettings/GetPublicSettingsHandler.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetPublicSettings/GetPublicSettingsHandler.cs
@@ -22,6 +22,8 @@ public sealed class GetPublicSettingsHandler(ISettingRepository repo)
     private static readonly HashSet<string> _publicKeys =
     [
         "portal.template",
+        "portal.logo",
+        "portal.favicon",
         "portal.contact.whatsapp",
         "portal.contact.telegram",
         "portal.chat.provider",

--- a/backend/src/Innovayse.Application/Admin/Services/PortalSettingsSeeder.cs
+++ b/backend/src/Innovayse.Application/Admin/Services/PortalSettingsSeeder.cs
@@ -28,6 +28,8 @@ public static class PortalSettingsSeeder
     private static readonly (string Key, string Value, string Description)[] _defaults =
     [
         ("portal.template",              "aurora", "Active storefront template: aurora or classic"),
+        ("portal.logo",                   "",       "URL of the storefront header logo. Empty renders the built-in mark and wordmark."),
+        ("portal.favicon",                "",       "URL of the browser tab icon. Empty falls back to the built-in favicon."),
         ("portal.contact.whatsapp",      "",       "WhatsApp number in international format, no leading +. Empty hides the action."),
         ("portal.contact.telegram",      "",       "Telegram handle without the @. Empty hides the action."),
         ("portal.chat.provider",         "",       "Live chat provider: chatwoot, or empty to disable the widget."),

--- a/client/app.vue
+++ b/client/app.vue
@@ -62,10 +62,17 @@ watch(locale, (newLocale) => {
 // Correct token for SSR injection
 const currentToken = computed(() => tokenMap[locale.value] ?? DEFAULT_CHAT_TOKEN)
 
+/** Operator-uploaded favicon, admin-managed with an environment fallback. Empty keeps nuxt.config's static default. */
+const { get: getPortalSetting } = usePortalSettings()
+const faviconUrl = computed(() => getPortalSetting('portal.favicon', 'portalFavicon'))
+
 useHead({
   htmlAttrs: {
     lang: () => langMap[locale.value] ?? 'en'
   },
+  // Overrides nuxt.config's static <link rel="icon">. Empty leaves it alone —
+  // a fresh install with nothing uploaded still gets the built-in favicon.
+  link: () => faviconUrl.value ? [{ rel: 'icon', href: faviconUrl.value }] : [],
   script: [
     {
       // Blocking script: always force dark on public pages

--- a/client/components/layout/Header.vue
+++ b/client/components/layout/Header.vue
@@ -7,7 +7,22 @@
       <div class="flex items-center justify-between h-16 lg:h-20">
         <!-- Logo -->
         <NuxtLink :to="localePath('/')" class="flex items-center">
+          <!--
+            Plain img, not NuxtImg, when an operator has uploaded a logo: IPX
+            optimises by reading the file straight off local disk, and an
+            uploaded logo is proxied from the API's wwwroot/uploads rather than
+            living in this app's public/ — the same reason slide images
+            (ProductsFullSlider.vue) render as plain img too.
+          -->
+          <img
+            v-if="uploadedLogoUrl"
+            :src="uploadedLogoUrl"
+            alt="Innovayse"
+            loading="eager"
+            class="h-10 sm:h-12 lg:h-14 xl:h-16 w-auto max-w-[200px] object-contain transition-transform hover:scale-105"
+          />
           <NuxtImg
+            v-else
             src="/logo.svg"
             alt="Innovayse"
             width="200"
@@ -307,6 +322,10 @@ const navLinks = computed(() => [
 /** Authentication state for the Client Area button */
 const { isLoggedIn, user, fetchUser, logout } = useClientAuth()
 const runtimeConfig = useRuntimeConfig()
+
+/** Operator-uploaded logo, admin-managed with an environment fallback. Empty renders the built-in /logo.svg. */
+const { get: getPortalSetting } = usePortalSettings()
+const uploadedLogoUrl = computed(() => getPortalSetting('portal.logo', 'portalLogo'))
 
 /** In SSO mode, link directly to SSO authorize (skips "Continue with Innovayse" page) */
 const clientAreaHref = computed(() =>

--- a/client/components/ui/FloatingActions.vue
+++ b/client/components/ui/FloatingActions.vue
@@ -111,7 +111,7 @@
       :class="isOpen ? 'bg-gray-700 rotate-45' : 'bg-gradient-to-br from-cyan-500 to-primary-600'"
       :style="isOpen ? '' : 'box-shadow: 0 4px 24px rgba(6,182,212,0.5);'"
       :aria-expanded="isOpen"
-      aria-label="Contact us"
+      :aria-label="$t('contact.info.quickConnect.toggle')"
       @click="isOpen = !isOpen"
     >
       <div v-if="!isOpen" class="absolute inset-0 rounded-full bg-cyan-500 animate-ping opacity-25" />

--- a/client/locales/en/contact.json
+++ b/client/locales/en/contact.json
@@ -60,7 +60,8 @@
         "title": "Quick Connect",
         "telegram": "Telegram",
         "whatsapp": "WhatsApp",
-        "liveChat": "Live Chat"
+        "liveChat": "Live Chat",
+        "toggle": "Contact us"
       }
     }
   }

--- a/client/locales/hy/contact.json
+++ b/client/locales/hy/contact.json
@@ -60,7 +60,8 @@
         "title": "Արագ կապ",
         "telegram": "Telegram",
         "whatsapp": "WhatsApp",
-        "liveChat": "Առցանց զրույց"
+        "liveChat": "Առցանց զրույց",
+        "toggle": "Կապ մեզ հետ"
       }
     }
   }

--- a/client/locales/ru/contact.json
+++ b/client/locales/ru/contact.json
@@ -60,7 +60,8 @@
         "title": "Быстрая связь",
         "telegram": "Telegram",
         "whatsapp": "WhatsApp",
-        "liveChat": "Живой чат"
+        "liveChat": "Живой чат",
+        "toggle": "Связаться с нами"
       }
     }
   }

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -91,6 +91,10 @@ export default defineNuxtConfig({
       // Active portal template. Phase 4 lets an admin override this from settings;
       // until then it is the only switch. Unknown values fall back to 'aurora'.
       portalTemplate: process.env.NUXT_PUBLIC_PORTAL_TEMPLATE || 'aurora',
+      // The header logo and browser tab icon, settable from the admin panel.
+      // Empty renders the template's built-in mark/wordmark and static favicon.
+      portalLogo: process.env.NUXT_PUBLIC_PORTAL_LOGO || '',
+      portalFavicon: process.env.NUXT_PUBLIC_PORTAL_FAVICON || '',
       // Header app launcher. Off unless a deployment actually runs the sibling
       // apps it links to; every app URL below has a development default, so
       // presence of a URL cannot decide this on its own.

--- a/client/templates/aurora/layout/Header.vue
+++ b/client/templates/aurora/layout/Header.vue
@@ -3,10 +3,13 @@
     class="relative flex flex-wrap items-center justify-between gap-x-6 gap-y-4 border-b border-line px-[clamp(16px,4vw,48px)] py-[18px] font-aurora"
   >
     <NuxtLink :to="localePath('/')" class="flex items-center gap-3 text-tx">
-      <span
-        class="grid h-[34px] w-[34px] place-items-center rounded-[10px] bg-brand text-[17px] font-extrabold text-[#08090F]"
-      >i</span>
-      <span class="text-[19px] font-bold -tracking-[0.01em]">Innovayse</span>
+      <img v-if="logoUrl" :src="logoUrl" alt="" class="h-[34px] w-auto max-w-[140px] object-contain" />
+      <template v-else>
+        <span
+          class="grid h-[34px] w-[34px] place-items-center rounded-[10px] bg-brand text-[17px] font-extrabold text-[#08090F]"
+        >i</span>
+        <span class="text-[19px] font-bold -tracking-[0.01em]">Innovayse</span>
+      </template>
     </NuxtLink>
 
     <nav class="hidden min-w-0 flex-auto flex-wrap items-center gap-x-[26px] gap-y-3 text-[15px] text-mut xl:flex">
@@ -90,8 +93,12 @@ const { t } = useI18n()
 const localePath = useLocalePath()
 const cart = useCartStore()
 const menuOpen = ref(false)
+const { get: getPortalSetting } = usePortalSettings()
 
 const cartCount = computed(() => cart.items.length)
+
+/** Operator-uploaded logo, admin-managed with an environment fallback. Empty renders the built-in mark and wordmark. */
+const logoUrl = computed(() => getPortalSetting('portal.logo', 'portalLogo'))
 
 const navLinks = computed(() => [
   { key: 'hosting', label: t('aurora.nav.hosting'), to: localePath('/hosting') },

--- a/client/templates/nova/layout/Header.vue
+++ b/client/templates/nova/layout/Header.vue
@@ -15,11 +15,14 @@
 
     <div class="mx-auto flex max-w-[1240px] items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
       <NuxtLink :to="localePath('/')" class="flex shrink-0 items-center gap-2.5 text-nova-ink">
-        <span
-          class="grid h-9 w-9 place-items-center rounded-xl bg-[linear-gradient(135deg,var(--n-brand),var(--n-accent))] text-[17px] font-extrabold text-[#08191f]"
-          aria-hidden="true"
-        >i</span>
-        <span class="text-lg font-bold tracking-tight">Innovayse</span>
+        <img v-if="logoUrl" :src="logoUrl" alt="" class="h-9 w-auto max-w-[120px] object-contain" />
+        <template v-else>
+          <span
+            class="grid h-9 w-9 place-items-center rounded-xl bg-[linear-gradient(135deg,var(--n-brand),var(--n-accent))] text-[17px] font-extrabold text-[#08191f]"
+            aria-hidden="true"
+          >i</span>
+          <span class="text-lg font-bold tracking-tight">Innovayse</span>
+        </template>
       </NuxtLink>
 
       <!--
@@ -168,8 +171,12 @@ const { t } = useI18n()
 const localePath = useLocalePath()
 const cart = useCartStore()
 const route = useRoute()
+const { get: getPortalSetting } = usePortalSettings()
 
 const menuOpen = ref(false)
+
+/** Operator-uploaded logo, admin-managed with an environment fallback. Empty renders the built-in mark and wordmark. */
+const logoUrl = computed(() => getPortalSetting('portal.logo', 'portalLogo'))
 const menuRef = ref<HTMLElement | null>(null)
 const toggleRef = ref<HTMLButtonElement | null>(null)
 


### PR DESCRIPTION
## Summary
- fix(client): translate the floating contact button's aria-label (was hardcoded English)
- feat(admin): add vue-i18n (en/hy/ru) — sidebar, dashboard, settings page chrome
- feat: upload storefront logo + favicon from Admin → Settings, applied across all 3 templates (aurora/nova/classic)

## Test plan
- [ ] Backend: `dotnet build` on Innovayse.API — 0 errors
- [ ] Admin: `vue-tsc --build` — no new errors vs main; `vite build` succeeds
- [ ] Manual: upload a logo/favicon in Admin → Settings → Branding, confirm it renders on the storefront in all 3 templates and in the browser tab
- [ ] Manual: switch admin panel language (EN/ՀՅ/РУ), confirm nav/dashboard/settings translate