### PR TITLE
ci: log out of the registry after the staging deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,16 @@ stages: [test, build, deploy]
     # on it. Inside the workspace this product is reached through that proxy; its
     # own nginx is for a standalone deployment.
     - docker compose -f docker-compose.prod.yml -f docker-compose.platform.yml up -d hostpanel-db hostpanel-api hostpanel-client admin
+  # This job has no `image:`, so it is the shell executor: the login above writes
+  # the runner user's real ~/.docker/config.json on the staging host, and nothing
+  # took it away again. CI_JOB_TOKEN dies with the job, but the entry stayed, and
+  # Docker sends it on every later pull from registry.gitlab.com - including
+  # public ones. That is how three main-branch test jobs failed to pull
+  # gitlab-runner-helper with "HTTP Basic: Access denied" before running a single
+  # test. after_script runs even when the deploy fails, which is exactly when the
+  # stale entry would otherwise be left behind.
+  after_script:
+    - docker logout "$CI_REGISTRY" || true
   rules:
     - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
 


### PR DESCRIPTION
`.deploy-staging` has no `image:`, so it runs on the shell executor — its `docker login` writes the runner user's real `~/.docker/config.json` on the staging host, and nothing took it away again.

`CI_JOB_TOKEN` dies with the job, but the entry stayed. **Docker attaches a credential by registry host, not by whether the image needs one**, so the dead token was sent on every later pull from `registry.gitlab.com` — public images included. A dead credential is worse than no credential.

That is how three main-branch test jobs failed today. `backend:test`, `client:test` and `admin:test` all died before running a single test:

```
failed to pull gitlab-runner-helper:x86_64-v19.2.0
HTTP Basic: Access denied
```

A retry reproduced it exactly on the same runner, which is what ruled out a transient registry fault and pointed at host state.

I cleared the entry by hand on the staging host to unblock the release (backup at `config.json.bak.20260830`) and confirmed the public pull then succeeds; `admin:test` has since passed on that same runner. This commit is what stops it returning on the next staging deploy — without it the host is unblocked, not fixed.

`after_script` rather than the end of `script`, because a **failed** deploy is precisely the case that would otherwise leave the entry behind.