### PR TITLE
Cover the payment gateway's HTTP client, guard the unvalidated enum parses

### DIFF
--- a/backend/src/Innovayse.Application/Domains/Commands/UpdateDomain/UpdateDomainValidator.cs
+++ b/backend/src/Innovayse.Application/Domains/Commands/UpdateDomain/UpdateDomainValidator.cs
@@ -1,0 +1,31 @@
+namespace Innovayse.Application.Domains.Commands.UpdateDomain;
+
+using FluentValidation;
+using Innovayse.Domain.Domains;
+
+/// <summary>Validates <see cref="UpdateDomainCommand"/> before the handler executes.</summary>
+/// <remarks>
+/// Added because the handler read <c>Status</c> with <c>Enum.Parse</c> and nothing checked it
+/// first: a mistyped status came back as an <see cref="ArgumentException"/>, which
+/// <c>ExceptionMiddleware</c> has no arm for on purpose, so an admin's typo was answered 500.
+/// </remarks>
+public sealed class UpdateDomainValidator : AbstractValidator<UpdateDomainCommand>
+{
+    /// <summary>Initializes validation rules for domain updates.</summary>
+    public UpdateDomainValidator()
+    {
+        RuleFor(x => x.DomainId).GreaterThan(0);
+
+        // Case-sensitive on purpose. The handler parses this with Enum.Parse<DomainStatus> and
+        // no ignoreCase flag, so "active" would clear an ignoreCase check here and still throw a
+        // line later -- a 500 on a value this validator had just approved. The rule matches the
+        // parse it guards rather than a friendlier version of it; make them agree in the handler
+        // first if the looser spelling is ever wanted.
+        RuleFor(x => x.Status)
+            .NotEmpty()
+            .Must(s => Enum.TryParse<DomainStatus>(s, out _))
+            .WithMessage(
+                "Status must be one of: PendingRegistration, PendingTransfer, Active, Expired, "
+                + "Redemption, Transferred, Cancelled.");
+    }
+}

--- a/backend/src/Innovayse.Application/Migration/Queries/GetMigrationLogs/GetMigrationLogsHandler.cs
+++ b/backend/src/Innovayse.Application/Migration/Queries/GetMigrationLogs/GetMigrationLogsHandler.cs
@@ -2,22 +2,54 @@ namespace Innovayse.Application.Migration.Queries.GetMigrationLogs;
 
 using Innovayse.Application.Migration.Common;
 using Innovayse.Application.Migration.Extensions;
+using Innovayse.Application.Resources;
 using Innovayse.Domain.Migration;
 using Innovayse.Domain.Migration.Interfaces;
+using Microsoft.Extensions.Localization;
 
 /// <summary>Handles <see cref="GetMigrationLogsQuery"/>.</summary>
