### PR TITLE
The API image has no ICU, so request localization crash-looped it

### DIFF
--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -90,6 +90,18 @@ RUN dotnet publish src/Innovayse.API/Innovayse.API.csproj -c Release -o /out --n
 # ── Prod target ───────────────────────────────────────────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS prod
 
+# The Alpine runtime images ship without ICU and set
+# DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true, where the only culture that exists is the
+# invariant one. UseRequestLocalization asks for `en` by name at startup, so the API threw
+# CultureNotFoundException before it could serve anything and the container crash-looped --
+# on a deployment whose build, unit suites and integration suite were all green, because
+# none of them run on this image.
+#
+# icu-data-full, not just icu-libs: the trimmed data set does not carry hy, and Armenian is
+# one of the three cultures this API answers in.
+RUN apk add --no-cache icu-libs icu-data-full
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
 WORKDIR /app
 COPY --from=build /out .
 


### PR DESCRIPTION
**Staging's `hostpanel-api` has been restarting in a loop since the localization work deployed.** Every request there answers 502.

```
[FTL] Application terminated unexpectedly
System.Globalization.CultureNotFoundException: Only the invariant culture is supported
in globalization-invariant mode. 'en' is an invalid culture identifier.
   at RequestLocalizationOptions.SetDefaultCulture(String defaultCulture)
   at Program.<Main>$(String[] args) in /src/src/Innovayse.API/Program.cs:line 494
```

The Alpine runtime images ship without ICU and bake in `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true`, where the invariant culture is the only one that exists. `UseRequestLocalization` asks for `en` by name at startup, so the API dies before serving anything.

`icu-data-full` rather than `icu-libs` alone: the trimmed data set does not carry `hy`, and Armenian is one of the three cultures this API answers in. Verified on the image — `en`, `ru` and `hy` all resolve.

### Why nothing caught it
The solution build, all three unit suites, the integration suite and the frontend tests were green. **None of them run on this image.** The integration suite boots the host, which is why I treated it as covering startup — but it boots it on the SDK image, where ICU is present. The one environment where the difference exists is the published Alpine container, and nothing tests that.

`innovayse-sso` is unaffected: it publishes from `aspnet:9.0`, which is Debian and carries ICU. Its API is healthy on staging.