### PR TITLE
Run the backend test projects one at a time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,16 @@ stages: [test, build, deploy]
     NuGetPackageSourceCredentials_innovayse: "Username=gitlab-ci-token;Password=${CI_JOB_TOKEN}"
   script:
     - cd "$SERVICE"
-    - dotnet test --nologo
+    # -m:1 keeps MSBuild to a single node, so the solution's test projects build and run one
+    # after another instead of all at once. The default fans them out, and each `dotnet test`
+    # host holds its own copy of the EF model -- roughly a gigabyte for the Infrastructure
+    # suite alone. The staging box has 7 GB in total and also hosts every product's containers
+    # and up to four concurrent CI jobs, so the parallel default exhausted it: the runner was
+    # killed mid-run and GitLab reported `no_updates_running` and `runner_system_failure` --
+    # never a failing assertion, and never a line of test output explaining it.
+    #
+    # It costs wall-clock and buys the job the ability to finish. Revisit if the host grows.
+    - dotnet test --nologo -m:1
 
 .test-node-yarn:
   stage: test


### PR DESCRIPTION
`backend:test` was killed twice on staging — first `no_updates_running`, then `runner_system_failure`.

**Neither is a failing assertion.** The log stops mid-run with four suites green and no error line:

```
Domain 89 · CWP 6 · Inecobank 25 · Application 186   ← then nothing
```

No Infrastructure result, no summary, no stack trace. GitLab's own classification says the runner died, not the tests.

`dotnet test` on a solution fans its projects across MSBuild nodes, and each test host holds its own copy of the EF model — roughly a gigabyte for the Infrastructure suite alone. The staging box has **7 GB in total**, runs every product's containers, and was carrying **six concurrent CI jobs** when this failed:

```
Mem: 7.1Gi total · 3.2Gi available    runners: 6
```

The parallel default cannot fit there. `-m:1` runs the projects in sequence: it costs wall-clock and buys the job the ability to finish.

### Separately, on the host
`deploy:staging` had been failing on `unable to lease content: lease does not exist` while pulling `postgres:17-alpine` — containerd could not write a layer. The disk was at **87%**. Pruning unused images older than 48 hours reclaimed **10.9 GB** (87% → 75%), and the deploy went green on retry; staging is running this branch's parent commit now.

Build cache and volumes were deliberately left alone: the cache is 19.9 GB with **0 B reclaimable** — all of it active, and this host is where the runners live, so clearing it would slow every subsequent build. "Unused" volumes can be a stopped stack's database.

### What this does not fix
7 GB is the host's size. Serialising the tests makes this job fit; the next memory-hungry thing will find the same ceiling. Worth considering whether the runners belong on the same box as every product's containers.