-public sealed class GetMigrationLogsHandler(IMigrationLogRepository logRepo)
+/// <remarks>
+/// <para>
+/// The two filters arrive as free strings off the query string, and this handler is the only
+/// thing that checks them: by this project's convention a query never carries a FluentValidation
+/// validator, so there is no middleware in front of it to refuse a bad value first. A validator
+/// is therefore not the fix available here, and the guard has to live in the handler.
+/// </para>
+/// <para>
+/// They were read with <c>Enum.Parse</c>, which answers a mistyped <c>?action=</c> with an
+/// <see cref="ArgumentException"/> — and <c>ExceptionMiddleware</c> deliberately has no arm for
+/// that type, because a blanket one would swallow the <see cref="ArgumentNullException"/> and
+/// <see cref="ArgumentOutOfRangeException"/> that derive from it and remove the only place a
+/// genuine programmer error is logged. So a caller's typo fell through to the catch-all and came
+/// back as a 500. <c>TryParse</c> plus a localised refusal makes it the 400 it always was,
+/// without touching that decision.
+/// </para>
+/// </remarks>
+/// <param name="logRepo">Migration log repository.</param>
+/// <param name="localizer">
+/// The refusal sentence, in the culture <c>UseRequestLocalization</c> read off the request. The
+/// handler resolves it itself because the middleware cannot guess which resource key the text of
+/// a plain <see cref="InvalidOperationException"/> came from, and must not string-match to find
+/// out.
+/// </param>
+public sealed class GetMigrationLogsHandler(
+    IMigrationLogRepository logRepo,
+    IStringLocalizer<ValidationMessages> localizer)
 {
     /// <summary>Returns a paginated, filtered list of migration log entries.</summary>
+    /// <param name="query">The job id, the two optional filters, and the page to return.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>One page of log entries together with the unpaged total.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="GetMigrationLogsQuery.Action"/> or
+    /// <see cref="GetMigrationLogsQuery.EntityType"/> is present but names no member of its enum.
+    /// <c>ExceptionMiddleware</c> answers it 400 with code <c>INVALID_OPERATION</c> and the
+    /// sentence resolved here.
+    /// </exception>
     public async Task<MigrationLogPageDto> HandleAsync(GetMigrationLogsQuery query, CancellationToken ct)
     {
-        MigrationLogAction? action = query.Action is not null
-            ? Enum.Parse<MigrationLogAction>(query.Action, ignoreCase: true)
-            : null;
-
-        MigrationEntityType? entityType = query.EntityType is not null
-            ? Enum.Parse<MigrationEntityType>(query.EntityType, ignoreCase: true)
-            : null;
+        var action = ParseFilter<MigrationLogAction>(query.Action);
+        var entityType = ParseFilter<MigrationEntityType>(query.EntityType);
 
         var (items, total) = await logRepo.ListByJobAsync(
             query.JobId, action, entityType, query.Page, query.PageSize, ct);
@@ -27,5 +59,33 @@ public sealed class GetMigrationLogsHandler(IMigrationLogRepository logRepo)
             total,
             query.Page,
             query.PageSize);
+    }
+
+    /// <summary>Reads an optional enum filter off the query string.</summary>
+    /// <typeparam name="TEnum">The enum the filter selects a member of.</typeparam>
+    /// <param name="value">The submitted value, or <see langword="null"/> for "no filter".</param>
+    /// <returns>The parsed member, or <see langword="null"/> when no filter was submitted.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a value was submitted but names no member.
+    /// </exception>
+    /// <remarks>
+    /// <c>ignoreCase</c> preserves what <c>Enum.Parse</c> did here before, so no filter spelling
+    /// that used to work stops working; the only behaviour that changes is the answer to a value
+    /// that never worked at all.
+    /// </remarks>
+    private TEnum? ParseFilter<TEnum>(string? value)
+        where TEnum : struct, Enum
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (!Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed))
+        {
+            throw new InvalidOperationException(localizer["InvalidFilterValue", value]);
+        }
+
+        return parsed;
     }
 }

--- a/backend/src/Innovayse.Application/Resources/ValidationMessages.hy.resx
+++ b/backend/src/Innovayse.Application/Resources/ValidationMessages.hy.resx
@@ -183,4 +183,8 @@
     <value>Հարցման մեկ կամ մի քանի դաշտեր չեն ընդունվել։</value>
     <comment>ExceptionMiddleware, for a message the Wolverine FluentValidation middleware refused. One sentence for every field failure on purpose: the per-field messages are English literals in the validators and are logged, not sent.</comment>
   </data>
+  <data name="InvalidFilterValue" xml:space="preserve">
+    <value>Զտիչի անթույլատրելի արժեք՝ {0}։</value>
+    <comment>GetMigrationLogsHandler. {0} is the value that was submitted for the action or entity-type filter. A query carries no validator in this project, so the handler resolves this itself.</comment>
+  </data>
 </root>

