### PR TITLE
fix(admin): clear the typecheck and the bugs it was hiding

### DIFF
--- a/admin/src/components/AppClientSelect.vue
+++ b/admin/src/components/AppClientSelect.vue
@@ -9,7 +9,13 @@ interface Client {
 }
 
 const props = defineProps<{
-  modelValue: string | number
+  /**
+   * Id of the selected client, or `null` when nothing is selected.
+   *
+   * Callers hold this as `number | null`; `String(null)` simply matches no client, which is
+   * how the placeholder is shown.
+   */
+  modelValue: string | number | null
   clients: Client[]
   placeholder?: string
 }>()

--- a/admin/src/components/AppDatePicker.vue
+++ b/admin/src/components/AppDatePicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import AppSelect from './AppSelect.vue'
+import { splitIsoDate } from '../utils/format'
 
 const props = defineProps<{
   modelValue: string | null
@@ -182,10 +183,7 @@ const handleInput = (event: Event) => {
   const parsed = parseDateInput(input)
   if (parsed) {
     emit('update:modelValue', parsed)
-    const [year, month, day] = parsed.split('-')
-    const yearNum = parseInt(year)
-    const monthNum = parseInt(month)
-    const dayNum = parseInt(day)
+    const { year: yearNum, month: monthNum } = splitIsoDate(parsed)
     currentMonth.value = new Date(yearNum, monthNum - 1, 1)
     // Clear preview when a complete date is confirmed
     previewDay.value = null

--- a/admin/src/components/AppDatePickerFuture.vue
+++ b/admin/src/components/AppDatePickerFuture.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import AppSelect from './AppSelect.vue'
+import { splitIsoDate } from '../utils/format'
 
 const props = defineProps<{
   modelValue: string | null
@@ -176,10 +177,7 @@ const handleInput = (event: Event) => {
   const parsed = parseDateInput(input)
   if (parsed) {
     emit('update:modelValue', parsed)
-    const [year, month, day] = parsed.split('-')
-    const yearNum = parseInt(year)
-    const monthNum = parseInt(month)
-    const dayNum = parseInt(day)
+    const { year: yearNum, month: monthNum } = splitIsoDate(parsed)
     currentMonth.value = new Date(yearNum, monthNum - 1, 1)
     previewDay.value = null
     previewMonth.value = null

--- a/admin/src/components/AppNumberInput.vue
+++ b/admin/src/components/AppNumberInput.vue
@@ -7,8 +7,16 @@
 import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
-  /** Current numeric value. */
-  modelValue: number
+  /**
+   * Current value.
+   *
+   * `null` and `''` both mean "no value yet" and are what the callers actually hold —
+   * `ServerFormModal`'s optional `maxAccounts` is `number | null`, and `DnsRecordsTable`
+   * seeds its priority fields with `''`. The component's arithmetic coerces both to 0, which
+   * is the behaviour those screens have always had; narrowing this to `number` would mean
+   * changing how they represent "unset", which is a separate change.
+   */
+  modelValue: number | string | null
   /** Minimum allowed value. */
   min?: number
   /** Maximum allowed value. */
@@ -32,11 +40,20 @@ const emit = defineEmits<{
   'update:modelValue': [value: number]
 }>()
 
+/**
+ * {@link modelValue} as a number.
+ *
+ * `Number()` reproduces exactly the coercion the arithmetic below already performed on the
+ * `null` and `''` a caller may hold: both become 0, a numeric string becomes its number, and
+ * anything else becomes `NaN` — the same results as `props.modelValue - props.step` gave.
+ */
+const numericValue = computed(() => Number(props.modelValue))
+
 /** Whether decrement is allowed. */
-const canDecrement = computed(() => props.min === undefined || props.modelValue - props.step >= props.min)
+const canDecrement = computed(() => props.min === undefined || numericValue.value - props.step >= props.min)
 
 /** Whether increment is allowed. */
-const canIncrement = computed(() => props.max === undefined || props.modelValue + props.step <= props.max)
+const canIncrement = computed(() => props.max === undefined || numericValue.value + props.step <= props.max)
 
 /**
  * Updates the value from direct input.
@@ -54,13 +71,13 @@ function onInput(e: Event): void {
 /** Decrements the value by step. */
 function decrement(): void {
   if (!canDecrement.value || props.disabled) return
-  emit('update:modelValue', clamp(round(props.modelValue - props.step)))
+  emit('update:modelValue', clamp(round(numericValue.value - props.step)))
 }
 
 /** Increments the value by step. */
 function increment(): void {
   if (!canIncrement.value || props.disabled) return
-  emit('update:modelValue', clamp(round(props.modelValue + props.step)))
+  emit('update:modelValue', clamp(round(numericValue.value + props.step)))
 }
 
 /**
@@ -97,7 +114,7 @@ function round(v: number): number {
       :disabled="disabled"
       class="w-full bg-white/[0.04] border border-border rounded-[10px] pl-3 pr-8 py-2 text-[0.82rem] text-text-primary focus:outline-none focus:border-primary-500/50 focus:ring-1 focus:ring-primary-500/10 transition-colors [appearance:textfield]"
       @input="onInput"
-      @blur="emit('update:modelValue', clamp(modelValue))"
+      @blur="emit('update:modelValue', clamp(numericValue))"
     />
     <!-- Spinner buttons -->
     <div class="absolute right-0 top-0 bottom-0 flex flex-col w-6 border-l border-border">

--- a/admin/src/components/AppPhoneInput.vue
+++ b/admin/src/components/AppPhoneInput.vue
@@ -2,7 +2,14 @@
 import { computed, ref } from 'vue'
 
 const props = defineProps<{
-  modelValue: string | null
+  /**
+   * Combined phone value.
+   *
+   * Optional: this component is driven by the `phoneNumber`/`countryCode` pair and never
+   * reads `modelValue`. It was declared required, which made every two-field call site —
+   * the only kind there is — a type error.
+   */
+  modelValue?: string | null
   phoneNumber?: string | null
   countryCode?: string
   placeholder?: string

--- a/admin/src/components/AppSelect.vue
+++ b/admin/src/components/AppSelect.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" generic="T extends string | number">
+<script setup lang="ts" generic="T extends string | number | null">
 /**
  * Custom styled dropdown select that matches the dark panel theme.
  * Replaces native <select> whose options cannot be themed cross-browser.

--- a/admin/src/components/DateRangePicker.vue
+++ b/admin/src/components/DateRangePicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue'
 import AppSelect from './AppSelect.vue'
+import { splitIsoDate } from '../utils/format'
 
 const props = defineProps<{
   modelValue: [string, string] | null
@@ -307,10 +308,16 @@ const handleInput = (event: Event) => {
 
   // Try to parse as range (e.g., "25052026-31052026" or "25/05/2026 - 31/05/2026")
   const parts = input.split(/[\s\-]+/).filter(p => p.length > 0)
+  // `filter` already guarantees each element is a non-empty string, but under
+  // `noUncheckedIndexedAccess` the compiler still types `parts[n]` as `string | undefined`.
+  // Destructuring once lets a single truthiness check stand in for the length checks below:
+  // `firstPart && secondPart` is exactly `parts.length >= 2`, and `firstPart` alone is
+  // exactly `parts.length === 1 && parts[0].length > 0`.
+  const [firstPart, secondPart] = parts
 
-  if (parts.length >= 2) {
-    const start = parseSingleDate(parts[0])
-    const end = parseSingleDate(parts[1])
+  if (firstPart && secondPart) {
+    const start = parseSingleDate(firstPart)
+    const end = parseSingleDate(secondPart)
 
     if (start && end) {
       const startDate = new Date(start + 'T00:00:00')
@@ -324,13 +331,13 @@ const handleInput = (event: Event) => {
         emit('update:modelValue', [start, end])
         inputText.value = `${formatDisplayDate(start)} - ${formatDisplayDate(end)}`
         // Navigate calendar to show the start date's month
-        const [year, month, day] = start.split('-')
-        currentMonth.value = new Date(parseInt(year), parseInt(month) - 1, 1)
+        const { year: startYear, month: startMonth } = splitIsoDate(start)
+        currentMonth.value = new Date(startYear, startMonth - 1, 1)
         isOpen.value = false
       }
-    } else if (parts.length >= 1) {
+    } else {
       // Partial range - update calendar based on what's typed so far
-      const partial = parsePartialDate(parts[0])
+      const partial = parsePartialDate(firstPart)
       if (partial.year || partial.month || partial.day) {
         const year = partial.year || currentMonth.value.getFullYear()
         const month = partial.month || (currentMonth.value.getMonth() + 1)
@@ -346,17 +353,17 @@ const handleInput = (event: Event) => {
       }
 
       // Check if there's a partial second date
-      if (parts.length >= 2) {
-        const partial2 = parsePartialDate(parts[1])
+      {
+        const partial2 = parsePartialDate(secondPart)
         if (partial2.day && partial2.month && partial2.year) {
           const fullDate = `${partial2.year}-${String(partial2.month).padStart(2, '0')}-${String(partial2.day).padStart(2, '0')}`
           previewEnd.value = new Date(fullDate + 'T00:00:00')
         }
       }
     }
-  } else if (parts.length === 1 && parts[0].length > 0) {
+  } else if (firstPart) {
     // User typing first date only
-    const partial = parsePartialDate(parts[0])
+    const partial = parsePartialDate(firstPart)
     if (partial.year || partial.month || partial.day) {
       const year = partial.year || currentMonth.value.getFullYear()
       const month = partial.month || (currentMonth.value.getMonth() + 1)

--- a/admin/src/components/FieldSelector.vue
+++ b/admin/src/components/FieldSelector.vue
@@ -7,8 +7,13 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import AppCheckbox from './AppCheckbox.vue'
 
 const props = defineProps<{
-  /** All available fields. */
-  fields: { key: string; label: string }[]
+  /**
+   * All available fields.
+   *
+   * `readonly` because this component only reads the list: every caller declares its
+   * columns with `as const`, and a mutable annotation rejected those literals outright.
+   */
+  fields: readonly { key: string; label: string }[]
   /** Currently selected field keys. */
   selected: Set<string>
 }>()

--- a/admin/src/composables/useGeoOptions.ts
+++ b/admin/src/composables/useGeoOptions.ts
@@ -55,7 +55,9 @@ export function useGeoOptions() {
     if (match) {
       const code = match[1]
       const found = geoCountries.find(g => g.phone && `+${g.phone}` === code)
-      if (found?.iso2) return { countryIso2: String(found.iso2), number: match[2] }
+      // Group 2 is mandatory in the regex above, so it is always present; falling back to
+      // the whole phone string keeps the same shape as the unmatched return below.
+      if (found?.iso2) return { countryIso2: String(found.iso2), number: match[2] ?? phone }
     }
     return { countryIso2: 'US', number: phone }
   }

--- a/admin/src/modules/billing/components/InvoicePaymentTab.vue
+++ b/admin/src/modules/billing/components/InvoicePaymentTab.vue
@@ -135,10 +135,13 @@ function handleWithSelected(): void {
 async function saveItems(): Promise<void> {
   savingItems.value = true
   const items = editItems.value.map(i => ({
-    id: i.id ?? undefined,
+    id: i.id ?? null,
     description: i.description,
     unitPrice: i.amount,
     quantity: 1,
+    // The API defaults IsDeleted to false when the field is absent, which is what these two
+    // tabs relied on; sending it explicitly keeps that and matches the other invoice tabs.
+    isDeleted: false,
   }))
   await store.updateItems(props.invoice.id, items)
   savingItems.value = false

--- a/admin/src/modules/billing/components/InvoiceRefundTab.vue
+++ b/admin/src/modules/billing/components/InvoiceRefundTab.vue
@@ -212,10 +212,13 @@ function handleWithSelected(): void {
 async function saveItems(): Promise<void> {
   savingItems.value = true
   const items = editItems.value.map(i => ({
-    id: i.id ?? undefined,
+    id: i.id ?? null,
     description: i.description,
     unitPrice: i.amount,
     quantity: 1,
+    // The API defaults IsDeleted to false when the field is absent, which is what these two
+    // tabs relied on; sending it explicitly keeps that and matches the other invoice tabs.
+    isDeleted: false,
   }))
   await store.updateItems(props.invoice.id, items)
   savingItems.value = false

--- a/admin/src/modules/billing/components/TransactionChart.vue
+++ b/admin/src/modules/billing/components/TransactionChart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { Transaction } from '../../../types/models'
+import { toIsoDay } from '../../../utils/format'
 
 interface Props {
   transactions: Transaction[]
@@ -15,7 +16,7 @@ const chartData = computed(() => {
   props.transactions.forEach(tx => {
     const parsed = new Date(tx.date)
     if (isNaN(parsed.getTime())) return
-    const date = parsed.toISOString().split('T')[0]
+    const date = toIsoDay(parsed)
     if (!dailyData[date]) {
       dailyData[date] = 0
     }
@@ -29,7 +30,7 @@ const chartData = computed(() => {
   for (let i = 29; i >= 0; i--) {
     const date = new Date(today)
     date.setDate(date.getDate() - i)
-    dates.push(date.toISOString().split('T')[0])
+    dates.push(toIsoDay(date))
   }
 
   return dates.map(date => ({
@@ -62,11 +63,18 @@ const points = computed(() => {
 const pathD = computed(() => {
   if (points.value.length === 0) return ''
 
-  let path = `M ${points.value[0].x} ${points.value[0].y}`
+  const [firstPoint] = points.value
+  // Unreachable given the length check above; narrows `firstPoint` for the compiler.
+  if (!firstPoint) return ''
+
+  let path = `M ${firstPoint.x} ${firstPoint.y}`
 
   for (let i = 1; i < points.value.length; i++) {
     const curr = points.value[i]
     const prev = points.value[i - 1]
+    // Both indices are inside the array's bounds; the guard only narrows away the
+    // `undefined` that `noUncheckedIndexedAccess` adds to every element read.
+    if (!curr || !prev) continue
     const cp1x = prev.x + (curr.x - prev.x) / 2
     const cp1y = prev.y
     const cp2x = prev.x + (curr.x - prev.x) / 2
@@ -80,6 +88,8 @@ const pathD = computed(() => {
 const areaPathD = computed(() => {
   if (pathD.value === '') return ''
   const lastPoint = points.value[points.value.length - 1]
+  // `pathD` is only non-empty when `points` has at least one entry, so this never fires.
+  if (!lastPoint) return ''
   return `${pathD.value} L ${lastPoint.x} ${padding.top + innerHeight} L ${padding.left} ${padding.top + innerHeight} Z`
 })
 
@@ -112,7 +122,10 @@ const xAxisLabels = computed(() => {
   const labels = []
   const step = Math.max(1, Math.floor(chartData.value.length / 4))
   for (let i = 0; i < chartData.value.length; i += step) {
-    const date = new Date(chartData.value[i].date)
+    const point = chartData.value[i]
+    // `i` is bounded by the loop condition; the guard only satisfies the index-access check.
+    if (!point) continue
+    const date = new Date(point.date)
     const x = padding.left + (i / (chartData.value.length - 1)) * innerWidth
     labels.push({
       date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),

--- a/admin/src/modules/billing/stores/billingStore.ts
+++ b/admin/src/modules/billing/stores/billingStore.ts
@@ -158,13 +158,28 @@ export const useBillingStore = defineStore('billing', () => {
   /**
    * Updates line items on an existing invoice.
    *
+   * The entry shape mirrors the API's `UpdateItemEntryRequest`: `id` is null for a new
+   * line, and `isDeleted` removes an existing one. Both were already being sent by every
+   * caller — the parameter type simply did not describe them.
+   *
    * @param invoiceId - The invoice to update.
-   * @param items - Updated line items array.
+   * @param items - The item changes to apply, replacing the invoice's line items.
    * @returns Promise that resolves when the update completes.
    */
   async function updateItems(
     invoiceId: number,
-    items: Array<{ id?: number; description: string; unitPrice: number; quantity: number }>,
+    items: Array<{
+      /** Existing line item id; null for a new line. */
+      id: number | null
+      /** Human-readable charge description. */
+      description: string
+      /** Price per unit. */
+      unitPrice: number
+      /** Number of units. */
+      quantity: number
+      /** When true, the line is removed from the invoice. */
+      isDeleted: boolean
+    }>,
   ): Promise<void> {
     loading.value = true
     error.value = null

--- a/admin/src/modules/billing/views/AddBillableItemView.vue
+++ b/admin/src/modules/billing/views/AddBillableItemView.vue
@@ -7,6 +7,7 @@ import AppSpinner from '../../../components/AppSpinner.vue'
 import AppDatePicker from '../../../components/AppDatePicker.vue'
 import { useBillableItemsStore } from '../stores/billableItemsStore'
 import { useApi } from '../../../composables/useApi'
+import { toIsoDay } from '../../../utils/format'
 
 const router = useRouter()
 const store = useBillableItemsStore()
@@ -49,7 +50,7 @@ const form = ref({
   amount: 0,
   currency: 'USD',
   invoiceAction: 'dont_invoice',
-  nextDueDate: new Date().toISOString().split('T')[0],
+  nextDueDate: toIsoDay(new Date()),
   invoiceCount: 0,
   recurringPeriod: 1,
   recurringPeriodType: 'month',

--- a/admin/src/modules/billing/views/AddQuoteView.vue
+++ b/admin/src/modules/billing/views/AddQuoteView.vue
@@ -11,6 +11,7 @@ import AppCountrySelect from '../../../components/AppCountrySelect.vue'
 import AppCheckbox from '../../../components/AppCheckbox.vue'
 import { useQuoteStore } from '../stores/quoteStore'
 import type { QuoteStage } from '../../../types/models'
+import { toIsoDay } from '../../../utils/format'
 import { useApi } from '../../../composables/useApi'
 
 const route = useRoute()
@@ -61,8 +62,8 @@ const currencyOptions = [
 ]
 
 const form = ref({
-  dateCreated: new Date().toISOString().split('T')[0],
-  validUntil: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+  dateCreated: toIsoDay(new Date()),
+  validUntil: toIsoDay(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)),
   subject: '',
   stage: 'Draft',
   quoteType: 'existing',
@@ -110,6 +111,9 @@ function openProductModal() {
 function addPredefinedProduct() {
   if (selectedProductId.value) {
     const product = products[selectedProductId.value]
+    // The id always comes from the select bound to `products`, so this never fires; without
+    // it the compiler cannot rule out a key that is not in the map.
+    if (!product) return
     form.value.lineItems.push({
       description: product.name,
       quantity: 1,
@@ -132,6 +136,8 @@ function removeLineItem(index: number) {
 
 function calculateLineAmount(index: number): number {
   const item = form.value.lineItems[index]
+  // Called only with an index the template is rendering, so the row always exists.
+  if (!item) return 0
   const subtotal = item.unitPrice * item.quantity
   const discountAmount = subtotal * (item.discount / 100)
   return subtotal - discountAmount

--- a/admin/src/modules/billing/views/AddTransactionView.vue
+++ b/admin/src/modules/billing/views/AddTransactionView.vue
@@ -8,6 +8,7 @@ import AppDatePicker from '../../../components/AppDatePicker.vue'
 import AppCheckbox from '../../../components/AppCheckbox.vue'
 import { useTransactionsStore } from '../stores/transactionsStore'
 import { useApi } from '../../../composables/useApi'
+import { toIsoDay } from '../../../utils/format'
 
 const router = useRouter()
 const store = useTransactionsStore()
@@ -30,7 +31,7 @@ const paymentMethodOptions = [
 ]
 
 const form = ref({
-  date: new Date().toISOString().split('T')[0],
+  date: toIsoDay(new Date()),
   clientId: '',
   transactionId: '',
   paymentMethod: '',
@@ -59,15 +60,24 @@ async function loadClients() {
 
 async function submit() {
   try {
+    // The form takes a comma-separated list but the API accepts a single optional invoice,
+    // so the first entry wins — the same mapping EditTransactionView already uses.
+    const firstInvoice = form.value.invoiceIds
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)[0]
+
     await store.create({
       clientId: parseInt(form.value.clientId),
+      date: form.value.date,
       description: form.value.description,
-      amount: form.value.amountIn > 0 ? form.value.amountIn : form.value.amountOut,
-      fees: form.value.fees,
-      currency: form.value.currency,
-      gateway: form.value.paymentMethod,
       transactionId: form.value.transactionId,
-      type: form.value.amountIn > 0 ? 'Credit' : 'Debit'
+      invoiceId: firstInvoice ? parseInt(firstInvoice) : null,
+      paymentMethod: form.value.paymentMethod,
+      amountIn: form.value.amountIn,
+      amountOut: form.value.amountOut,
+      fees: form.value.fees,
+      addToCredit: form.value.addToCredit,
     })
     router.push('/billing/transactions')
   } catch (e) {

--- a/admin/src/modules/billing/views/EditTransactionView.vue
+++ b/admin/src/modules/billing/views/EditTransactionView.vue
@@ -7,6 +7,7 @@ import AppSpinner from '../../../components/AppSpinner.vue'
 import AppDatePicker from '../../../components/AppDatePicker.vue'
 import { useTransactionsStore } from '../stores/transactionsStore'
 import { useApi } from '../../../composables/useApi'
+import { toIsoDay } from '../../../utils/format'
 
 const router = useRouter()
 const route = useRoute()
@@ -30,7 +31,7 @@ const paymentMethodOptions = [
 ]
 
 const form = ref({
-  date: new Date().toISOString().split('T')[0],
+  date: toIsoDay(new Date()),
   clientId: '',
   transactionId: '',
   paymentMethod: '',
@@ -65,7 +66,7 @@ async function loadTransaction() {
   if (tx) {
     const parsed = new Date(tx.date)
     form.value = {
-      date: isNaN(parsed.getTime()) ? new Date().toISOString().split('T')[0] : parsed.toISOString().split('T')[0],
+      date: isNaN(parsed.getTime()) ? toIsoDay(new Date()) : toIsoDay(parsed),
       clientId: String(tx.clientId),
       transactionId: tx.transactionId || '',
       paymentMethod: tx.paymentMethod || '',

--- a/admin/src/modules/billing/views/GatewayLogView.vue
+++ b/admin/src/modules/billing/views/GatewayLogView.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import DateRangePicker from '../../../components/DateRangePicker.vue'
+import { toIsoDay } from '../../../utils/format'
 
 const page = ref(1)
 const pageSize = 20
@@ -143,7 +144,7 @@ const filteredLogs = computed(() => {
   return logs.value.filter(log => {
     if (dateRange.value) {
       const [startStr, endStr] = dateRange.value
-      const logDate = new Date(log.dateTime).toISOString().split('T')[0]
+      const logDate = toIsoDay(new Date(log.dateTime))
       if (logDate < startStr || logDate > endStr) return false
     }
 

--- a/admin/src/modules/billing/views/InvoiceDetailView.vue
+++ b/admin/src/modules/billing/views/InvoiceDetailView.vue
@@ -6,6 +6,7 @@ import AppSelect from '../../../components/AppSelect.vue'
 import AppSpinner from '../../../components/AppSpinner.vue'
 import AppDatePicker from '../../../components/AppDatePicker.vue'
 import AppCheckbox from '../../../components/AppCheckbox.vue'
+import { toIsoDay } from '../../../utils/format'
 
 const router = useRouter()
 const route = useRoute()
@@ -20,8 +21,8 @@ const invoiceId = computed(() => Number(route.params.id))
 const summaryPaymentMethod = ref('')
 
 // Options form state
-const optionsInvoiceDate = ref<string>(new Date().toISOString().split('T')[0])
-const optionsDueDate = ref<string>(new Date().toISOString().split('T')[0])
+const optionsInvoiceDate = ref<string>(toIsoDay(new Date()))
+const optionsDueDate = ref<string>(toIsoDay(new Date()))
 const optionsPaymentMethod = ref('')
 const optionsTaxRate1 = ref(0)
 const optionsTaxRate1Percent = ref(0)
@@ -31,7 +32,7 @@ const optionsInvoiceNumber = ref('')
 const optionsStatus = ref('Draft')
 
 // Add Payment form state
-const paymentDate = ref<string>(new Date().toISOString().split('T')[0])
+const paymentDate = ref<string>(toIsoDay(new Date()))
 const paymentMethod = ref('')
 const transactionId = ref('')
 const paymentAmount = ref(0)
@@ -205,7 +206,9 @@ function download() {
 onMounted(() => {
   // Загрузить счета если они еще не загружены
   if (store.invoices.length === 0) {
-    store.fetchAll(1, store.pageSize)
+    // The billing store exposes no `pageSize`, so this used to pass `undefined` and fall back
+  // to `fetchAll`'s own default of 25. Calling it with the page alone does exactly that.
+  store.fetchAll(1)
   }
   // Инициализировать Payment Method
   summaryPaymentMethod.value = invoice.value?.gateway || ''

--- a/admin/src/modules/billing/views/QuoteDetailView.vue
+++ b/admin/src/modules/billing/views/QuoteDetailView.vue
@@ -131,8 +131,8 @@ function populateForm(): void {
   if (!q) return
   subject.value = q.subject
   stage.value = q.stage
-  dateCreated.value = q.dateCreated ? q.dateCreated.split('T')[0] : ''
-  validUntil.value = q.validUntil ? q.validUntil.split('T')[0] : ''
+  dateCreated.value = q.dateCreated ? (q.dateCreated.split('T')[0] ?? '') : ''
+  validUntil.value = q.validUntil ? (q.validUntil.split('T')[0] ?? '') : ''
   proposalText.value = q.proposalText ?? ''
   customerNotes.value = q.customerNotes ?? ''
   adminNotes.value = q.adminNotes ?? ''

--- a/admin/src/modules/billing/views/TransactionsListView.vue
+++ b/admin/src/modules/billing/views/TransactionsListView.vue
@@ -6,6 +6,7 @@ import AppSpinner from '../../../components/AppSpinner.vue'
 import DateRangePicker from '../../../components/DateRangePicker.vue'
 import TransactionChart from '../components/TransactionChart.vue'
 import { useTransactionsStore } from '../stores/transactionsStore'
+import { toIsoDay } from '../../../utils/format'
 
 const store = useTransactionsStore()
 const router = useRouter()
@@ -84,7 +85,7 @@ const filteredTransactions = computed(() => {
 
     if (appliedFilters.value.dateRange) {
       const [startStr, endStr] = appliedFilters.value.dateRange
-      const txDate = new Date(tx.date).toISOString().split('T')[0]
+      const txDate = toIsoDay(new Date(tx.date))
       if (txDate < startStr || txDate > endStr) return false
     }
 
@@ -128,12 +129,12 @@ const stats = computed(() => {
 
     const prevEndDate = new Date(startDate.getTime() - 1000 * 60 * 60 * 24) // 1 day before start
     const prevStartDate = new Date(prevEndDate.getTime() - rangeDuration)
-    const prevStartStr = prevStartDate.toISOString().split('T')[0]
-    const prevEndStr = prevEndDate.toISOString().split('T')[0]
+    const prevStartStr = toIsoDay(prevStartDate)
+    const prevEndStr = toIsoDay(prevEndDate)
 
     // Apply same filters but with previous date range
     allTransactions.forEach(tx => {
-      const txDate = new Date(tx.date).toISOString().split('T')[0]
+      const txDate = toIsoDay(new Date(tx.date))
       if (txDate >= prevStartStr && txDate <= prevEndStr) {
         if (appliedFilters.value.show !== 'all') {
           if (appliedFilters.value.show === 'in' && !(tx.amountIn > 0)) return

--- a/admin/src/modules/clients/views/ClientTicketDetailView.vue
+++ b/admin/src/modules/clients/views/ClientTicketDetailView.vue
@@ -91,7 +91,8 @@ function formatDateTime(iso: string): string {
 const lastReplyAt = computed(() => {
   const t = store.currentTicket
   if (!t || t.replies.length === 0) return null
-  return t.replies[t.replies.length - 1].createdAt
+  // The length check above guarantees a last reply; `?.` only narrows the index access.
+  return t.replies[t.replies.length - 1]?.createdAt ?? null
 })
 
 /**

--- a/admin/src/modules/migration/stores/migrationStore.ts
+++ b/admin/src/modules/migration/stores/migrationStore.ts
@@ -54,6 +54,12 @@ export const useMigrationStore = defineStore('migration', () => {
     exportKnowledgebase?: boolean
     exportContacts?: boolean
     exportTicketReplies?: boolean
+    // The API's CreateMigrationJobRequest has carried these three since the
+    // AddMigrationJobNewModules migration; the store never forwarded them, so the matching
+    // toggles on the migration screen had no effect and the server applied its default.
+    exportAnnouncements?: boolean
+    exportDownloads?: boolean
+    exportNetworkIssues?: boolean
   }): Promise<MigrationJob> {
     const job = await request<MigrationJob>('/admin/migrations', {
       method: 'POST',
@@ -72,6 +78,9 @@ export const useMigrationStore = defineStore('migration', () => {
         exportKnowledgebase: opts.exportKnowledgebase ?? true,
         exportContacts:      opts.exportContacts      ?? true,
         exportTicketReplies: opts.exportTicketReplies ?? true,
+        exportAnnouncements: opts.exportAnnouncements ?? true,
+        exportDownloads:     opts.exportDownloads     ?? true,
+        exportNetworkIssues: opts.exportNetworkIssues ?? true,
       }),
     })
     jobs.value.unshift(job)

--- a/admin/src/modules/reports/chart.ts
+++ b/admin/src/modules/reports/chart.ts
@@ -1,0 +1,25 @@
+/**
+ * Shapes for the chart.js datasets the report screens build by hand.
+ *
+ * These views declare their datasets once and then refill `datasets[n].data` on every load.
+ * Typed as a plain array, `datasets[n]` reads as possibly `undefined` under
+ * `noUncheckedIndexedAccess`, even though the number of series is fixed at the declaration.
+ * Declaring the datasets as a **tuple** of this type is what makes each index a definite
+ * read, and it documents how many series the chart has.
+ */
+
+/** One line series on a report chart. */
+export interface ReportLineSeries {
+  /** Legend label for the series. */
+  label: string
+  /** The plotted values, refilled on each load. */
+  data: number[]
+  /** Stroke colour. */
+  borderColor: string
+  /** Fill colour under the line. */
+  backgroundColor: string
+  /** Whether the area under the line is filled. */
+  fill: boolean
+  /** Bezier tension applied to the line. */
+  tension: number
+}

--- a/admin/src/modules/reports/components/ReportsInnerSidebar.vue
+++ b/admin/src/modules/reports/components/ReportsInnerSidebar.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { REPORTS } from '../reports'
-import { REPORT_ICONS } from '../reportIcons'
+import { FALLBACK_REPORT_ICON, REPORT_ICONS } from '../reportIcons'
 
 const route = useRoute()
 const expanded = ref(false)
@@ -12,7 +12,7 @@ function isActive(slug: string): boolean {
 }
 
 function iconFor(name: string): string {
-  return REPORT_ICONS[name] ?? REPORT_ICONS['bar-chart']
+  return REPORT_ICONS[name] ?? FALLBACK_REPORT_ICON
 }
 
 </script>

--- a/admin/src/modules/reports/currency.ts
+++ b/admin/src/modules/reports/currency.ts
@@ -1,0 +1,39 @@
+/**
+ * The currency a report screen can restate its figures in, and the fixed conversion
+ * table those screens share.
+ *
+ * Every reports view carried its own copy of these four maps. Beyond the duplication, the
+ * copies were typed `Record<string, …>`, which made `rates[selectedCurrency.value]` a
+ * possibly-`undefined` read on a value that is in fact always one of the four keys. Naming
+ * the union here is what lets the lookup be total, so the multiplication in each `fmt`
+ * can no longer silently produce `NaN`.
+ *
+ * The rates are hard-coded, exactly as they were in each view — this module only moves them.
+ */
+
+/** A currency the reports screens can display amounts in. */
+export type ReportCurrency = 'USD' | 'EUR' | 'RUB' | 'AMD'
+
+/** Multiplier applied to a USD-denominated figure to restate it in the given currency. */
+export const REPORT_CURRENCY_RATES: Record<ReportCurrency, number> = {
+  USD: 1,
+  EUR: 0.92,
+  RUB: 90.5,
+  AMD: 387,
+}
+
+/** Symbol prefixed to a converted amount. */
+export const REPORT_CURRENCY_SYMBOLS: Record<ReportCurrency, string> = {
+  USD: '$',
+  EUR: '€',
+  RUB: '₽',
+  AMD: '֏',
+}
+
+/** Options for the currency `AppSelect` shown above a report. */
+export const REPORT_CURRENCY_OPTIONS: { value: ReportCurrency; label: string }[] = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'RUB', label: 'RUB — Russian Ruble' },
+  { value: 'AMD', label: 'AMD — Armenian Dram' },
+]

--- a/admin/src/modules/reports/reportIcons.ts
+++ b/admin/src/modules/reports/reportIcons.ts
@@ -2,10 +2,18 @@
  * Inner SVG markup for each report icon (Feather-style, 24x24, stroke).
  * Rendered via v-html inside an <svg> in the reports sidebar.
  */
+/**
+ * Icon served when a report names an icon the map does not define.
+ *
+ * Named separately so the sidebar's fallback is a value the compiler can see is present,
+ * rather than another `Record<string, string>` lookup that could itself be `undefined`.
+ */
+export const FALLBACK_REPORT_ICON = '<line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/><line x1="2" y1="20" x2="22" y2="20"/>'
+
 export const REPORT_ICONS: Record<string, string> = {
   'share': '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>',
   'clock': '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
-  'bar-chart': '<line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/><line x1="2" y1="20" x2="22" y2="20"/>',
+  'bar-chart': FALLBACK_REPORT_ICON,
   'user': '<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
   'pie-chart': '<path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/>',
   'file-text': '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>',

--- a/admin/src/modules/reports/views/AgingInvoicesView.vue
+++ b/admin/src/modules/reports/views/AgingInvoicesView.vue
@@ -27,6 +27,15 @@ function fmtCurrency(amount: number, currency: string): string {
 
 const chartColors = ['#22c55e', '#3b82f6', '#f59e0b', '#ef4444', '#8b5cf6']
 
+/**
+ * Colour for the nth pie slice, cycling through {@link chartColors}.
+ *
+ * The modulo keeps the index in range, so the fallback is unreachable; it exists because
+ * `noUncheckedIndexedAccess` types every element read as possibly `undefined`, which
+ * chart.js will not accept for `backgroundColor`.
+ */
+const chartColorAt = (i: number): string => chartColors[i % chartColors.length] ?? '#22c55e'
+
 const chartData = computed(() => {
   if (!data.value) return { labels: [], datasets: [] }
   // Aggregate all currencies into one total per period for the chart
@@ -35,12 +44,13 @@ const chartData = computed(() => {
     Object.values(p.amountsByCurrency).reduce((a, b) => a + b, 0)
   )
   // Only show periods with values > 0
-  const filtered = labels.map((l, i) => ({ label: l, value: values[i] })).filter(x => x.value > 0)
+  // `values` is built from the same array as `labels`, so the index always hits.
+  const filtered = labels.map((l, i) => ({ label: l, value: values[i] ?? 0 })).filter(x => x.value > 0)
   return {
     labels: filtered.map(x => x.label),
     datasets: [{
       data: filtered.map(x => x.value),
-      backgroundColor: filtered.map((_, i) => chartColors[i % chartColors.length]),
+      backgroundColor: filtered.map((_, i) => chartColorAt(i)),
       borderWidth: 0,
     }],
   }

--- a/admin/src/modules/reports/views/AnnualIncomeView.vue
+++ b/admin/src/modules/reports/views/AnnualIncomeView.vue
@@ -19,9 +19,25 @@ const yearOptions = Array.from({ length: 5 }, (_, i) => {
   return { value: y, label: String(y) }
 })
 
-const chartData = ref({
-  labels: [] as string[],
-  datasets: [{ label: 'Income', data: [] as number[], backgroundColor: '#ef4444', borderRadius: 6 }],
+/** The single bar series on this chart. Local to this view — no other screen draws it. */
+interface AnnualIncomeSeries {
+  /** Legend label for the series. */
+  label: string
+  /** The plotted monthly totals, refilled on each load. */
+  data: number[]
+  /** Bar fill colour. */
+  backgroundColor: string
+  /** Corner radius applied to each bar. */
+  borderRadius: number
+}
+
+const chartData = ref<{
+  labels: string[]
+  /** A single fixed series, refilled in place by `load`; the tuple keeps index 0 definite. */
+  datasets: [AnnualIncomeSeries]
+}>({
+  labels: [],
+  datasets: [{ label: 'Income', data: [], backgroundColor: '#ef4444', borderRadius: 6 }],
 })
 
 const chartOptions = {

--- a/admin/src/modules/reports/views/ClientsByCountryView.vue
+++ b/admin/src/modules/reports/views/ClientsByCountryView.vue
@@ -37,7 +37,8 @@ const top10 = computed(() => {
     const idx = sorted.findIndex(r => r.country === selectedCountry.value)
     if (idx > 0) {
       const [item] = sorted.splice(idx, 1)
-      sorted.unshift(item)
+      // `idx > 0` means the entry exists, so `splice` always yields exactly one element.
+      if (item) sorted.unshift(item)
     } else if (idx === -1) {
       // Selected country not in top 10 — find it in full list and prepend
       const found = rows.value.find(r => r.country === selectedCountry.value)

--- a/admin/src/modules/reports/views/DailyPerformanceView.vue
+++ b/admin/src/modules/reports/views/DailyPerformanceView.vue
@@ -6,6 +6,7 @@ import DateRangePicker from '../../../components/DateRangePicker.vue'
 import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import { useApi } from '../../../composables/useApi'
+import type { ReportLineSeries } from '../chart'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
 
@@ -16,8 +17,12 @@ const dateRange = ref<[string, string] | null>(null)
 
 const rows = ref<{ date: string; completedOrders: number; newInvoices: number; paidInvoices: number; openedTickets: number; ticketReplies: number; cancellationRequests: number }[]>([])
 
-const chartData = ref({
-  labels: [] as string[],
+const chartData = ref<{
+  labels: string[]
+  /** Six fixed series, refilled in place by `load`; the tuple keeps each index definite. */
+  datasets: [ReportLineSeries, ReportLineSeries, ReportLineSeries, ReportLineSeries, ReportLineSeries, ReportLineSeries]
+}>({
+  labels: [],
   datasets: [
     { label: 'Completed Orders', data: [] as number[], borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.1)', fill: true, tension: 0.4 },
     { label: 'New Invoices', data: [] as number[], borderColor: '#10b981', backgroundColor: 'rgba(16,185,129,0.1)', fill: true, tension: 0.4 },

--- a/admin/src/modules/reports/views/IncomeByProductView.vue
+++ b/admin/src/modules/reports/views/IncomeByProductView.vue
@@ -4,6 +4,8 @@ import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
+import { REPORT_CURRENCY_RATES, REPORT_CURRENCY_SYMBOLS, REPORT_CURRENCY_OPTIONS } from '../currency'
+import type { ReportCurrency } from '../currency'
 
 const { request } = useApi()
 const loading = ref(false)
@@ -12,19 +14,11 @@ const error = ref<string | null>(null)
 const now = new Date()
 const selectedYear = ref(now.getFullYear())
 const selectedMonth = ref(now.getMonth() + 1)
-const selectedCurrency = ref('USD')
+const selectedCurrency = ref<ReportCurrency>('USD')
 
 const monthOptions = ['January','February','March','April','May','June','July','August','September','October','November'].concat(['December'])
   .map((name, i) => ({ value: i + 1, label: name }))
 const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
-const currencyOptions = [
-  { value: 'USD', label: 'USD — US Dollar' },
-  { value: 'EUR', label: 'EUR — Euro' },
-  { value: 'RUB', label: 'RUB — Russian Ruble' },
-  { value: 'AMD', label: 'AMD — Armenian Dram' },
-]
-const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
-const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
 
 interface ProductRow { productId: number; productName: string; unitsSold: number; totalIncome: number }
 interface Group { groupName: string; products: ProductRow[]; groupUnitsSold: number; groupIncome: number }
@@ -38,8 +32,8 @@ const reportTitle = computed(() => data.value
   : 'Income by Product')
 
 function fmt(n: number) {
-  const converted = n * rates[selectedCurrency.value]
-  return `${symbols[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
+  const converted = n * REPORT_CURRENCY_RATES[selectedCurrency.value]
+  return `${REPORT_CURRENCY_SYMBOLS[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
 }
 
 async function load() {
@@ -67,7 +61,7 @@ onMounted(load)
           </div>
           <div class="w-[180px]">
             <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Currency</label>
-            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+            <AppSelect v-model="selectedCurrency" :options="REPORT_CURRENCY_OPTIONS" />
           </div>
           <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
         </div>

--- a/admin/src/modules/reports/views/IncomeForecastView.vue
+++ b/admin/src/modules/reports/views/IncomeForecastView.vue
@@ -5,6 +5,7 @@ import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement
 import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import { useApi } from '../../../composables/useApi'
+import type { ReportLineSeries } from '../chart'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
 
@@ -13,9 +14,13 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 const rows = ref<{ month: string; monthly: number; quarterly: number; semiAnnual: number; annual: number; total: number }[]>([])
 
-const chartData = ref({
-  labels: [] as string[],
-  datasets: [{ label: 'Cumulative Forecast', data: [] as number[], borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.15)', fill: true, tension: 0.4 }],
+const chartData = ref<{
+  labels: string[]
+  /** A single fixed series, refilled in place by `load`; the tuple keeps index 0 definite. */
+  datasets: [ReportLineSeries]
+}>({
+  labels: [],
+  datasets: [{ label: 'Cumulative Forecast', data: [], borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.15)', fill: true, tension: 0.4 }],
 })
 
 const chartOptions = {

--- a/admin/src/modules/reports/views/MonthlyOrdersView.vue
+++ b/admin/src/modules/reports/views/MonthlyOrdersView.vue
@@ -4,6 +4,8 @@ import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
+import { REPORT_CURRENCY_RATES, REPORT_CURRENCY_SYMBOLS, REPORT_CURRENCY_OPTIONS } from '../currency'
+import type { ReportCurrency } from '../currency'
 
 const { request } = useApi()
 const loading = ref(false)
@@ -23,23 +25,15 @@ const monthNames = ['January','February','March','April','May','June','July','Au
 const monthOptions = monthNames.map((name, i) => ({ value: i + 1, label: name }))
 const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
 
-const currencyOptions = [
-  { value: 'USD', label: 'USD — US Dollar' },
-  { value: 'EUR', label: 'EUR — Euro' },
-  { value: 'RUB', label: 'RUB — Russian Ruble' },
-  { value: 'AMD', label: 'AMD — Armenian Dram' },
-]
-const selectedCurrency = ref('USD')
-const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
-const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+const selectedCurrency = ref<ReportCurrency>('USD')
 
 const reportTitle = computed(() => data.value
   ? `Sales by Product for ${monthNames[data.value.month - 1]} ${data.value.year}`
   : 'Monthly Orders')
 
 function fmt(n: number) {
-  const converted = n * rates[selectedCurrency.value]
-  return `${symbols[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
+  const converted = n * REPORT_CURRENCY_RATES[selectedCurrency.value]
+  return `${REPORT_CURRENCY_SYMBOLS[selectedCurrency.value]}${converted.toFixed(2)} ${selectedCurrency.value}`
 }
 
 async function load() {
@@ -68,7 +62,7 @@ onMounted(load)
           </div>
           <div class="w-[180px]">
             <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Currency</label>
-            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+            <AppSelect v-model="selectedCurrency" :options="REPORT_CURRENCY_OPTIONS" />
           </div>
           <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
         </div>

--- a/admin/src/modules/reports/views/MonthlyTransactionsView.vue
+++ b/admin/src/modules/reports/views/MonthlyTransactionsView.vue
@@ -6,6 +6,8 @@ import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
+import { REPORT_CURRENCY_RATES, REPORT_CURRENCY_SYMBOLS, REPORT_CURRENCY_OPTIONS } from '../currency'
+import type { ReportCurrency } from '../currency'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
 
@@ -16,19 +18,11 @@ const error = ref<string | null>(null)
 const now = new Date()
 const selectedYear = ref(now.getFullYear())
 const selectedMonth = ref(now.getMonth() + 1)
-const selectedCurrency = ref('USD')
+const selectedCurrency = ref<ReportCurrency>('USD')
 
 const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December']
 const monthOptions = monthNames.map((name, i) => ({ value: i + 1, label: name }))
 const yearOptions = Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map(y => ({ value: y, label: String(y) }))
-const currencyOptions = [
-  { value: 'USD', label: 'USD — US Dollar' },
-  { value: 'EUR', label: 'EUR — Euro' },
-  { value: 'RUB', label: 'RUB — Russian Ruble' },
-  { value: 'AMD', label: 'AMD — Armenian Dram' },
-]
-const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
-const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
 
 interface DailyRow { date: string; amountIn: number; fees: number; amountOut: number; balance: number }
 interface ReportData { month: number; year: number; rows: DailyRow[]; totalAmountIn: number; totalFees: number; totalAmountOut: number }
@@ -42,13 +36,13 @@ const reportTitle = computed(() => data.value
   : 'Monthly Transactions')
 
 function fmt(n: number) {
-  const v = n * rates[selectedCurrency.value]
-  return `${symbols[selectedCurrency.value]}${v.toFixed(2)}`
+  const v = n * REPORT_CURRENCY_RATES[selectedCurrency.value]
+  return `${REPORT_CURRENCY_SYMBOLS[selectedCurrency.value]}${v.toFixed(2)}`
 }
 
 const chartData = computed(() => {
   const rows = data.value?.rows ?? []
-  const r = rates[selectedCurrency.value]
+  const r = REPORT_CURRENCY_RATES[selectedCurrency.value]
   return {
     labels: rows.map(r => r.date.slice(5)), // MM-DD
     datasets: [
@@ -96,7 +90,7 @@ onMounted(load)
           </div>
           <div class="w-[190px]">
             <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Choose Currency</label>
-            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+            <AppSelect v-model="selectedCurrency" :options="REPORT_CURRENCY_OPTIONS" />
           </div>
           <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate</button>
         </div>

--- a/admin/src/modules/reports/views/NewCustomersView.vue
+++ b/admin/src/modules/reports/views/NewCustomersView.vue
@@ -5,6 +5,7 @@ import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement
 import ReportPage from '../components/ReportPage.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
+import type { ReportLineSeries } from '../chart'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
 
@@ -19,8 +20,12 @@ const yearOptions = Array.from({ length: 10 }, (_, i) => {
   return { value: y, label: String(y) }
 })
 
-const chartData = ref({
-  labels: [] as string[],
+const chartData = ref<{
+  labels: string[]
+  /** Three fixed series, refilled in place by `load`; the tuple keeps each index definite. */
+  datasets: [ReportLineSeries, ReportLineSeries, ReportLineSeries]
+}>({
+  labels: [],
   datasets: [
     { label: 'New Signups', data: [] as number[], borderColor: '#10b981', backgroundColor: 'rgba(16,185,129,0.1)', fill: true, tension: 0.4 },
     { label: 'Orders Placed', data: [] as number[], borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.1)', fill: true, tension: 0.4 },

--- a/admin/src/modules/reports/views/SalesTaxView.vue
+++ b/admin/src/modules/reports/views/SalesTaxView.vue
@@ -5,6 +5,8 @@ import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import DateRangePicker from '../../../components/DateRangePicker.vue'
 import { useApi } from '../../../composables/useApi'
+import { REPORT_CURRENCY_RATES, REPORT_CURRENCY_SYMBOLS, REPORT_CURRENCY_OPTIONS } from '../currency'
+import type { ReportCurrency } from '../currency'
 
 const { request } = useApi()
 const loading = ref(false)
@@ -15,16 +17,7 @@ const dateRange = ref<[string, string]>([
   `${now.getFullYear()}-01-01`,
   `${now.getFullYear()}-12-31`,
 ])
-const selectedCurrency = ref('USD')
-
-const currencyOptions = [
-  { value: 'USD', label: 'USD — US Dollar' },
-  { value: 'EUR', label: 'EUR — Euro' },
-  { value: 'RUB', label: 'RUB — Russian Ruble' },
-  { value: 'AMD', label: 'AMD — Armenian Dram' },
-]
-const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
-const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+const selectedCurrency = ref<ReportCurrency>('USD')
 
 interface SalesTaxRow { id: number; clientName: string; invoiceDate: string; datePaid: string | null; subTotal: number; tax: number; credit: number; total: number }
 interface ReportData { totalInvoices: number; totalInvoiced: number; taxLevel1Liability: number; taxLevel2Liability: number; rows: SalesTaxRow[] }
@@ -32,8 +25,8 @@ interface ReportData { totalInvoices: number; totalInvoiced: number; taxLevel1Li
 const data = ref<ReportData | null>(null)
 
 function fmt(n: number) {
-  const v = n * rates[selectedCurrency.value]
-  return `${symbols[selectedCurrency.value]}${v.toFixed(2)} ${selectedCurrency.value}`
+  const v = n * REPORT_CURRENCY_RATES[selectedCurrency.value]
+  return `${REPORT_CURRENCY_SYMBOLS[selectedCurrency.value]}${v.toFixed(2)} ${selectedCurrency.value}`
 }
 
 async function load() {
@@ -59,7 +52,7 @@ onMounted(load)
           </div>
           <div class="w-[190px]">
             <label class="block text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1">Choose Currency</label>
-            <AppSelect v-model="selectedCurrency" :options="currencyOptions" />
+            <AppSelect v-model="selectedCurrency" :options="REPORT_CURRENCY_OPTIONS" />
           </div>
           <button class="px-5 py-2 gradient-brand text-white text-[0.82rem] font-semibold rounded-[9px] transition-opacity hover:opacity-90" @click="load">Generate Report</button>
         </div>

--- a/admin/src/modules/reports/views/SupportTicketsReportView.vue
+++ b/admin/src/modules/reports/views/SupportTicketsReportView.vue
@@ -90,7 +90,7 @@ onMounted(load)
               <td class="px-4 py-2.5 text-[0.75rem] font-bold text-text-primary sticky left-0 bg-surface-card z-10">Total</td>
               <td v-for="(day, i) in dayHeaders" :key="day"
                 class="px-2 py-2.5 text-center text-[0.78rem] font-semibold text-text-primary">
-                {{ data.rows.reduce((s, r) => s + r.dailyCounts[i], 0) || '' }}
+                {{ data.rows.reduce((s, r) => s + (r.dailyCounts[i] ?? 0), 0) || '' }}
               </td>
               <td class="px-4 py-2.5 text-right text-[0.88rem] font-bold text-text-primary">
                 {{ data.rows.reduce((s, r) => s + r.total, 0) }}

--- a/admin/src/modules/reports/views/VatMossView.vue
+++ b/admin/src/modules/reports/views/VatMossView.vue
@@ -4,6 +4,8 @@ import ReportPage from '../components/ReportPage.vue'
 import ReportTimestamp from '../components/ReportTimestamp.vue'
 import AppSelect from '../../../components/AppSelect.vue'
 import { useApi } from '../../../composables/useApi'
+import { REPORT_CURRENCY_RATES, REPORT_CURRENCY_SYMBOLS } from '../currency'
+import type { ReportCurrency } from '../currency'
 
 const { request } = useApi()
 const loading = ref(false)
@@ -26,10 +28,14 @@ const now = new Date()
 const currentQuarter = Math.floor(now.getMonth() / 3) + 1
 const selectedYear = ref(now.getFullYear())
 const selectedQuarter = ref(currentQuarter)
-const selectedCurrency = ref('USD')
+const selectedCurrency = ref<ReportCurrency>('USD')
 
-const rates: Record<string, number> = { USD: 1, EUR: 0.92, RUB: 90.5, AMD: 387 }
-const symbols: Record<string, string> = { USD: '$', EUR: '€', RUB: '₽', AMD: '֏' }
+/**
+ * Currency codes offered by the inline picker, in the alphabetical order this screen shows
+ * them. Typed here rather than inline in the template so assigning one to
+ * {@link selectedCurrency} keeps its `ReportCurrency` type.
+ */
+const currencyCodes: ReportCurrency[] = ['AMD', 'EUR', 'RUB', 'USD']
 
 // Build quarter options for last 4 years
 const quarterOptions = computed(() => {
@@ -46,15 +52,16 @@ const quarterOptions = computed(() => {
 const selectedQuarterValue = computed({
   get: () => `${selectedYear.value}-${selectedQuarter.value}`,
   set: (v: string) => {
-    const [y, q] = v.split('-')
+    // The value always comes from `quarterOptions`, which builds it as `${year}-${quarter}`.
+    const [y = '', q = ''] = v.split('-')
     selectedYear.value = parseInt(y)
     selectedQuarter.value = parseInt(q)
   },
 })
 
 function fmt(n: number) {
-  const v = n * rates[selectedCurrency.value]
-  return `${symbols[selectedCurrency.value]}${v.toFixed(2)}`
+  const v = n * REPORT_CURRENCY_RATES[selectedCurrency.value]
+  return `${REPORT_CURRENCY_SYMBOLS[selectedCurrency.value]}${v.toFixed(2)}`
 }
 
 async function load() {
@@ -96,7 +103,7 @@ onMounted(load)
         </div>
         <div v-if="data" class="mt-3 flex gap-2 text-[0.78rem] text-text-muted">
           <span>Choose Currency:</span>
-          <button v-for="c in ['AMD','EUR','RUB','USD']" :key="c"
+          <button v-for="c in currencyCodes" :key="c"
             @click="selectedCurrency = c"
             :class="selectedCurrency === c ? 'text-accent font-semibold' : 'hover:text-text-primary'"
             class="transition-colors">{{ c }}</button>

--- a/admin/src/modules/servers/components/ServerFormModal.vue
+++ b/admin/src/modules/servers/components/ServerFormModal.vue
@@ -52,6 +52,24 @@ const ns4Ip = ref('')
 const ns5Hostname = ref('')
 const ns5Ip = ref('')
 
+/**
+ * The five nameserver rows, pairing each row's label with the refs that back its two inputs.
+ *
+ * Declared here rather than as an array literal inside the `v-for`. In a template, a
+ * top-level `<script setup>` ref is already unwrapped, so the literal held plain strings and
+ * `ns.h.value` read `undefined` — and assigning to it on keystroke threw
+ * `TypeError: Cannot create property 'value' on string` in the compiled render function's
+ * strict-mode scope. Refs nested inside an array declared in the script are *not* unwrapped,
+ * so `ns.h.value` here is the real ref on both read and write.
+ */
+const nameserverRows = [
+  { label: 'Primary', h: ns1Hostname, hKey: 'ns1Hostname', ip: ns1Ip, ipKey: 'ns1Ip' },
+  { label: 'Secondary', h: ns2Hostname, hKey: 'ns2Hostname', ip: ns2Ip, ipKey: 'ns2Ip' },
+  { label: 'Third', h: ns3Hostname, hKey: 'ns3Hostname', ip: ns3Ip, ipKey: 'ns3Ip' },
+  { label: 'Fourth', h: ns4Hostname, hKey: 'ns4Hostname', ip: ns4Ip, ipKey: 'ns4Ip' },
+  { label: 'Fifth', h: ns5Hostname, hKey: 'ns5Hostname', ip: ns5Ip, ipKey: 'ns5Ip' },
+]
+
 // --- Server Details ---
 const module = ref<ServerModule>('Cwp7')
 const username = ref('')
@@ -308,13 +326,7 @@ function validate(): boolean {
         <div v-show="tab === 'nameservers'" class="flex flex-col gap-3">
           <p class="text-[0.75rem] text-text-muted">Enter nameservers that will be shown when provisioning new accounts on this server.</p>
 
-          <template v-for="(ns, i) in [
-            { label: 'Primary', h: ns1Hostname, hKey: 'ns1Hostname', ip: ns1Ip, ipKey: 'ns1Ip' },
-            { label: 'Secondary', h: ns2Hostname, hKey: 'ns2Hostname', ip: ns2Ip, ipKey: 'ns2Ip' },
-            { label: 'Third', h: ns3Hostname, hKey: 'ns3Hostname', ip: ns3Ip, ipKey: 'ns3Ip' },
-            { label: 'Fourth', h: ns4Hostname, hKey: 'ns4Hostname', ip: ns4Ip, ipKey: 'ns4Ip' },
-            { label: 'Fifth', h: ns5Hostname, hKey: 'ns5Hostname', ip: ns5Ip, ipKey: 'ns5Ip' },
-          ]" :key="i">
+          <template v-for="(ns, i) in nameserverRows" :key="i">
             <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_140px] gap-2 items-end">
               <div>
                 <label class="block text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-1.5">{{ ns.label }} Nameserver</label>

--- a/admin/src/modules/settings/views/SlideFormView.vue
+++ b/admin/src/modules/settings/views/SlideFormView.vue
@@ -24,6 +24,26 @@ const settingsStore = useSettingsStore()
 /** Available locales for translations. Adding a new locale only requires extending this array. */
 const LOCALES = ['en', 'ru', 'hy'] as const
 
+/**
+ * A locale this form has a translation tab for.
+ *
+ * Derived from {@link LOCALES} so the two can never drift, and so `translations[locale]` is
+ * a total lookup rather than the possibly-`undefined` read a `Record<string, …>` gives.
+ */
+type SlideLocale = (typeof LOCALES)[number]
+
+/**
+ * Narrows a locale code that came from the API to one this form can display.
+ *
+ * The slide endpoint may return translations for a locale the admin does not render; those
+ * were already skipped by the truthiness check this replaces.
+ *
+ * @param value - Locale code as sent by the API.
+ * @returns True when the form has a tab for it.
+ */
+const isSlideLocale = (value: string): value is SlideLocale =>
+  (LOCALES as readonly string[]).includes(value)
+
 /** Display names for each supported locale. */
 const LOCALE_LABELS: Record<string, string> = {
   en: 'English',
@@ -141,7 +161,7 @@ const uploadDragging = ref(false)
 const uploadError = ref<string | null>(null)
 
 /** Currently active translation tab locale. */
-const activeLocale = ref<string>('en')
+const activeLocale = ref<SlideLocale>('en')
 
 /**
  * Creates a blank translation form object.
@@ -160,9 +180,14 @@ function createEmptyTranslation(): TranslationForm {
 }
 
 /** Reactive translations keyed by locale code. */
-const translations = reactive<Record<string, TranslationForm>>(
-  Object.fromEntries(LOCALES.map(loc => [loc, createEmptyTranslation()])),
-)
+const translations = reactive<Record<SlideLocale, TranslationForm>>({
+  // Written out per locale rather than built from LOCALES: `Object.fromEntries` produces a
+  // string index signature, which cannot prove every locale is present. Spelling them out
+  // means adding a locale to LOCALES fails to compile here until its tab is initialised too.
+  en: createEmptyTranslation(),
+  ru: createEmptyTranslation(),
+  hy: createEmptyTranslation(),
+})
 
 
 /**
@@ -298,7 +323,7 @@ onMounted(async () => {
         translations[locale] = createEmptyTranslation()
       }
       for (const t of slide.translations) {
-        if (translations[t.locale]) {
+        if (isSlideLocale(t.locale)) {
           translations[t.locale] = {
             title: t.title,
             tagline: t.tagline ?? '',
@@ -323,19 +348,19 @@ onMounted(async () => {
 /**
  * Adds a new empty feature input to the specified locale's feature list.
  *
- * @param locale - The locale code to add the feature to.
+ * @param locale - The locale to add the feature to.
  */
-function addFeature(locale: string): void {
+function addFeature(locale: SlideLocale): void {
   translations[locale].features.push('')
 }
 
 /**
  * Removes a feature from the specified locale's feature list by index.
  *
- * @param locale - The locale code to remove the feature from.
+ * @param locale - The locale to remove the feature from.
  * @param index - The index of the feature to remove.
  */
-function removeFeature(locale: string, index: number): void {
+function removeFeature(locale: SlideLocale, index: number): void {
   translations[locale].features.splice(index, 1)
 }
 

--- a/admin/src/modules/settings/views/SystemSettingsView.vue
+++ b/admin/src/modules/settings/views/SystemSettingsView.vue
@@ -73,7 +73,11 @@ async function saveRow(setting: Setting) {
   // Only on success. This used to drop the draft either way, so a failed save
   // replaced whatever the operator had typed with the value already stored —
   // leaving an error banner and no way back to the text that caused it.
-  if (await onSave(setting.id, drafts.value[setting.id])) {
+  const draft = drafts.value[setting.id]
+  // `isDirty` above already established the key is present; this only narrows it.
+  if (draft === undefined) return
+
+  if (await onSave(setting.id, draft)) {
     delete drafts.value[setting.id]
   }
 }

--- a/admin/src/modules/settings/views/TldConfigFormView.vue
+++ b/admin/src/modules/settings/views/TldConfigFormView.vue
@@ -22,6 +22,13 @@ const store = useTldConfigsStore()
 /** Available registration periods in years. */
 const PERIODS = ['1', '2', '3', '5', '10'] as const
 
+// The six price maps below are keyed by period string and are seeded with every entry in
+// PERIODS by `emptyPriceMap()`, so a period always has a value. They stay
+// `Record<string, number>` on purpose: a map loaded from the API may carry a period this
+// build does not list, and `fromApiMap`/`toNonZeroMap` round-trip it untouched rather than
+// dropping it. That is why the template reads `map[period] ?? 0` — `AppSpinner` needs a
+// definite `number`, and the fallback is unreachable while the seeding above holds.
+
 /** Provider options for the registrar module dropdown. */
 const PROVIDER_OPTIONS = [
   { label: 'Name.am', value: 'NameAm' },
@@ -436,7 +443,7 @@ const sellSymbol = computed(() => {
                   <td class="py-2.5 text-text-secondary">{{ period }} {{ Number(period) === 1 ? 'Year' : 'Years' }}</td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="costRegister[period]"
+                      :model-value="costRegister[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"
@@ -445,7 +452,7 @@ const sellSymbol = computed(() => {
                   </td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="sellRegister[period]"
+                      :model-value="sellRegister[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"
@@ -482,7 +489,7 @@ const sellSymbol = computed(() => {
                   <td class="py-2.5 text-text-secondary">{{ period }} {{ Number(period) === 1 ? 'Year' : 'Years' }}</td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="costTransfer[period]"
+                      :model-value="costTransfer[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"
@@ -491,7 +498,7 @@ const sellSymbol = computed(() => {
                   </td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="sellTransfer[period]"
+                      :model-value="sellTransfer[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"
@@ -528,7 +535,7 @@ const sellSymbol = computed(() => {
                   <td class="py-2.5 text-text-secondary">{{ period }} {{ Number(period) === 1 ? 'Year' : 'Years' }}</td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="costRenew[period]"
+                      :model-value="costRenew[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"
@@ -537,7 +544,7 @@ const sellSymbol = computed(() => {
                   </td>
                   <td class="py-2.5 pr-2">
                     <AppSpinner
-                      :model-value="sellRenew[period]"
+                      :model-value="sellRenew[period] ?? 0"
                       :step="0.01"
                       :min="0"
                       placeholder="0.00"

--- a/admin/src/modules/support/views/DownloadsView.vue
+++ b/admin/src/modules/support/views/DownloadsView.vue
@@ -467,6 +467,9 @@ function navigateHome(): void {
  */
 function navigateToBreadcrumb(index: number): void {
   const crumb = breadcrumbs.value[index]
+  // Only ever called with an index the template rendered, so this never fires; without it
+  // the compiler cannot rule out an out-of-range read.
+  if (!crumb) return
   breadcrumbs.value = breadcrumbs.value.slice(0, index + 1)
   currentCategoryId.value = crumb.id
   fetchDownloads()

--- a/admin/src/modules/support/views/NetworkIssuesView.vue
+++ b/admin/src/modules/support/views/NetworkIssuesView.vue
@@ -47,8 +47,11 @@ interface StatusFilter {
 const { request } = useApi()
 
 /** Available status filters. */
+/** The filter shown when the active one matches nothing — the first tab. */
+const defaultStatusFilter: StatusFilter = { label: 'Open', value: 'open', heading: 'Open Issues' }
+
 const statusFilters: StatusFilter[] = [
-  { label: 'Open', value: 'open', heading: 'Open Issues' },
+  defaultStatusFilter,
   { label: 'Scheduled', value: 'Scheduled', heading: 'Scheduled Issues' },
   { label: 'Resolved', value: 'Resolved', heading: 'Resolved Issues' },
 ]
@@ -85,7 +88,7 @@ const totalPages = computed(() => Math.max(1, Math.ceil(totalCount.value / pageS
 
 /** Active filter object for display. */
 const activeFilterObj = computed(() =>
-  statusFilters.find(f => f.value === activeFilter.value) ?? statusFilters[0]
+  statusFilters.find(f => f.value === activeFilter.value) ?? defaultStatusFilter
 )
 
 /**

--- a/admin/src/types/models.ts
+++ b/admin/src/types/models.ts
@@ -242,6 +242,16 @@ export interface InvoiceItem {
   quantity: number
   /** Line total (unitPrice x quantity). */
   amount: number
+
+  /**
+   * BUG — read by `InvoiceDetailView`'s "Taxed" column, but `InvoiceItemDto` has no such
+   * field, so the column has always rendered "No" for every line regardless of tax.
+   *
+   * Declared optional so the type states what actually arrives (`undefined`) instead of
+   * promising a boolean. Whether tax is per-line or invoice-wide (`Invoice.taxRate`) is a
+   * product decision; nothing here can infer it.
+   */
+  taxed?: boolean
 }
 
 /** Payment, refund, or credit transaction recorded against an invoice. */
@@ -302,6 +312,24 @@ export interface Invoice {
   items: InvoiceItem[]
   /** Payment/refund/credit transactions. */
   transactions: InvoiceTransaction[]
+
+  /**
+   * BUG — read by `InvoiceDetailView` (the "Payment Method" summary field and the payment
+   * panel), but `InvoiceDto` sends no `gateway`. Both call sites therefore show their
+   * fallback — '' and 'Not set' — on every invoice, paid or not.
+   *
+   * The API's nearest equivalents are {@link Invoice.paymentMethod} and
+   * {@link Invoice.gatewayTransactionId}. Switching to one of those changes what the screen
+   * displays, so it is left as-is and recorded here.
+   */
+  gateway?: string
+
+  /**
+   * BUG — read by `InvoicesListView`'s "Last Updated" column as
+   * `invoice.updatedAt || invoice.createdAt`, but `InvoiceListItemDto` has no `updatedAt`.
+   * The column has always shown the creation date.
+   */
+  updatedAt?: string
 }
 
 /** Represents a single admin activity log entry for a client. */
@@ -1006,40 +1034,64 @@ export interface ClientUserItem {
   createdAt: string
 }
 
-/** Represents a billable item that can be invoiced to a client. */
+/**
+ * A billable item that can be invoiced to a client.
+ *
+ * Mirrors the API's `BillableItemDto` (`GET /billing/billable-items`) and its client-scoped
+ * twin `ClientBillableItemDto` (`GET /clients/{id}/billable-items`), which differ only in
+ * that the client-scoped one omits `clientName`.
+ *
+ * This interface previously described a different record altogether — `serviceId`,
+ * `serviceName`, `hoursQty`, `isHours`, `invoiceAction`, `dueDate`, `invoiceCount` and three
+ * `recurrence*` fields, none of which either endpoint has ever returned — while omitting
+ * `clientName`, `currency`, `type` and `isInvoiced`, which they all return. See the note on
+ * the three retained fields below.
+ */
 export interface BillableItem {
   /** Unique billable item identifier. */
   id: number
   /** Associated client identifier. */
   clientId: number
-  /** FK to client service, if applicable. */
-  serviceId?: number
-  /** Product/service name from the linked service. */
-  serviceName?: string
+  /**
+   * Display name of the owning client.
+   *
+   * Only the admin-wide list (`/billing/billable-items`) carries it; the client-scoped
+   * endpoint does not, which is why it is optional.
+   */
+  clientName?: string
   /** Charge description. */
   description: string
-  /** Total charge amount. */
+  /** Charge amount. */
   amount: number
-  /** Hours or quantity value. */
-  hoursQty: number
-  /** Whether hoursQty represents hours (true) or quantity (false). */
-  isHours: boolean
-  /** How and when this item should be invoiced. */
-  invoiceAction: string
-  /** ISO 8601 due date. */
-  dueDate: string
-  /** FK to invoice if invoiced, null if uninvoiced. */
-  invoiceId?: number
-  /** Number of times this item has been invoiced. */
-  invoiceCount: number
-  /** Recurrence interval (recur every N periods). */
-  recurrenceInterval?: number
-  /** Recurrence period unit. */
-  recurrencePeriod?: string
-  /** Max number of recurrences (null = unlimited). */
-  recurrenceLimit?: number
+  /** ISO 4217 currency code. */
+  currency: string
+  /** Item type — `OneTime` or `Recurring`. */
+  type: string
+  /** Recurrence period; null for one-time items. */
+  recurringPeriod: string | null
+  /** Whether the item has already been invoiced. */
+  isInvoiced: boolean
+  /** FK to the invoice; null while uninvoiced. */
+  invoiceId: number | null
+  /** ISO 8601 next due date for recurring items; null otherwise. */
+  nextDueDate: string | null
   /** ISO 8601 creation timestamp. */
   createdAt: string
+
+  /**
+   * BUG — these three are read by `ClientBillableItemsView` but **no endpoint sends them**,
+   * so that screen's "Hours/Qty" and "Invoice Action" columns render blank at runtime.
+   *
+   * They are kept here, optional, so the type states the truth (`undefined` at runtime)
+   * without silently deleting the columns from the screen. Fixing it properly means either
+   * adding the fields to `ClientBillableItemDto` or dropping the columns — a product
+   * decision, not a typing one.
+   */
+  hoursQty?: number
+  /** See the note on {@link BillableItem.hoursQty} — never sent by the API. */
+  isHours?: boolean
+  /** See the note on {@link BillableItem.hoursQty} — never sent by the API. */
+  invoiceAction?: string
 }
 
 /** Response from the billable items list endpoint. */

--- a/admin/src/utils/format.ts
+++ b/admin/src/utils/format.ts
@@ -24,3 +24,35 @@ export function toDateInputValue(iso: string | null | undefined): string {
   if (isNaN(d.getTime())) return ''
   return d.toISOString().split('T')[0] ?? ''
 }
+
+/**
+ * Splits a `YYYY-MM-DD` date string into its numeric year, month and day parts.
+ *
+ * Exists because `noUncheckedIndexedAccess` types the result of `String.split` as
+ * `(string | undefined)[]`, which every caller would otherwise have to widen by hand.
+ * A missing part yields `NaN`, exactly as `parseInt(undefined as never)` did before —
+ * callers here always pass a string that has already been validated as a full date, so
+ * the `NaN` branch is unreachable in practice and is preserved only to keep behaviour
+ * identical for a malformed input.
+ *
+ * @param iso - Date string in `YYYY-MM-DD` form.
+ * @returns The three parts as numbers; `NaN` for any part the string did not contain.
+ */
+export const splitIsoDate = (iso: string): { year: number; month: number; day: number } => {
+  const [year = '', month = '', day = ''] = iso.split('-')
+  return { year: parseInt(year), month: parseInt(month), day: parseInt(day) }
+}
+
+/**
+ * Renders a `Date` as its UTC `YYYY-MM-DD` day, the form every date `<input>` and every
+ * date-keyed lookup in the admin uses.
+ *
+ * `Date.toISOString()` always contains a `T`, so the first split part is always present —
+ * but `noUncheckedIndexedAccess` cannot know that, and spelling the fallback out at each of
+ * the ~18 call sites would bury the intent. Callers must pass a valid `Date`; an invalid one
+ * makes `toISOString()` throw here exactly as it did inline.
+ *
+ * @param date - The date to render. Must be a valid `Date`.
+ * @returns The UTC calendar day as `YYYY-MM-DD`.
+ */
+export const toIsoDay = (date: Date): string => date.toISOString().split('T')[0] ?? ''


### PR DESCRIPTION
The admin SPA carried **149 TypeScript errors**. Nothing forced them to zero, so they had become background noise — and three of them were real defects that had shipped.

### Fixed

Each of these was a feature that simply did not work, with an unambiguous intended shape.

- **The five nameserver fields in `ServerFormModal` threw on every keystroke.** The row list was an array literal *inside the template*, where a top-level `<script setup>` ref is already unwrapped — so `ns.h` was a plain string and `ns.h.value = …` raised `TypeError` in the render function's strict scope. The list moved into the script; the template body is unchanged.
- **Add Transaction could never succeed.** It posted `{amount, gateway, type, currency}` while `CreateTransactionCommand` requires ten fields — five mandatory — so every submit 400'd. The form already collected the right values; `EditTransactionView` already had the correct mapping.
- **Three migration toggles did nothing.** `exportAnnouncements`, `exportDownloads` and `exportNetworkIssues` were never forwarded, so the server applied its `= true` defaults regardless of the checkbox.

### Found but deliberately not changed

The fix for these is a product decision, and a hosting panel's admin must not shift behaviour silently. Each is now optional in `models.ts` with a `BUG —` note naming the endpoint and the symptom:

| Symptom | Cause |
|---|---|
| Two columns render blank on every row | `BillableItem` described a record no endpoint returns |
| Payment Method always reads "Not set" | `invoice.gateway` does not exist |
| Taxed always reads "No" | `InvoiceItem.taxed` does not exist |
| Last Updated always shows the creation date | `invoice.updatedAt` does not exist |

### How the rest were cleared

The dominant cause was `noUncheckedIndexedAccess`: every indexed read is `T | undefined`. These were made **total rather than asserted away** — a `ReportCurrency` union replaces five copies of `Record<string, number>` rate maps (so `fmt` can no longer produce `NaN`), chart datasets became tuples, and two date helpers replace eighteen hand-rolled `toISOString().split('T')[0]` sites.

**No `any`, no `as unknown as`, no `@ts-ignore`, no non-null assertions.** The only assertion added anywhere is a widening cast inside a type predicate.

### Verified

```
vue-tsc --build --force    149 errors -> 0
vite build                 succeeds
oxlint / eslint            unchanged (no new findings)
```

The three behaviour changes were re-checked against the backend by hand: `CreateTransactionCommand` takes exactly the ten fields now sent, and `CreateMigrationJobRequest` accepts the three forwarded flags.