--- a/backend/src/Innovayse.Application/Resources/ValidationMessages.resx
+++ b/backend/src/Innovayse.Application/Resources/ValidationMessages.resx
@@ -227,4 +227,8 @@
     <value>One or more fields in the request were not accepted.</value>
     <comment>ExceptionMiddleware, for a message the Wolverine FluentValidation middleware refused. One sentence for every field failure on purpose: the per-field messages are English literals in the validators and are logged, not sent.</comment>
   </data>
+  <data name="InvalidFilterValue" xml:space="preserve">
+    <value>Invalid filter value: {0}.</value>
+    <comment>GetMigrationLogsHandler. {0} is the value that was submitted for the action or entity-type filter. A query carries no validator in this project, so the handler resolves this itself.</comment>
+  </data>
 </root>

--- a/backend/src/Innovayse.Application/Resources/ValidationMessages.ru.resx
+++ b/backend/src/Innovayse.Application/Resources/ValidationMessages.ru.resx
@@ -183,4 +183,8 @@
     <value>Одно или несколько полей запроса не приняты.</value>
     <comment>ExceptionMiddleware, for a message the Wolverine FluentValidation middleware refused. One sentence for every field failure on purpose: the per-field messages are English literals in the validators and are logged, not sent.</comment>
   </data>
+  <data name="InvalidFilterValue" xml:space="preserve">
+    <value>Недопустимое значение фильтра: {0}.</value>
+    <comment>GetMigrationLogsHandler. {0} is the value that was submitted for the action or entity-type filter. A query carries no validator in this project, so the handler resolves this itself.</comment>
+  </data>
 </root>

--- a/backend/src/Innovayse.Application/Support/Commands/CreateNetworkIssue/CreateNetworkIssueValidator.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/CreateNetworkIssue/CreateNetworkIssueValidator.cs
@@ -1,0 +1,29 @@
+namespace Innovayse.Application.Support.Commands.CreateNetworkIssue;
+
+using FluentValidation;
+using Innovayse.Domain.Support;
+
+/// <summary>Validates <see cref="CreateNetworkIssueCommand"/> before the handler executes.</summary>
+/// <remarks>
+/// Added because the handler read <c>Type</c> and <c>Priority</c> with <c>Enum.Parse</c> and
+/// nothing checked them first, so a bad value reached the caller as a 500 rather than a 400.
+/// </remarks>
+public sealed class CreateNetworkIssueValidator : AbstractValidator<CreateNetworkIssueCommand>
+{
+    /// <summary>Initializes validation rules for network issue creation.</summary>
+    public CreateNetworkIssueValidator()
+    {
+        // ignoreCase on both, matching the handler's Enum.Parse<...>(value, true) exactly. A rule
+        // stricter than the parse it guards would refuse input the handler accepts; a looser one
+        // would approve input the handler throws on.
+        RuleFor(x => x.Type)
+            .NotEmpty()
+            .Must(t => Enum.TryParse<NetworkIssueType>(t, ignoreCase: true, out _))
+            .WithMessage("Type must be one of: Server, Other.");
+
+        RuleFor(x => x.Priority)
+            .NotEmpty()
+            .Must(p => Enum.TryParse<NetworkIssuePriority>(p, ignoreCase: true, out _))
+            .WithMessage("Priority must be one of: Low, Medium, High, Critical.");
+    }
+}

--- a/backend/src/Innovayse.Application/Support/Commands/UpdateNetworkIssue/UpdateNetworkIssueValidator.cs
+++ b/backend/src/Innovayse.Application/Support/Commands/UpdateNetworkIssue/UpdateNetworkIssueValidator.cs
@@ -1,0 +1,35 @@
+namespace Innovayse.Application.Support.Commands.UpdateNetworkIssue;
+
+using FluentValidation;
+using Innovayse.Domain.Support;
+
+/// <summary>Validates <see cref="UpdateNetworkIssueCommand"/> before the handler executes.</summary>
+/// <remarks>
+/// Added because the handler read <c>Type</c>, <c>Priority</c> and <c>Status</c> with
+/// <c>Enum.Parse</c> and nothing checked them first, so a bad value reached the caller as a 500
+/// rather than a 400.
+/// </remarks>
+public sealed class UpdateNetworkIssueValidator : AbstractValidator<UpdateNetworkIssueCommand>
+{
+    /// <summary>Initializes validation rules for network issue updates.</summary>
+    public UpdateNetworkIssueValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+
+        // ignoreCase on all three, matching the handler's Enum.Parse<...>(value, true) exactly.
+        RuleFor(x => x.Type)
+            .NotEmpty()
+            .Must(t => Enum.TryParse<NetworkIssueType>(t, ignoreCase: true, out _))
+            .WithMessage("Type must be one of: Server, Other.");
+
+        RuleFor(x => x.Priority)
+            .NotEmpty()
+            .Must(p => Enum.TryParse<NetworkIssuePriority>(p, ignoreCase: true, out _))
+            .WithMessage("Priority must be one of: Low, Medium, High, Critical.");
+
+        RuleFor(x => x.Status)
+            .NotEmpty()
+            .Must(s => Enum.TryParse<NetworkIssueStatus>(s, ignoreCase: true, out _))
+            .WithMessage("Status must be one of: Reported, Investigating, Scheduled, Resolved.");
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
@@ -353,6 +353,33 @@ public static class DependencyInjection
         // what configures the default client itself.
         services.AddHttpClient(string.Empty)
             .AddNoRetryResilience(o => o.Default);
+
+        // The Inecobank gateway plugin's own named client.
+        //
+        // The plugin asks the factory for its plugin id, and until this existed that name matched
+        // no registration -- and IHttpClientFactory answers an unknown name with a default client
+        // rather than an error. So the one payment gateway in this product was also the last
+        // 100-second path in it: no handler, no retry, no breaker, and a bank having a bad
+        // afternoon holding a checkout thread for a minute and a half.
+        //
+        // Registered here rather than in the provider because the provider has no composition
+        // root of its own: PluginLoader reflects it out of plugins/ and Infrastructure
+        // deliberately does not reference it, so the client name is the whole contract between
+        // the two ends. It is spelled once, on HttpClientResilienceExtensions.
+        //
+        // Retries only getOrderStatusExtended.do. register.do and refund.do are POSTs to the same
+        // host over the same verb, so the method separates nothing and the predicate reads the
+        // endpoint out of the path -- a repeated refund.do is a second refund. The timeout, and
+        // why this money-moving client gets a breaker when the others do not, are argued on
+        // HttpResilienceOptions.Inecobank.
+        services.AddHttpClient(HttpClientResilienceExtensions.InecobankClientName, client =>
+        {
+            // Outer backstop only. The pipeline below decides in 15s and 40s; this catches a
+            // pipeline that was configured wrong, nothing else.
+            client.Timeout = TimeSpan.FromSeconds(60);
+        })
+            .AddInecobankResilience();
+
         services.AddScoped<IPaymentPluginResolver, PaymentPluginResolver>();
 
         // Audit

--- a/backend/src/Innovayse.Infrastructure/Resilience/Extensions/HttpClientResilienceExtensions.cs
+++ b/backend/src/Innovayse.Infrastructure/Resilience/Extensions/HttpClientResilienceExtensions.cs
@@ -33,8 +33,10 @@ using Polly.Retry;
 /// <b>The HTTP method is not a usable idempotency signal in this codebase</b>, which is why
 /// there is no shared method-based predicate. WHM and Namecheap perform every operation,
 /// including account creation and domain registration, over GET; CWP and CWP7 perform every
-/// operation, including the read ones, over POST with the verb in a form field. A predicate
-/// copied from a service whose API is RESTful would repeat <c>createacct</c> here.
+/// operation, including the read ones, over POST with the verb in a form field; and the
+/// Inecobank payment gateway posts a status lookup, a payment registration and a refund to the
+/// same host over the same verb. A predicate copied from a service whose API is RESTful would
+/// repeat <c>createacct</c> here — or <c>refund.do</c>.
 /// </para>
 /// </remarks>
 public static class HttpClientResilienceExtensions
@@ -63,6 +65,24 @@ public static class HttpClientResilienceExtensions
     /// </summary>
     private static readonly string[] NameAmRepeatablePostPaths =
         ["/client/domains/check", "/auth/login"];
+
+    /// <summary>
+    /// The name the Inecobank payment plugin asks <see cref="IHttpClientFactory"/> for. It is
+    /// that provider's plugin id, spelled here as a literal rather than referenced as
+    /// <c>InecobankPaymentGateway.PluginId</c>: the provider is loaded reflectively out of
+    /// <c>plugins/</c> and Infrastructure deliberately does not reference it, so the two ends of
+    /// this string are matched by convention and nothing else. Change one and the plugin drops
+    /// back to the factory's unnamed client without a word — and loses this profile with it.
+    /// </summary>
+    public const string InecobankClientName = "innovayse-inecobank";
+
+    /// <summary>
+    /// The one Inecobank endpoint a repeat cannot make worse: a pure read of an order's status.
+    /// An allowlist of one rather than a denylist, so an endpoint added to that provider later
+    /// counts as a write until somebody names it here. The cost of guessing wrong in the other
+    /// direction is a second refund or a second charge.
+    /// </summary>
+    private const string InecobankReadEndpoint = "getOrderStatusExtended.do";
 
     /// <summary>
     /// Applies a resilience pipeline to a registered HTTP client.
@@ -210,6 +230,37 @@ public static class HttpClientResilienceExtensions
     /// <returns>The same <paramref name="builder"/>, for chaining.</returns>
     public static IHttpClientBuilder AddNamecheapResilience(this IHttpClientBuilder builder) =>
         builder.AddResilience(o => o.Namecheap, IsNamecheapRepeatable);
+
+    /// <summary>
+    /// Applies the Inecobank profile, repeating only the order-status lookup — never the call
+    /// that opens a payment session and never the one that refunds.
+    /// </summary>
+    /// <param name="builder">The client registration to wrap.</param>
+    /// <returns>The same <paramref name="builder"/>, for chaining.</returns>
+    public static IHttpClientBuilder AddInecobankResilience(this IHttpClientBuilder builder) =>
+        builder.AddResilience(o => o.Inecobank, IsInecobankRepeatable);
+
+    /// <summary>
+    /// Whether an Inecobank request may be repeated.
+    /// </summary>
+    /// <param name="request">The request that failed.</param>
+    /// <returns>True only for the extended order-status lookup.</returns>
+    /// <remarks>
+    /// Every call this gateway makes is a POST of form-urlencoded credentials to
+    /// <c>{gateway}/payment/rest/{endpoint}</c>, so the verb separates nothing and the operation
+    /// has to be read out of the final path segment. <c>register.do</c> opens a payment session
+    /// against a merchant order number and <c>refund.do</c> returns money to a cardholder with no
+    /// idempotency key of its own; only <c>getOrderStatusExtended.do</c> reads, and reading it
+    /// twice costs nothing.
+    /// </remarks>
+    private static bool IsInecobankRepeatable(HttpRequestMessage request)
+    {
+        var path = PathOf(request);
+        var lastSlash = path.LastIndexOf('/');
+        var endpoint = lastSlash >= 0 ? path[(lastSlash + 1)..] : path;
+
+        return endpoint.Equals(InecobankReadEndpoint, StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <summary>
     /// Whether a Name.am request may be repeated.

--- a/backend/src/Innovayse.Infrastructure/Resilience/Options/HttpResilienceOptions.cs
+++ b/backend/src/Innovayse.Infrastructure/Resilience/Options/HttpResilienceOptions.cs
@@ -333,6 +333,68 @@ public sealed class HttpResilienceOptions
     };
 
     /// <summary>
+    /// The Inecobank (Armenian Card) hosted-payment gateway — the payment plugin's own named
+    /// client. Retries only the order-status lookup; see the predicate in
+    /// <c>HttpClientResilienceExtensions</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>All three of its operations are POSTs to the same host, so the method says nothing</b>
+    /// — the same lesson WHM, Namecheap and both CWP panels already taught. The operation is the
+    /// final path segment: <c>register.do</c> opens a payment session for a customer standing at
+    /// the pay button, <c>refund.do</c> sends money back to a cardholder, and
+    /// <c>getOrderStatusExtended.do</c> reads. Only the read is repeated. <c>refund.do</c> takes
+    /// an order id and an amount and carries no idempotency key of any kind, so a repeat is
+    /// simply a second refund; <c>register.do</c> is keyed by the merchant order number, so a
+    /// repeat either comes back as a duplicate-order error — turning a dropped response into a
+    /// hard checkout failure — or opens a second payment session against the same invoice.
+    /// </para>
+    /// <para>
+    /// <b>15 seconds an attempt, 40 in total</b>, inside the registration's 60-second
+    /// <see cref="HttpClient.Timeout"/> backstop. <b>The per-attempt number is taken from
+    /// <c>register.do</c></b>, because that is the only one of the three a person is waiting on:
+    /// it runs inside checkout with the customer watching a spinner, and it is not retried, so
+    /// the per-attempt budget <em>is</em> what they wait. Fifteen seconds is well past the
+    /// gateway's normal sub-second answer and still under a sixth of the 100-second default it
+    /// replaces. The total is sized for the one operation that does retry — two attempts of 15
+    /// plus a jittered backoff fit inside 40 with room — and caps everything else besides.
+    /// </para>
+    /// <para>
+    /// <b>The breaker is on, and it is the only money-moving client here that has one.</b> The
+    /// reason it is safe is that this client addresses a single host: a deployment configures one
+    /// <c>gateway_url</c>, so an open breaker sheds calls to exactly the thing that is down,
+    /// rather than to every server the platform owns the way it would on cPanel or the migration
+    /// source. Weighed against a customer mid-payment: the worst an open breaker can do is refuse
+    /// a <c>register.do</c>, which is a checkout that never started and which the customer can
+    /// start again. <b>It cannot lose money already taken</b> — a payment completed on the hosted
+    /// page is recovered by <c>ReconcileGatewayPaymentsCronHandler</c>, which re-reads the order
+    /// status on its own schedule long after any 15-second break has closed, and which is the
+    /// designed safety net for this whole no-webhook flow. Set against that, a gateway outage
+    /// without a breaker burns 15 seconds of a request thread per checkout and fails anyway.
+    /// </para>
+    /// <para>
+    /// <b><see cref="ResilienceProfileOptions.MinimumThroughput"/> is 20, twice everyone else's,
+    /// and <see cref="ResilienceProfileOptions.BreakDuration"/> is 15 seconds, the shortest
+    /// here.</b> Both move the same way — open reluctantly, close quickly — because the call
+    /// being shed is somebody's payment. A payment gateway sees an order of magnitude less
+    /// traffic than a registrar availability lookup, and the usual threshold of 10 would let a
+    /// quiet minute with two bad calls refuse the next customer who arrives.
+    /// </para>
+    /// </remarks>
+    public ResilienceProfileOptions Inecobank { get; set; } = new()
+    {
+        AttemptTimeout = TimeSpan.FromSeconds(15),
+        TotalTimeout = TimeSpan.FromSeconds(40),
+        MaxRetryAttempts = 1,
+        RetryDelay = TimeSpan.FromSeconds(1),
+        CircuitBreakerEnabled = true,
+        FailureRatio = 0.5,
+        MinimumThroughput = 20,
+        SamplingDuration = TimeSpan.FromSeconds(60),
+        BreakDuration = TimeSpan.FromSeconds(15),
+    };
+
+    /// <summary>
     /// The factory's default, unnamed client. Registered with no retry stage and no breaker.
     /// </summary>
     /// <remarks>
@@ -376,6 +438,7 @@ public sealed class HttpResilienceOptions
         yield return (nameof(Migration), Migration);
         yield return (nameof(NameAm), NameAm);
         yield return (nameof(Namecheap), Namecheap);
+        yield return (nameof(Inecobank), Inecobank);
         yield return (nameof(Default), Default);
     }
 }

--- a/backend/src/Innovayse.Infrastructure/Resilience/Options/HttpResilienceOptionsValidator.cs
+++ b/backend/src/Innovayse.Infrastructure/Resilience/Options/HttpResilienceOptionsValidator.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 /// <remarks>
 /// <para>
 /// Written by hand rather than left to <c>ValidateDataAnnotations()</c> because that only reads
-/// attributes on the options object's own properties and never descends into the ten nested
+/// attributes on the options object's own properties and never descends into the eleven nested
 /// profiles — which is where every number actually lives. A misconfigured section would have
 /// passed validation and then thrown out of <c>AddResilienceHandler</c> on the first call to the
 /// affected client, in a different process lifetime and with a message naming Polly rather than


### PR DESCRIPTION
Follows #152 on the same branch.

**The Inecobank gateway had no resilience at all.** It asked `IHttpClientFactory` for a client under `innovayse-inecobank`, which nothing registered, so it got factory defaults: no retry, no breaker, and `HttpClient`'s 100-second timeout. Last uncovered client in the solution, and the only one that moves money.

The HTTP method separates nothing here — every call is a POST to the same host and the operation is the last path segment. That is the **third** client in this codebase where method-based classification would be wrong, after WHM and Namecheap doing registration over GET and CWP doing reads over POST.

| Endpoint | Retry | Why |
|---|---|---|
| `getOrderStatusExtended` | yes | pure read |
| `register.do` | **no** | keyed by merchant order number — a repeat either fails the checkout outright or opens a second session against one invoice |
| `refund.do` | **no** | carries no idempotency key of any kind; a repeat is simply a second refund |

The predicate allowlists the one safe endpoint, so an endpoint added later is a write until someone says otherwise.

**The breaker is on** — the only money-moving client here that has one. A deployment configures a single gateway host, so an open breaker sheds calls to exactly the thing that is down, unlike cPanel or the migration source where one registration addresses many hosts. It cannot lose money already taken: a payment completed on the hosted page is recovered by the reconciliation cron, which re-reads order status long after a 15-second break has closed.

**Seven enum parses ran on unvalidated input.** `UpdateDomain`, `CreateNetworkIssue` and `UpdateNetworkIssue` had no validator at all. Each new validator matches its handler's case sensitivity exactly — an `ignoreCase` rule in front of a case-sensitive `Enum.Parse` approves a value that then throws a line later, which is a 500 on input the validator had just accepted. `GetMigrationLogs` is a query and cannot carry a validator, so it uses `TryParse` and refuses through the `InvalidOperationException` path the middleware already answers as 400.

No `ArgumentException` arm was added: it would catch `ArgumentNullException` and `ArgumentOutOfRangeException` with it, turning genuine programmer error into a tidy 400 and removing the only place those are logged.

### Verification
```
Build succeeded.  0 Warning(s)  0 Error(s)
Application 117 · Domain 84 · Infrastructure 40 · CWP 6 · Inecobank 25
```
No number moved.

### Known gaps, stated rather than glossed
- **The predicate and profile have no test coverage.** The Inecobank suite drives the API client through its test seam and never goes through the factory, so its 25 passing tests do not exercise this work.
- **`Innovayse.Integration.Tests` did not run.** Given the socket and both documented Testcontainers flags it stalled in restore for ~35 minutes without reaching a test. Not a code failure, and not worked around — reported as not run. **Startup is still unexercised**, which is where a Wolverine codegen failure would surface.
- `UpdateDomainHandler:30-31` has the same latent 500 via `DateTimeOffset.Parse`, throwing `FormatException`. Outside this change's mandate; flagged for follow-up.