### PR TITLE
Client fixes: announcements 500, setup validation, first-order flow, admin dialogs

### DIFF
--- a/admin/src/composables/useUnsavedChangesGuard.ts
+++ b/admin/src/composables/useUnsavedChangesGuard.ts
@@ -1,0 +1,63 @@
+import { ref, type Ref } from 'vue'
+import { onBeforeRouteLeave } from 'vue-router'
+
+/** What {@link useUnsavedChangesGuard} hands back to the view. */
+export interface UnsavedChangesGuard {
+  /** True while the question is on screen and the navigation is parked. */
+  pending: Ref<boolean>
+  /** Answers "leave anyway" — the parked navigation proceeds. */
+  confirmLeave: () => void
+  /** Answers "stay" — the parked navigation is cancelled. */
+  cancelLeave: () => void
+}
+
+/**
+ * Parks a route change while the reader is asked about unsaved edits.
+ *
+ * A form that navigates away silently loses whatever was typed, so the guard exists; what it
+ * used to use was the browser's `confirm()`, because a guard taking `next()` has to answer on
+ * the spot and a modal answers a tick later. That constraint is not real: `onBeforeRouteLeave`
+ * also accepts a returned promise, and the router waits for it. So the guard returns one, and
+ * this composable resolves it when the view's modal reports an answer.
+ *
+ * @param isDirty Called at navigation time; return true to ask, false to leave without asking.
+ *                It is a function rather than a ref so the caller can fold in conditions like
+ *                "a save is already in flight, so this is not a loss".
+ * @returns The modal's open state and the two answers.
+ *
+ * @example
+ * const guard = useUnsavedChangesGuard(() => isDirty.value && !saving.value)
+ * // <ConfirmModal v-if="guard.pending.value" @confirm="guard.confirmLeave" @close="guard.cancelLeave" />
+ */
+export const useUnsavedChangesGuard = (isDirty: () => boolean): UnsavedChangesGuard => {
+  const pending = ref(false)
+
+  /**
+   * Resolver of the promise the guard returned, held between the question and the answer.
+   *
+   * Null whenever no navigation is parked, which is what makes a stray answer harmless.
+   */
+  let resolveLeave: ((leave: boolean) => void) | null = null
+
+  onBeforeRouteLeave(() => {
+    if (!isDirty()) return true
+
+    pending.value = true
+    return new Promise<boolean>((resolve) => {
+      resolveLeave = resolve
+    })
+  })
+
+  /** Closes the question and releases the parked navigation with the reader's answer. */
+  const answer = (leave: boolean): void => {
+    pending.value = false
+    resolveLeave?.(leave)
+    resolveLeave = null
+  }
+
+  return {
+    pending,
+    confirmLeave: () => answer(true),
+    cancelLeave: () => answer(false),
+  }
+}

--- a/admin/src/modules/clients/components/ContactFormModal.vue
+++ b/admin/src/modules/clients/components/ContactFormModal.vue
@@ -7,6 +7,7 @@ import { ref, computed, onMounted } from 'vue'
 import type { Contact } from '../../../types/models'
 import { useGeoOptions } from '../../../composables/useGeoOptions'
 import AppSelect from '../../../components/AppSelect.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import ToggleSwitch from '../../../components/ToggleSwitch.vue'
 
 const props = defineProps<{
@@ -154,13 +155,26 @@ function handleSave(): void {
   })
 }
 
+/** True while the delete confirmation prompt is showing; nothing is staged when false. */
+const showDeleteConfirm = ref(false)
+
 /**
- * Confirms and emits the delete event.
+ * Stages the delete confirmation. Only opens the prompt — {@link confirmDelete} does the work,
+ * so the question is asked by the app's own modal instead of the browser's blocking dialog.
  */
-function handleDelete(): void {
-  if (confirm('Permanently delete this contact? This cannot be undone.')) {
-    emit('delete')
-  }
+const handleDelete = (): void => {
+  showDeleteConfirm.value = true
+}
+
+/**
+ * Emits the delete event and dismisses the prompt.
+ *
+ * There is no in-flight flag: the parent owns the request and unmounts this modal as soon as it
+ * accepts the event, so this component never observes the outcome.
+ */
+const confirmDelete = (): void => {
+  showDeleteConfirm.value = false
+  emit('delete')
 }
 
 /**
@@ -437,5 +451,17 @@ onMounted(() => {
         </div>
       </form>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="showDeleteConfirm"
+      title="Delete Contact"
+      message="Permanently delete this contact? This cannot be undone."
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      variant="danger"
+      @confirm="confirmDelete"
+      @close="showDeleteConfirm = false"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/components/DnsRecordsTable.vue
+++ b/admin/src/modules/clients/components/DnsRecordsTable.vue
@@ -8,6 +8,7 @@ import { useApi } from '../../../composables/useApi'
 import { DNS_RECORD_TYPE_OPTIONS } from '../../../utils/constants'
 import AppNumberInput from '../../../components/AppNumberInput.vue'
 import AppSelect from '../../../components/AppSelect.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import type { DnsRecordItem } from '../../../types/models'
 
 const props = defineProps<{
@@ -171,15 +172,35 @@ async function saveEdit(): Promise<void> {
   }
 }
 
+/** ID of the record awaiting delete confirmation, null when nothing is staged. */
+const deleteTargetId = ref<number | null>(null)
+
+/** True while the staged record is being deleted. */
+const deleting = ref(false)
+
 /**
- * Deletes a DNS record after confirmation.
+ * Stages a DNS record for deletion. Only opens the prompt — {@link confirmDelete} does the work,
+ * so the question is asked by the app's own modal instead of the browser's blocking dialog.
  *
  * @param recordId - The ID of the record to delete.
+ */
+const handleDelete = (recordId: number): void => {
+  deleteTargetId.value = recordId
+}
+
+/**
+ * Deletes the staged DNS record and clears the prompt.
+ *
+ * The target is cleared in `finally` so a failed request still dismisses the modal, matching the
+ * pre-existing behaviour where a rejected call left the row in place with no message.
+ *
  * @returns Promise that resolves when the record is deleted.
  */
-async function handleDelete(recordId: number): Promise<void> {
-  if (!confirm('Delete this DNS record?')) return
+const confirmDelete = async (): Promise<void> => {
+  const recordId = deleteTargetId.value
+  if (recordId === null) return
   saving.value = true
+  deleting.value = true
   try {
     await request(`/domains/${props.domainId}/dns/${recordId}`, { method: 'DELETE' })
     emit('refresh')
@@ -187,6 +208,8 @@ async function handleDelete(recordId: number): Promise<void> {
     // Error is handled silently; the user can retry
   } finally {
     saving.value = false
+    deleting.value = false
+    deleteTargetId.value = null
   }
 }
 </script>
@@ -381,5 +404,18 @@ async function handleDelete(recordId: number): Promise<void> {
         <p class="text-[0.82rem] text-text-muted">No DNS records found</p>
       </div>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="deleteTargetId !== null"
+      title="Delete DNS Record"
+      message="Delete this DNS record?"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deleting"
+      variant="danger"
+      @confirm="confirmDelete"
+      @close="deleteTargetId = null"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/components/EmailForwardingTable.vue
+++ b/admin/src/modules/clients/components/EmailForwardingTable.vue
@@ -5,6 +5,7 @@
  */
 import { ref } from 'vue'
 import { useApi } from '../../../composables/useApi'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import ToggleSwitch from '../../../components/ToggleSwitch.vue'
 import type { EmailForwardingRuleItem } from '../../../types/models'
 
@@ -158,15 +159,35 @@ async function toggleActive(rule: EmailForwardingRuleItem): Promise<void> {
   }
 }
 
+/** ID of the rule awaiting delete confirmation, null when nothing is staged. */
+const deleteTargetId = ref<number | null>(null)
+
+/** True while the staged rule is being deleted. */
+const deleting = ref(false)
+
 /**
- * Deletes an email forwarding rule after confirmation.
+ * Stages a forwarding rule for deletion. Only opens the prompt — {@link confirmDelete} does the
+ * work, so the question is asked by the app's own modal instead of the browser's blocking dialog.
  *
  * @param ruleId - The ID of the rule to delete.
+ */
+const handleDelete = (ruleId: number): void => {
+  deleteTargetId.value = ruleId
+}
+
+/**
+ * Deletes the staged forwarding rule and clears the prompt.
+ *
+ * The target is cleared in `finally` so a failed request still dismisses the modal, matching the
+ * pre-existing behaviour where a rejected call left the row in place with no message.
+ *
  * @returns Promise that resolves when the rule is deleted.
  */
-async function handleDelete(ruleId: number): Promise<void> {
-  if (!confirm('Delete this email forwarding rule?')) return
+const confirmDelete = async (): Promise<void> => {
+  const ruleId = deleteTargetId.value
+  if (ruleId === null) return
   saving.value = true
+  deleting.value = true
   try {
     await request(`/domains/${props.domainId}/email-forwarding/${ruleId}`, { method: 'DELETE' })
     emit('refresh')
@@ -174,6 +195,8 @@ async function handleDelete(ruleId: number): Promise<void> {
     // Error is handled silently; the user can retry
   } finally {
     saving.value = false
+    deleting.value = false
+    deleteTargetId.value = null
   }
 }
 </script>
@@ -336,5 +359,18 @@ async function handleDelete(ruleId: number): Promise<void> {
         <p class="text-[0.82rem] text-text-muted">No email forwarding rules found</p>
       </div>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="deleteTargetId !== null"
+      title="Delete Forwarding Rule"
+      message="Delete this email forwarding rule?"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deleting"
+      variant="danger"
+      @confirm="confirmDelete"
+      @close="deleteTargetId = null"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/components/UserFormModal.vue
+++ b/admin/src/modules/clients/components/UserFormModal.vue
@@ -6,6 +6,7 @@
 import { ref, onMounted } from 'vue'
 import AppCheckbox from '../../../components/AppCheckbox.vue'
 import AppSelect from '../../../components/AppSelect.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import type { UserDetail } from '../stores/usersStore'
 import { PERMISSION_LABELS, ClientPermission } from '../../../types/models'
 import { LANGUAGE_OPTIONS } from '../../../utils/constants'
@@ -101,13 +102,26 @@ function handleSave(): void {
   }
 }
 
+/** True while the delete confirmation prompt is showing; nothing is staged when false. */
+const showDeleteConfirm = ref(false)
+
 /**
- * Confirms and emits delete.
+ * Stages the delete confirmation. Only opens the prompt — {@link confirmDelete} does the work,
+ * so the question is asked by the app's own modal instead of the browser's blocking dialog.
  */
-function handleDelete(): void {
-  if (confirm(`Permanently delete user "${email.value}"? This cannot be undone.`)) {
-    emit('delete')
-  }
+const handleDelete = (): void => {
+  showDeleteConfirm.value = true
+}
+
+/**
+ * Emits the delete event and dismisses the prompt.
+ *
+ * There is no in-flight flag: the parent owns the request and unmounts this modal as soon as it
+ * accepts the event, so this component never observes the outcome.
+ */
+const confirmDelete = (): void => {
+  showDeleteConfirm.value = false
+  emit('delete')
 }
 </script>
 
@@ -255,5 +269,17 @@ function handleDelete(): void {
         </div>
       </div>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="showDeleteConfirm"
+      title="Delete User"
+      :message="`Permanently delete user &quot;${email}&quot;? This cannot be undone.`"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      variant="danger"
+      @confirm="confirmDelete"
+      @close="showDeleteConfirm = false"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/views/CancellationRequestsView.vue
+++ b/admin/src/modules/clients/views/CancellationRequestsView.vue
@@ -3,10 +3,17 @@
  * Cancellation Requests — paginated table of all service cancellation requests.
  * Shows Date, Product/Service, Client, Reason, Type, Status, and Actions (delete).
  */
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useCancellationRequestsStore } from '../stores/cancellationRequestsStore'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 
 const store = useCancellationRequestsStore()
+
+/** ID of the request awaiting delete confirmation, null when nothing is staged. */
+const deleteTarget = ref<number | null>(null)
+
+/** True while the staged request is being deleted. */
+const deleting = ref(false)
 
 /**
  * Type badge style map, keyed by the backend `CancellationType` member name. The API sends the
@@ -81,13 +88,32 @@ function goToPage(p: number): void {
 }
 
 /**
- * Prompts for confirmation, then deletes a cancellation request.
+ * Stages a cancellation request for deletion. Only opens the prompt — {@link handleDelete} does
+ * the work, so the question is asked by the app's own modal rather than the browser's dialog.
  *
  * @param id - The cancellation request ID to delete.
  */
-function confirmDelete(id: number): void {
-  if (confirm('Are you sure you want to delete this cancellation request?')) {
-    store.deleteRequest(id)
+const confirmDelete = (id: number): void => {
+  deleteTarget.value = id
+}
+
+/**
+ * Deletes the staged cancellation request and clears the prompt.
+ *
+ * The store swallows the failure into its own `error` ref, which the page already renders, so
+ * there is nothing to catch here — the target is cleared either way, as the native prompt did.
+ *
+ * @returns Promise that resolves when the delete attempt has finished.
+ */
+const handleDelete = async (): Promise<void> => {
+  const id = deleteTarget.value
+  if (id === null) return
+  deleting.value = true
+  try {
+    await store.deleteRequest(id)
+  } finally {
+    deleting.value = false
+    deleteTarget.value = null
   }
 }
 
@@ -223,5 +249,18 @@ onMounted(() => store.fetchAll())
       </div>
       <p class="text-[0.875rem] font-medium text-text-secondary">No cancellation requests found</p>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="deleteTarget !== null"
+      title="Delete Cancellation Request"
+      message="Are you sure you want to delete this cancellation request?"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deleting"
+      variant="danger"
+      @confirm="handleDelete"
+      @close="deleteTarget = null"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/views/ClientContactsView.vue
+++ b/admin/src/modules/clients/views/ClientContactsView.vue
@@ -6,6 +6,7 @@ import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useClientsStore } from '../stores/clientsStore'
 import { CONTACT_TYPE_STYLES } from '../../../utils/constants'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import ContactFormModal from '../components/ContactFormModal.vue'
 import type { Contact } from '../../../types/models'
 
@@ -87,33 +88,58 @@ async function handleUpdateContact(payload: Record<string, unknown>): Promise<vo
   }
 }
 
+/** ID of the contact awaiting delete confirmation, null when nothing is staged. */
+const deleteContactTarget = ref<number | null>(null)
+
+/** True while the staged contact is being deleted. */
+const deletingContact = ref(false)
+
 /**
- * Handles deleting a contact by ID with confirmation.
+ * Stages a contact for deletion. Only opens the prompt — {@link confirmDeleteContact} does the
+ * work, so the question is asked by the app's own modal rather than the browser's dialog.
  *
  * @param contactId - The ID of the contact to delete.
+ */
+const handleDeleteContact = (contactId: number): void => {
+  deleteContactTarget.value = contactId
+}
+
+/**
+ * Deletes the staged contact and clears the prompt.
+ *
+ * The target is cleared in `finally` so a failure closes the prompt and leaves the reason on the
+ * inline error banner, which is where every other action on this page reports one.
+ *
  * @returns Promise that resolves when the contact is removed.
  */
-async function handleDeleteContact(contactId: number): Promise<void> {
-  if (!confirm('Are you sure you want to delete this contact? This cannot be undone.')) return
+const confirmDeleteContact = async (): Promise<void> => {
+  const contactId = deleteContactTarget.value
+  if (contactId === null) return
   contactError.value = null
+  deletingContact.value = true
   try {
     await store.removeContact(clientId.value, contactId)
     showSuccess('Contact deleted successfully.')
   } catch {
     contactError.value = 'Failed to delete contact.'
+  } finally {
+    deletingContact.value = false
+    deleteContactTarget.value = null
   }
 }
 
 /**
  * Handles the delete event from the edit modal.
  *
- * @returns Promise that resolves when the contact is removed.
+ * Closes the edit modal first, then stages the same confirmation the row action uses — the edit
+ * modal has already asked once, so this is the second half of a prompt chain that predates the
+ * move off `confirm()` and is preserved exactly.
  */
-async function handleDeleteFromModal(): Promise<void> {
+const handleDeleteFromModal = (): void => {
   if (!editingContact.value) return
   const id = editingContact.value.id
   editingContact.value = null
-  await handleDeleteContact(id)
+  handleDeleteContact(id)
 }
 
 /**
@@ -244,6 +270,19 @@ function openEditModal(contact: Contact): void {
       @save="handleUpdateContact"
       @delete="handleDeleteFromModal"
       @close="editingContact = null"
+    />
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="deleteContactTarget !== null"
+      title="Delete Contact"
+      message="Are you sure you want to delete this contact? This cannot be undone."
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deletingContact"
+      variant="danger"
+      @confirm="confirmDeleteContact"
+      @close="deleteContactTarget = null"
     />
   </div>
 </template>

--- a/admin/src/modules/clients/views/ClientDomainDetailView.vue
+++ b/admin/src/modules/clients/views/ClientDomainDetailView.vue
@@ -11,6 +11,7 @@ import { formatDate, toDateInputValue } from '../../../utils/format'
 import AppDatePicker from '../../../components/AppDatePicker.vue'
 import AppNumberInput from '../../../components/AppNumberInput.vue'
 import AppSelect from '../../../components/AppSelect.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import ToggleSwitch from '../../../components/ToggleSwitch.vue'
 import DnsRecordsTable from '../components/DnsRecordsTable.vue'
 import EmailForwardingTable from '../components/EmailForwardingTable.vue'
@@ -57,6 +58,9 @@ const showEppModal = ref(false)
 
 /** Whether the renew modal is visible. */
 const showRenewModal = ref(false)
+
+/** Whether the register confirmation modal is visible. */
+const showRegisterModal = ref(false)
 
 /** Number of years to renew, bound to the renew modal input. */
 const renewYears = ref(1)
@@ -212,12 +216,23 @@ async function handleSave(): Promise<void> {
 }
 
 /**
- * Sends a register command to the registrar API.
+ * Opens the register confirmation modal. Only stages the intent — {@link confirmRegister} sends
+ * the command, so the question is asked by the app's own modal rather than the browser's dialog.
+ */
+const handleRegister = (): void => {
+  showRegisterModal.value = true
+}
+
+/**
+ * Sends a register command to the registrar API and closes the confirmation modal.
+ *
+ * The modal is dismissed before the request so the page's own `commandLoading` state drives the
+ * button row, exactly as the renew command beside it does.
  *
  * @returns Promise that resolves when the action completes.
  */
-async function handleRegister(): Promise<void> {
-  if (!confirm('Register this domain with the registrar?')) return
+const confirmRegister = async (): Promise<void> => {
+  showRegisterModal.value = false
   commandLoading.value = true
   try {
     await request(`/domains/${domainId.value}/register`, { method: 'POST' })
@@ -758,6 +773,19 @@ onMounted(() => fetchDomain())
           </div>
         </div>
       </Teleport>
+
+      <!-- Register Confirmation Modal -->
+      <ConfirmModal
+        v-if="showRegisterModal"
+        title="Register Domain"
+        message="Register this domain with the registrar?"
+        confirm-label="Register"
+        loading-label="Processing..."
+        :loading="commandLoading"
+        variant="primary"
+        @confirm="confirmRegister"
+        @close="showRegisterModal = false"
+      />
 
       <!-- EPP Code Modal -->
       <Teleport to="body">

--- a/admin/src/modules/clients/views/ClientUsersView.vue
+++ b/admin/src/modules/clients/views/ClientUsersView.vue
@@ -10,6 +10,7 @@ import { useUsersStore, type UserDetail } from '../stores/usersStore'
 import { PERMISSION_LABELS, ClientPermission, type ClientUserItem } from '../../../types/models'
 import { formatDate as sharedFormatDate } from '../../../utils/format'
 import AppCheckbox from '../../../components/AppCheckbox.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import UserFormModal from '../components/UserFormModal.vue'
 
 const route = useRoute()
@@ -334,14 +335,35 @@ async function handleUpdatePermissions(permissions: number): Promise<void> {
   }
 }
 
+/** The user awaiting ownership-transfer confirmation, null when nothing is staged. */
+const makeOwnerTarget = ref<UserDetail | null>(null)
+
+/** True while the staged ownership transfer is in flight. */
+const transferringOwnership = ref(false)
+
 /**
- * Transfers ownership to the editing user.
+ * Stages the ownership transfer to the editing user. Only opens the prompt —
+ * {@link confirmMakeOwner} does the work, so the question is asked by the app's own modal.
+ *
+ * The user is captured here rather than read again on confirm: the manage modal stays open
+ * behind the prompt and could be pointed at somebody else by the time it is answered.
  */
-async function handleMakeOwner(): Promise<void> {
+const handleMakeOwner = (): void => {
   if (!editingUser.value) return
-  if (!confirm(`Transfer ownership to "${editingUser.value.email}"? The current owner will become a regular user.`)) return
+  makeOwnerTarget.value = editingUser.value
+}
+
+/**
+ * Transfers ownership to the staged user and clears the prompt.
+ *
+ * @returns Promise that resolves when the transfer attempt has finished.
+ */
+const confirmMakeOwner = async (): Promise<void> => {
+  const target = makeOwnerTarget.value
+  if (!target) return
+  transferringOwnership.value = true
   try {
-    await request(`/clients/${clientId.value}/users/${editingUser.value.id}/make-owner`, {
+    await request(`/clients/${clientId.value}/users/${target.id}/make-owner`, {
       method: 'POST',
     })
     showManageModal.value = false
@@ -350,6 +372,9 @@ async function handleMakeOwner(): Promise<void> {
     setTimeout(() => { successMessage.value = null }, 3000)
   } catch {
     error.value = 'Failed to transfer ownership.'
+  } finally {
+    transferringOwnership.value = false
+    makeOwnerTarget.value = null
   }
 }
 
@@ -369,15 +394,33 @@ async function handleDeleteUser(): Promise<void> {
   }
 }
 
+/** The user awaiting removal confirmation, null when nothing is staged. */
+const removeUserTarget = ref<ClientUserItem | null>(null)
+
+/** True while the staged user is being removed. */
+const removingUser = ref(false)
+
 /**
- * Removes a non-owner user from this client.
+ * Stages a non-owner user for removal from this client. Only opens the prompt —
+ * {@link confirmRemoveUser} does the work, so the question is asked by the app's own modal.
  *
  * @param clientUser - The user to remove.
  */
-async function handleRemoveUser(clientUser: ClientUserItem): Promise<void> {
-  if (!confirm(`Remove "${clientUser.email}" from this client? They will lose access to this account.`)) return
+const handleRemoveUser = (clientUser: ClientUserItem): void => {
+  removeUserTarget.value = clientUser
+}
+
+/**
+ * Removes the staged user from this client and clears the prompt.
+ *
+ * @returns Promise that resolves when the removal attempt has finished.
+ */
+const confirmRemoveUser = async (): Promise<void> => {
+  const target = removeUserTarget.value
+  if (!target) return
+  removingUser.value = true
   try {
-    await request(`/clients/${clientId.value}/users/${clientUser.userId}`, {
+    await request(`/clients/${clientId.value}/users/${target.userId}`, {
       method: 'DELETE',
     })
     await fetchUsers()
@@ -385,6 +428,9 @@ async function handleRemoveUser(clientUser: ClientUserItem): Promise<void> {
     setTimeout(() => { successMessage.value = null }, 3000)
   } catch {
     error.value = 'Failed to remove user.'
+  } finally {
+    removingUser.value = false
+    removeUserTarget.value = null
   }
 }
 
@@ -682,5 +728,31 @@ onMounted(() => fetchUsers())
         @close="showManageModal = false"
       />
     </Teleport>
+
+    <!-- Transfer Ownership Confirm Modal -->
+    <ConfirmModal
+      v-if="makeOwnerTarget"
+      title="Transfer Ownership"
+      :message="`Transfer ownership to &quot;${makeOwnerTarget.email}&quot;? The current owner will become a regular user.`"
+      confirm-label="Transfer"
+      loading-label="Transferring..."
+      :loading="transferringOwnership"
+      variant="warning"
+      @confirm="confirmMakeOwner"
+      @close="makeOwnerTarget = null"
+    />
+
+    <!-- Remove User Confirm Modal -->
+    <ConfirmModal
+      v-if="removeUserTarget"
+      title="Remove User"
+      :message="`Remove &quot;${removeUserTarget.email}&quot; from this client? They will lose access to this account.`"
+      confirm-label="Remove"
+      loading-label="Removing..."
+      :loading="removingUser"
+      variant="danger"
+      @confirm="confirmRemoveUser"
+      @close="removeUserTarget = null"
+    />
   </div>
 </template>

--- a/admin/src/modules/clients/views/ManageUsersView.vue
+++ b/admin/src/modules/clients/views/ManageUsersView.vue
@@ -33,6 +33,44 @@ const openDropdownId = ref<string | null>(null)
 const dropdownRefs = ref<Map<string, HTMLElement>>(new Map())
 
 /**
+ * Message reporting a failed action, null when there is nothing to report.
+ *
+ * Kept separate from `store.error`, which reports a failed *list load* and is rendered in place
+ * of the table; an action failure must not hide the table the user is still working in.
+ */
+const actionError = ref<string | null>(null)
+
+/** Message reporting a completed action, null when there is nothing to report. */
+const actionSuccess = ref<string | null>(null)
+
+/**
+ * Shows a success message and clears it after a few seconds.
+ *
+ * Auto-clearing matches the sibling client screens (ClientUsersView, ClientContactsView) — a
+ * success needs acknowledging, not dismissing, which is why only this half expires.
+ *
+ * @param message - The message to display.
+ */
+const showSuccess = (message: string): void => {
+  actionError.value = null
+  actionSuccess.value = message
+  setTimeout(() => { actionSuccess.value = null }, 3000)
+}
+
+/**
+ * Shows a failure message, replacing any earlier one.
+ *
+ * This does not auto-clear: a failure stays until the next action either succeeds or fails, so a
+ * user who looked away still finds out the request did not go through.
+ *
+ * @param message - The message to display.
+ */
+const showError = (message: string): void => {
+  actionSuccess.value = null
+  actionError.value = message
+}
+
+/**
  * Applies the search filter.
  */
 function applySearch(): void {
@@ -76,7 +114,7 @@ async function handleSaveUser(data: { firstName: string; lastName: string; email
     editingUser.value = null
     await store.fetchAll(search.value || undefined)
   } catch {
-    alert('Failed to save user.')
+    showError('Failed to save user.')
   } finally {
     savingUser.value = false
   }
@@ -92,7 +130,7 @@ async function handleDeleteUser(): Promise<void> {
     editingUser.value = null
     await store.fetchAll(search.value || undefined)
   } catch {
-    alert('Failed to delete user.')
+    showError('Failed to delete user.')
   }
 }
 
@@ -105,9 +143,9 @@ async function handleSendPasswordReset(userId: string): Promise<void> {
   openDropdownId.value = null
   try {
     await store.sendPasswordReset(userId)
-    alert('Password reset email sent.')
+    showSuccess('Password reset email sent.')
   } catch {
-    alert('Failed to send password reset email.')
+    showError('Failed to send password reset email.')
   }
 }
 
@@ -133,7 +171,7 @@ async function handleChangePassword(password: string): Promise<void> {
     await store.changePassword(changingPasswordFor.value, password)
     changingPasswordFor.value = null
   } catch {
-    alert('Failed to change password.')
+    showError('Failed to change password.')
   } finally {
     savingPassword.value = false
   }
@@ -187,6 +225,14 @@ onUnmounted(() => {
 
 <template>
   <div class="p-4 sm:p-6 lg:p-8 w-full">
+
+    <!-- Action feedback — sits above the table so a failed action never replaces it -->
+    <div v-if="actionSuccess" class="mb-4 px-4 py-2.5 text-[0.82rem] text-status-green bg-status-green/10 border border-status-green/20 rounded-xl">
+      {{ actionSuccess }}
+    </div>
+    <div v-if="actionError" class="mb-4 px-4 py-2.5 text-[0.82rem] text-status-red bg-status-red/10 border border-status-red/20 rounded-xl">
+      {{ actionError }}
+    </div>
 
     <!-- Header -->
     <div class="flex items-start justify-between mb-5">

--- a/admin/src/modules/dashboard/views/DashboardView.vue
+++ b/admin/src/modules/dashboard/views/DashboardView.vue
@@ -63,7 +63,7 @@ const statConfig = [
 </script>
 
 <template>
-  <div class="p-4 sm:p-6 lg:p-8 max-w-5xl w-full">
+  <div class="p-4 sm:p-6 lg:p-8 w-full">
 
     <!-- Page header -->
     <div class="flex items-start justify-between mb-8">

--- a/admin/src/modules/integrations/views/CwpIntegrationPage.vue
+++ b/admin/src/modules/integrations/views/CwpIntegrationPage.vue
@@ -76,7 +76,7 @@ async function handleTest(): Promise<void> {
 </script>
 
 <template>
-  <div class="p-4 sm:p-6 lg:p-8 max-w-5xl w-full flex flex-col gap-5">
+  <div class="p-4 sm:p-6 lg:p-8 w-full flex flex-col gap-5">
 
     <!-- Breadcrumb -->
     <div class="flex items-center gap-2 text-[0.78rem]">

--- a/admin/src/modules/integrations/views/IntegrationDetailView.vue
+++ b/admin/src/modules/integrations/views/IntegrationDetailView.vue
@@ -78,7 +78,7 @@ async function handleTest(): Promise<void> {
   <CwpIntegrationPage v-if="isCwp" />
   <Cwp7IntegrationPage v-else-if="isCwp7" />
 
-  <div v-else class="p-4 sm:p-6 lg:p-8 max-w-5xl w-full">
+  <div v-else class="p-4 sm:p-6 lg:p-8 w-full">
 
     <!-- Breadcrumb -->
     <div class="flex items-center gap-2 text-[0.78rem] mb-6">

--- a/admin/src/modules/orders/views/OrderDetailView.vue
+++ b/admin/src/modules/orders/views/OrderDetailView.vue
@@ -100,7 +100,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="p-4 sm:p-6 lg:p-8 w-full max-w-6xl">
+  <div class="p-4 sm:p-6 lg:p-8 w-full">
 
     <!-- Back button -->
     <RouterLink to="/orders" class="inline-flex items-center gap-1.5 text-[0.78rem] text-text-muted hover:text-text-secondary transition-colors mb-4">

--- a/admin/src/modules/plugins/views/PluginsView.vue
+++ b/admin/src/modules/plugins/views/PluginsView.vue
@@ -36,7 +36,7 @@ async function handleUpload(file: File): Promise<void> {
 </script>
 
 <template>
-  <div class="p-4 sm:p-6 lg:p-8 w-full max-w-3xl">
+  <div class="p-4 sm:p-6 lg:p-8 w-full">
 
     <!-- Header -->
     <div class="mb-6">

--- a/admin/src/modules/servers/views/ServersView.vue
+++ b/admin/src/modules/servers/views/ServersView.vue
@@ -8,6 +8,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useServersStore } from '../stores/serversStore'
 import ServerFormModal from '../components/ServerFormModal.vue'
+import ConfirmModal from '../../../components/ConfirmModal.vue'
 import GroupFormModal from '../components/GroupFormModal.vue'
 import type { ServerDto, ServerGroupDto, ServerPayload, ServerGroupPayload } from '../types/server.types'
 import { MODULE_LABELS, FILL_TYPE_LABELS } from '../types/server.types'
@@ -57,6 +58,18 @@ const showServerModal = ref(false)
 const editingGroup = ref<ServerGroupDto | null>(null)
 /** True when the group form modal is open. */
 const showGroupModal = ref(false)
+
+/** The server awaiting delete confirmation, or null when nothing is staged. */
+const deleteServerTarget = ref<ServerDto | null>(null)
+
+/** True while the staged server is being deleted. */
+const deletingServer = ref(false)
+
+/** The group awaiting delete confirmation, or null when nothing is staged. */
+const deleteGroupTarget = ref<ServerGroupDto | null>(null)
+
+/** True while the staged group is being deleted. */
+const deletingGroup = ref(false)
 
 /** Groups servers by module type for display. */
 const serversByModule = computed(() => {
@@ -120,9 +133,21 @@ async function handleSaveServer(payload: ServerPayload): Promise<void> {
  *
  * @param server - Server to delete.
  */
-async function handleDeleteServer(server: ServerDto): Promise<void> {
-  if (!confirm(`Delete "${server.name}"? This cannot be undone.`)) return
-  await store.deleteServer(server.id)
+function handleDeleteServer(server: ServerDto): void {
+  deleteServerTarget.value = server
+}
+
+/** Deletes the staged server and clears the prompt. */
+async function confirmDeleteServer(): Promise<void> {
+  const target = deleteServerTarget.value
+  if (!target) return
+  deletingServer.value = true
+  try {
+    await store.deleteServer(target.id)
+    deleteServerTarget.value = null
+  } finally {
+    deletingServer.value = false
+  }
 }
 
 /**
@@ -148,9 +173,21 @@ async function handleSaveGroup(payload: ServerGroupPayload): Promise<void> {
  *
  * @param group - Group to delete.
  */
-async function handleDeleteGroup(group: ServerGroupDto): Promise<void> {
-  if (!confirm(`Delete group "${group.name}"? Servers will be unassigned.`)) return
-  await store.deleteGroup(group.id)
+function handleDeleteGroup(group: ServerGroupDto): void {
+  deleteGroupTarget.value = group
+}
+
+/** Deletes the staged group and clears the prompt. */
+async function confirmDeleteGroup(): Promise<void> {
+  const target = deleteGroupTarget.value
+  if (!target) return
+  deletingGroup.value = true
+  try {
+    await store.deleteGroup(target.id)
+    deleteGroupTarget.value = null
+  } finally {
+    deletingGroup.value = false
+  }
 }
 
 onMounted(async () => {
@@ -159,7 +196,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="p-4 sm:p-6 lg:p-8 max-w-6xl w-full flex flex-col gap-6">
+  <div class="p-4 sm:p-6 lg:p-8 w-full flex flex-col gap-6">
 
     <!-- Page header -->
     <div class="flex flex-wrap items-center justify-between gap-3">
@@ -433,4 +470,28 @@ onMounted(async () => {
     </Teleport>
 
   </div>
+
+    <ConfirmModal
+      v-if="deleteServerTarget"
+      title="Delete Server"
+      :message="`Delete &quot;${deleteServerTarget.name}&quot;? This cannot be undone.`"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deletingServer"
+      variant="danger"
+      @confirm="confirmDeleteServer"
+      @close="deleteServerTarget = null"
+    />
+
+    <ConfirmModal
+      v-if="deleteGroupTarget"
+      title="Delete Group"
+      :message="`Delete group &quot;${deleteGroupTarget.name}&quot;? Servers in it will be unassigned.`"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deletingGroup"
+      variant="danger"
+      @confirm="confirmDeleteGroup"
+      @close="deleteGroupTarget = null"
+    />
 </template>

--- a/admin/src/modules/settings/views/SlideFormView.vue
+++ b/admin/src/modules/settings/views/SlideFormView.vue
@@ -7,7 +7,9 @@
  * Provides unsaved-changes guard on navigation away.
  */
 import { ref, reactive, computed, onMounted, watch } from 'vue'
-import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import { useUnsavedChangesGuard } from '@/composables/useUnsavedChangesGuard'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useSlidesStore } from '../stores/slidesStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import ToggleSwitch from '@/components/ToggleSwitch.vue'
@@ -283,14 +285,8 @@ watch(translations, () => { isDirty.value = true }, { deep: true })
 
 // ── Unsaved changes guard ────────────────────────────────────
 
-onBeforeRouteLeave((_to, _from, next) => {
-  if (isDirty.value && !saving.value) {
-    const leave = confirm('You have unsaved changes. Are you sure you want to leave?')
-    next(leave)
-  } else {
-    next()
-  }
-})
+/** Parks a route change while the reader is asked about unsaved edits. */
+const leaveGuard = useUnsavedChangesGuard(() => isDirty.value && !saving.value)
 
 // ── Load data on mount ───────────────────────────────────────
 
@@ -840,6 +836,17 @@ function handleCancel(): void {
     </template>
 
   </div>
+
+    <!-- Unsaved-changes question, asked while the route change waits -->
+    <ConfirmModal
+      v-if="leaveGuard.pending.value"
+      title="Unsaved changes"
+      message="You have unsaved changes. Are you sure you want to leave?"
+      confirm-label="Leave"
+      variant="warning"
+      @confirm="leaveGuard.confirmLeave"
+      @close="leaveGuard.cancelLeave"
+    />
 </template>
 
 <style>

--- a/admin/src/modules/settings/views/SlidesView.vue
+++ b/admin/src/modules/settings/views/SlidesView.vue
@@ -10,6 +10,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import draggable from 'vuedraggable'
 import { useSlidesStore } from '../stores/slidesStore'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import type { Slide } from '@/types/models'
 
 const router = useRouter()
@@ -56,16 +57,47 @@ function navigateEdit(slide: Slide): void {
   router.push(`/settings/slides/${slide.id}/edit`)
 }
 
+/** The slide awaiting delete confirmation, null when nothing is staged. */
+const deleteTarget = ref<Slide | null>(null)
+
+/** True while the staged slide is being deleted. */
+const deleting = ref(false)
+
 /**
- * Confirms and deletes a slide.
+ * Resolves the title shown for a slide, falling back to its ID so a slide with no translation
+ * row still names something the operator can recognise in the prompt.
+ *
+ * @param slide - The slide to label.
+ * @returns The slide's first translated title, or a `Slide #id` placeholder.
+ */
+const slideTitle = (slide: Slide): string => slide.translations[0]?.title ?? `Slide #${slide.id}`
+
+/**
+ * Stages a slide for deletion. Only opens the prompt — {@link confirmDelete} does the work, so
+ * the question is asked by the app's own modal rather than the browser's blocking dialog.
  *
  * @param slide - The slide to delete.
  */
-async function handleDelete(slide: Slide): Promise<void> {
-  const title = slide.translations[0]?.title ?? `Slide #${slide.id}`
-  if (!confirm(`Delete "${title}"? This action cannot be undone.`)) return
-  await store.deleteSlide(slide.id)
-  syncLocal()
+const handleDelete = (slide: Slide): void => {
+  deleteTarget.value = slide
+}
+
+/**
+ * Deletes the staged slide, resyncs the draggable list, and clears the prompt.
+ *
+ * @returns Promise that resolves when the delete attempt has finished.
+ */
+const confirmDelete = async (): Promise<void> => {
+  const target = deleteTarget.value
+  if (!target) return
+  deleting.value = true
+  try {
+    await store.deleteSlide(target.id)
+    syncLocal()
+  } finally {
+    deleting.value = false
+    deleteTarget.value = null
+  }
 }
 
 /**
@@ -273,6 +305,19 @@ function formatDateRange(from: string | null, until: string | null): string {
         </tbody>
       </table>
     </div>
+
+    <!-- Delete Confirm Modal -->
+    <ConfirmModal
+      v-if="deleteTarget"
+      title="Delete Slide"
+      :message="`Delete &quot;${slideTitle(deleteTarget)}&quot;? This action cannot be undone.`"
+      confirm-label="Delete"
+      loading-label="Deleting..."
+      :loading="deleting"
+      variant="danger"
+      @confirm="confirmDelete"
+      @close="deleteTarget = null"
+    />
 
   </div>
 </template>

--- a/admin/src/modules/settings/views/TldConfigFormView.vue
+++ b/admin/src/modules/settings/views/TldConfigFormView.vue
@@ -8,7 +8,9 @@
  * reusable components instead of raw HTML inputs.
  */
 import { ref, computed, onMounted, watch } from 'vue'
-import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import { useUnsavedChangesGuard } from '@/composables/useUnsavedChangesGuard'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useTldConfigsStore } from '../stores/tldConfigsStore'
 import AppSelect from '@/components/AppSelect.vue'
 import AppSpinner from '@/components/AppSpinner.vue'
@@ -184,14 +186,8 @@ watch(
 
 // -- Unsaved changes guard --
 
-onBeforeRouteLeave((_to, _from, next) => {
-  if (isDirty.value && !saving.value) {
-    const leave = confirm('You have unsaved changes. Are you sure you want to leave?')
-    next(leave)
-  } else {
-    next()
-  }
-})
+/** Parks a route change while the reader is asked about unsaved edits. */
+const leaveGuard = useUnsavedChangesGuard(() => isDirty.value && !saving.value)
 
 // -- Load data on mount --
 
@@ -591,4 +587,15 @@ const sellSymbol = computed(() => {
     </template>
 
   </div>
+
+    <!-- Unsaved-changes question, asked while the route change waits -->
+    <ConfirmModal
+      v-if="leaveGuard.pending.value"
+      title="Unsaved changes"
+      message="You have unsaved changes. Are you sure you want to leave?"
+      confirm-label="Leave"
+      variant="warning"
+      @confirm="leaveGuard.confirmLeave"
+      @close="leaveGuard.cancelLeave"
+    />
 </template>

--- a/backend/src/Innovayse.Application/Orders/Commands/PlaceOrder/PlaceOrderHandler.cs
+++ b/backend/src/Innovayse.Application/Orders/Commands/PlaceOrder/PlaceOrderHandler.cs
@@ -159,12 +159,22 @@ public sealed class PlaceOrderHandler(
             {
                 return existing.Id;
             }
+
+            // Their first order. The account already exists — they authenticated to get here —
+            // so what is missing is only this product's client row, and the credential carries
+            // everything it needs. Provisioning is deliberately not called: it creates accounts,
+            // and where an SSO owns them it refuses, which is correct and not what is wanted
+            // here.
+            //
+            // Without this the caller cannot order at all. The validator asks a signed-in caller
+            // for no email and no password, so the guest branch below always refused them, and
+            // the client area they were sent back to says they have no account to order against.
+            return await CreateClientForCallerAsync(subject, cmd, ct);
         }
 
-        // Reached two ways, and the sentence has to be true of both: a signed-in caller whose
-        // subject has no client row, and an anonymous caller who sent no registration. The
-        // validator already refuses the second before the handler runs, so in practice this is
-        // the first — which is why it no longer says the session expired. It had not.
+        // Anonymous, and guest checkout is the only way left. The validator already requires all
+        // four fields of a caller with no subject, so this refusal is reached only when something
+        // dispatched the command without going through it.
         if (string.IsNullOrWhiteSpace(cmd.Email) || string.IsNullOrWhiteSpace(cmd.Password))
         {
             throw new InvalidOperationException(localizer[NoClientAccountKey]);
@@ -179,6 +189,70 @@ public sealed class PlaceOrderHandler(
         await uow.SaveChangesAsync(ct);
 
         return newClient.Id;
+    }
+
+    /// <summary>
+    /// Creates the client row for a signed-in caller who does not have one yet.
+    /// </summary>
+    /// <remarks>
+    /// Names come from the order when it carries them and from the credential otherwise. The
+    /// checkout form asks a signed-in caller for neither, so in practice it is the credential;
+    /// the command is preferred anyway because a caller who did type a billing name meant it.
+    /// <para>
+    /// The email is read from the credential rather than the command on purpose. A caller can
+    /// put any address in a form field, and this row decides which account every later invoice
+    /// and service belongs to.
+    /// </para>
+    /// </remarks>
+    /// <param name="subject">The caller's subject, already known to have no client row.</param>
+    /// <param name="cmd">The order being placed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The new client's ID.</returns>
+    private async Task<int> CreateClientForCallerAsync(string subject, PlaceOrderCommand cmd, CancellationToken ct)
+    {
+        var (credentialFirst, credentialLast) = SplitDisplayName(caller.UserName);
+
+        var client = Client.Create(
+            subject,
+            FirstNonBlank(cmd.FirstName, credentialFirst) ?? string.Empty,
+            FirstNonBlank(cmd.LastName, credentialLast) ?? string.Empty,
+            caller.UserEmail ?? cmd.Email ?? string.Empty);
+
+        clientRepo.Add(client);
+        await uow.SaveChangesAsync(ct);
+
+        return client.Id;
+    }
+
+    /// <summary>Returns the first of two values that is neither null nor blank.</summary>
+    /// <param name="preferred">The value to use when it says something.</param>
+    /// <param name="fallback">Used when <paramref name="preferred"/> does not.</param>
+    /// <returns>The chosen value, or <see langword="null"/> when neither says anything.</returns>
+    private static string? FirstNonBlank(string? preferred, string? fallback) =>
+        string.IsNullOrWhiteSpace(preferred) ? (string.IsNullOrWhiteSpace(fallback) ? null : fallback) : preferred;
+
+    /// <summary>
+    /// Splits a credential's display name into the first and last name the client row stores.
+    /// </summary>
+    /// <remarks>
+    /// A display name is one string and this schema wants two, so the split is a guess: the
+    /// first word is the given name and whatever follows is the family name. It is wrong for
+    /// some names and there is no parse that is right for all of them. It is used only to fill
+    /// the row at creation — the customer can correct both fields in their profile, and nothing
+    /// but display reads them.
+    /// </remarks>
+    /// <param name="displayName">The credential's name claim, if it carries one.</param>
+    /// <returns>The first and last name, each null when the name does not supply it.</returns>
+    private static (string? First, string? Last) SplitDisplayName(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return (null, null);
+        }
+
+        var parts = displayName.Trim().Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+        return (parts[0], parts.Length > 1 ? parts[1] : null);
     }
 
     /// <summary>

--- a/backend/src/Innovayse.Application/Services/Commands/SetupService/SetupServiceValidator.cs
+++ b/backend/src/Innovayse.Application/Services/Commands/SetupService/SetupServiceValidator.cs
@@ -1,0 +1,43 @@
+namespace Innovayse.Application.Services.Commands.SetupService;
+
+using System.Text.RegularExpressions;
+using FluentValidation;
+
+/// <summary>Validates <see cref="SetupServiceCommand"/> before the service is provisioned.</summary>
+/// <remarks>
+/// The chokepoint every provisioning path funnels through: the client-facing
+/// <c>SetupMyServiceCommand</c> delegates here, and any future staff route dispatches this same
+/// command, so the rules cannot be bypassed by choosing a different entry. They mirror the
+/// setup wizard's own field checks, because a form check the server does not repeat is not a
+/// check at all — a caller reaching the endpoint directly must be refused a malformed domain,
+/// a bad username, or a too-short password exactly as the UI would refuse them.
+/// </remarks>
+public sealed class SetupServiceValidator : AbstractValidator<SetupServiceCommand>
+{
+    /// <summary>
+    /// A hostname of two or more dot-separated labels ending in a letters-only TLD, e.g.
+    /// <c>example.com</c>. Each label is a–z/0–9/hyphen without a leading or trailing hyphen;
+    /// the whole name is capped at 253 characters. Case-insensitive.
+    /// </summary>
+    private static readonly Regex DomainPattern = new(
+        @"^(?=.{1,253}$)([a-z0-9](-*[a-z0-9])*\.)+[a-z]{2,}$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Initialises the domain, username, and password rules for service setup.</summary>
+    public SetupServiceValidator()
+    {
+        RuleFor(x => x.Domain)
+            .NotEmpty().WithMessage("Domain is required.")
+            .Must(d => DomainPattern.IsMatch(d.Trim()))
+            .WithMessage("Enter a valid domain, e.g. example.com.");
+
+        RuleFor(x => x.Username)
+            .NotEmpty().WithMessage("Username is required.")
+            .Matches("^[a-z][a-z0-9]{2,7}$")
+            .WithMessage("Username must start with a letter, use only lowercase letters and numbers, and be 3 to 8 characters.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.");
+    }
+}

--- a/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
@@ -323,6 +323,13 @@ public static class DependencyInjection
         services.AddScoped<IProvisioningProvider, NullCPanelProvisioningProvider>();
         services.AddScoped<Innovayse.Domain.Services.Interfaces.IProvisioningProvider, NullProvisioningProvider>();
 
+        // Provisioning behaviour switches. Left unset everywhere but development, where
+        // appsettings.Development.json turns UseFakeProvider on so the setup flow can complete
+        // without a live CWP7 panel to call.
+        services.AddOptions<Innovayse.Infrastructure.Provisioning.Options.ProvisioningOptions>()
+            .Bind(configuration.GetSection(
+                Innovayse.Infrastructure.Provisioning.Options.ProvisioningOptions.SectionName));
+
         // Provisioning provider factory — creates per-server providers (CWP7, cPanel, etc.)
         services.AddScoped<Innovayse.Domain.Provisioning.Interfaces.IProvisioningProviderFactory, Innovayse.Infrastructure.Provisioning.ProvisioningProviderFactory>();
 

--- a/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
+++ b/backend/src/Innovayse.Infrastructure/Persistence/DevDataSeeder.cs
@@ -391,9 +391,48 @@ public sealed class DevDataSeeder(
                     var product = products[Rng.Next(products.Count)];
                     var cycle = billingCycles[Rng.Next(2)];
                     var svc = ClientService.Create(client.Id, product.Id, cycle);
+
+                    // ClientService.Create leaves both amounts at zero, and every renewal is
+                    // billed from RecurringAmount by ProcessRenewalsCronHandler. Without this
+                    // the seeded portal shows a wall of 0.00 invoices — the Pay screens have
+                    // nothing to charge and no dev sees what a real balance looks like. The two
+                    // production callers, OrderServiceHandler and MigrationPullWorker, both set
+                    // these the same way immediately after Create; this seeder was the only one
+                    // that did not.
+                    var cyclePrice = cycle == "annual" ? product.AnnualPrice : product.MonthlyPrice;
+
+                    svc.Update(
+                        domain: null, dedicatedIp: null, username: null,
+                        password: null, billingCycle: cycle,
+                        recurringAmount: cyclePrice, paymentMethod: null,
+                        nextRenewalAt: null, subscriptionId: null,
+                        overrideAutoSuspend: false, suspendUntil: null,
+                        autoTerminateEndOfCycle: false, autoTerminateReason: null,
+                        adminNotes: null, provisioningRef: null,
+                        firstPaymentAmount: cyclePrice,
+                        promotionCode: null, terminatedAt: null,
+                        serverId: null, quantity: 1, productId: null);
+
                     var monthsBack = Rng.Next(1, 12);
                     db.Entry(svc).Property(nameof(ClientService.CreatedAt)).CurrentValue = MonthsAgo(monthsBack);
-                    svc.Activate("prov_" + Rng.Next(10000, 99999));
+
+                    // Leave the first of a client's several services Pending, the rest Active. This
+                    // is what gives the portal a service to run the setup wizard against — without
+                    // it every seeded service is already provisioned and "Build My Server" has
+                    // nothing to act on. A client with only one service keeps it Active so no
+                    // account is left unusable; a Pending service is never activated and holds no
+                    // provisioning ref, exactly the state the wizard fills in.
+                    if (i == 0 && numServices > 1)
+                    {
+                        logger.LogInformation(
+                            "Left one service for client {ClientId} Pending to seed the setup flow",
+                            client.Id);
+                    }
+                    else
+                    {
+                        svc.Activate("prov_" + Rng.Next(10000, 99999));
+                    }
+
                     db.ClientServices.Add(svc);
                 }
             }
@@ -732,9 +771,20 @@ public sealed class DevDataSeeder(
                 true, 50, false, false, 800m, "US-West DC", null,
                 "ns1.hostpanel.com", "192.168.1.1", "ns2.hostpanel.com", "192.168.1.2",
                 null, null, null, null, null, null),
+
+            // The only CWP7 server, and the only one the setup flow can actually pick: every
+            // hosting product maps to the Cwp7 module (SetupServiceHandler.MapProductTypeToModule),
+            // so without a Cwp7 server the server selector returns nothing and "Build My Server"
+            // fails before it starts. The access hash is a dev placeholder — the real CWP7 call is
+            // short-circuited by the fake provider (Provisioning:UseFakeProvider), so it is never used.
+            new ServerDetails("CWP7 US-01", "cwp01.hostpanel.com", "203.0.113.20", null,
+                ServerModule.Cwp7, "root", "changeme", null, "dev-access-hash",
+                true, 200, true, false, 300m, "US-East DC", null,
+                "ns1.hostpanel.com", "192.168.1.1", "ns2.hostpanel.com", "192.168.1.2",
+                null, null, null, null, null, null),
         };
 
-        var groupIds = new[] { sharedGroup.Id, sharedGroup.Id, vpsGroup.Id, vpsGroup.Id };
+        var groupIds = new[] { sharedGroup.Id, sharedGroup.Id, vpsGroup.Id, vpsGroup.Id, sharedGroup.Id };
         for (var i = 0; i < serverDefs.Length; i++)
         {
             var server = Server.Create(serverDefs[i]);

--- a/backend/src/Innovayse.Infrastructure/Provisioning/Options/ProvisioningOptions.cs
+++ b/backend/src/Innovayse.Infrastructure/Provisioning/Options/ProvisioningOptions.cs
@@ -1,0 +1,27 @@
+namespace Innovayse.Infrastructure.Provisioning.Options;
+
+/// <summary>
+/// Behaviour switches for how <see cref="ProvisioningProviderFactory"/> talks to control panels,
+/// bound from the <c>Provisioning</c> section.
+/// </summary>
+/// <remarks>
+/// The one setting here exists because the factory otherwise only knows how to build a provider
+/// that makes real HTTP calls to a live CWP7 panel on port 2304. A developer running the stack has
+/// no such panel, so setting up a service — the last step of the order flow — cannot complete and
+/// the whole path is untestable. With <see cref="UseFakeProvider"/> on, the factory returns the
+/// in-process no-op provider instead, so "Build My Server" runs end to end against seeded data.
+/// It defaults off: every real environment provisions for real.
+/// </remarks>
+public sealed class ProvisioningOptions
+{
+    /// <summary>The configuration section name.</summary>
+    public const string SectionName = "Provisioning";
+
+    /// <summary>
+    /// When <see langword="true"/>, the provider factory returns an in-process provider that
+    /// reports success without contacting any external control panel. Development and testing
+    /// only; must stay <see langword="false"/> in stage and production, where a service marked
+    /// active would otherwise have no account behind it.
+    /// </summary>
+    public bool UseFakeProvider { get; set; }
+}

--- a/backend/src/Innovayse.Infrastructure/Provisioning/ProvisioningProviderFactory.cs
+++ b/backend/src/Innovayse.Infrastructure/Provisioning/ProvisioningProviderFactory.cs
@@ -2,8 +2,10 @@ namespace Innovayse.Infrastructure.Provisioning;
 
 using Innovayse.Domain.Provisioning.Interfaces;
 using Innovayse.Domain.Servers;
+using Innovayse.Infrastructure.Provisioning.Options;
 using Innovayse.Providers.CWP7;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 /// <summary>
 /// Creates <see cref="IProvisioningProvider"/> instances configured for a specific server.
@@ -11,9 +13,11 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 /// <param name="httpClientFactory">Factory for creating HTTP clients for provider API calls.</param>
 /// <param name="loggerFactory">Factory for creating typed loggers for each provider.</param>
+/// <param name="options">Provisioning behaviour switches, notably the development fake-provider flag.</param>
 public sealed class ProvisioningProviderFactory(
     IHttpClientFactory httpClientFactory,
-    ILoggerFactory loggerFactory) : IProvisioningProviderFactory
+    ILoggerFactory loggerFactory,
+    IOptions<ProvisioningOptions> options) : IProvisioningProviderFactory
 {
     /// <summary>Default CWP7 API port.</summary>
     private const int DefaultCwp7Port = 2304;
@@ -27,6 +31,17 @@ public sealed class ProvisioningProviderFactory(
     /// <exception cref="InvalidOperationException">Thrown when required credentials are missing.</exception>
     public IProvisioningProvider CreateFor(Server server)
     {
+        // Development short-circuit: with no live control panel to call, return the in-process
+        // no-op provider so the setup flow completes. Guarded by config that defaults off, so a
+        // real environment never reaches this and always builds a provider that provisions for
+        // real. Server selection still ran before this, so the flow is exercised end to end bar
+        // the outbound HTTP call itself.
+        if (options.Value.UseFakeProvider)
+        {
+            return new NullCPanelProvisioningProvider(
+                loggerFactory.CreateLogger<NullCPanelProvisioningProvider>());
+        }
+
         return server.Module switch
         {
             ServerModule.Cwp7 => CreateCwp7Provider(server),

--- a/backend/tests/Innovayse.Application.Tests/Orders/PlaceOrderClientProvisioningTests.cs
+++ b/backend/tests/Innovayse.Application.Tests/Orders/PlaceOrderClientProvisioningTests.cs
@@ -1,0 +1,193 @@
+namespace Innovayse.Application.Tests.Orders;
+
+using Innovayse.Application.Auth.Interfaces;
+using Innovayse.Application.Common;
+using Innovayse.Application.Orders.Commands.PlaceOrder;
+using Innovayse.Application.Resources;
+using Innovayse.Domain.Auth.Interfaces;
+using Innovayse.Domain.Billing.Interfaces;
+using Innovayse.Domain.Clients;
+using Innovayse.Domain.Clients.Interfaces;
+using Innovayse.Domain.Orders.Interfaces;
+using Innovayse.Domain.Products;
+using Innovayse.Domain.Products.Interfaces;
+using Microsoft.Extensions.Localization;
+using Moq;
+using System.Reflection;
+using Wolverine;
+using Xunit;
+
+/// <summary>
+/// Proves a signed-in caller placing their first order gets a client record rather than a refusal.
+/// </summary>
+/// <remarks>
+/// The state these cover is the ordinary one for anyone whose account lives in the SSO: they
+/// authenticate, so a subject exists, but nothing has ever created this product's client row for
+/// them. The handler used to fall through to the guest-checkout branch, which needs an email and
+/// a password the validator never asks a signed-in caller for — so the branch always refused, and
+/// the client area they were sent back to told them they had no account to order against. There
+/// was no way out of that loop from inside the product.
+/// </remarks>
+public sealed class PlaceOrderClientProvisioningTests
+{
+    /// <summary>The caller's subject in every test below.</summary>
+    private const string CallerSubject = "sso-subject-1";
+
+    /// <summary>The product every order here is for.</summary>
+    private const int ProductId = 3;
+
+    /// <summary>Builds the product the order references.</summary>
+    /// <returns>An active hosting product carrying <see cref="ProductId"/>.</returns>
+    private static Product HostingProduct()
+    {
+        var product = Product.Create(
+            groupId: 1, name: "Pro Hosting", description: null, website: null, slug: null,
+            packageName: null, type: ProductType.SharedHosting,
+            monthlyPrice: 19.99m, annualPrice: 199.99m);
+
+        // Create leaves Id at 0 for EF to assign, and the handler looks the product up by id.
+        // Entity.Id has a private setter, so the backing field is the only way in — the same
+        // approach StartGatewayPaymentHandlerTests uses for the same reason.
+        typeof(Innovayse.Domain.Common.Entity)
+            .GetField("<Id>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(product, ProductId);
+
+        return product;
+    }
+
+    /// <summary>An order for one month of <see cref="HostingProduct"/>, as a signed-in caller sends it.</summary>
+    /// <remarks>
+    /// Name, email and password are all absent on purpose: <c>PlaceOrderValidator</c> requires
+    /// them only of a caller with no subject, so this is exactly the shape the checkout form
+    /// produces for someone who is signed in.
+    /// </remarks>
+    /// <returns>The command under test.</returns>
+    private static PlaceOrderCommand SignedInOrder() => new(
+        FirstName: null, LastName: null, Email: null, Password: null, Phone: null,
+        PaymentMethod: "stripe",
+        Items: [new PlaceOrderItemDto(ProductId, "monthly", null, null)]);
+
+    /// <summary>
+    /// Builds the handler over a world in which the caller's subject has no client row.
+    /// </summary>
+    /// <param name="added">Receives the client the handler creates, if it creates one.</param>
+    /// <param name="provisioning">Observed so a test can assert it was never asked to make an account.</param>
+    /// <param name="displayName">The credential's name claim.</param>
+    /// <param name="email">The credential's email claim.</param>
+    /// <returns>The handler under test.</returns>
+    private static PlaceOrderHandler HandlerWithNoClientFor(
+        List<Client> added,
+        out Mock<IUserProvisioning> provisioning,
+        string? displayName = "Ada Lovelace",
+        string? email = "ada@example.com")
+    {
+        var clients = new Mock<IClientRepository>();
+        clients.Setup(r => r.FindByUserIdAsync(CallerSubject, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Client?)null);
+        clients.Setup(r => r.Add(It.IsAny<Client>())).Callback<Client>(added.Add);
+
+        var products = new Mock<IProductRepository>();
+        products.Setup(r => r.FindByIdsAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([HostingProduct()]);
+
+        var orders = new Mock<IOrderRepository>();
+        orders.Setup(r => r.GetNextOrderNumberAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var caller = new Mock<ICurrentRequestContext>();
+        caller.SetupGet(c => c.UserId).Returns(CallerSubject);
+        caller.SetupGet(c => c.UserName).Returns(displayName);
+        caller.SetupGet(c => c.UserEmail).Returns(email);
+
+        // Strict: any call to the provisioner is a failure, asserted by the test that says so.
+        provisioning = new Mock<IUserProvisioning>(MockBehavior.Strict);
+
+        return new PlaceOrderHandler(
+            orders.Object,
+            products.Object,
+            clients.Object,
+            Mock.Of<IInvoiceRepository>(),
+            Mock.Of<IUnitOfWork>(),
+            provisioning.Object,
+            Mock.Of<ISubjectRoleStore>(),
+            Mock.Of<IMessageBus>(),
+            caller.Object,
+            Mock.Of<IStringLocalizer<ValidationMessages>>());
+    }
+
+    /// <summary>The order goes through, instead of being refused for a missing account.</summary>
+    [Fact]
+    public async Task FirstOrderFromASignedInCallerCreatesTheirClientRecord()
+    {
+        var added = new List<Client>();
+        var handler = HandlerWithNoClientFor(added, out _);
+
+        await handler.HandleAsync(SignedInOrder(), CancellationToken.None);
+
+        Assert.Single(added);
+        Assert.Equal(CallerSubject, added[0].UserId);
+    }
+
+    /// <summary>The row is filled from the credential, not from the order body.</summary>
+    /// <remarks>
+    /// The identity decides which account every later invoice and service belongs to, and a form
+    /// field is something the caller can put anything in.
+    /// </remarks>
+    [Fact]
+    public async Task TheNewClientIsNamedFromTheCredential()
+    {
+        var added = new List<Client>();
+        var handler = HandlerWithNoClientFor(added, out _);
+
+        await handler.HandleAsync(SignedInOrder(), CancellationToken.None);
+
+        Assert.Equal("Ada", added[0].FirstName);
+        Assert.Equal("Lovelace", added[0].LastName);
+    }
+
+    /// <summary>No account is provisioned: the caller already has one, which is how they got here.</summary>
+    /// <remarks>
+    /// It matters because where an SSO owns the accounts the provisioner refuses, and calling it
+    /// would turn a first order back into that refusal.
+    /// </remarks>
+    [Fact]
+    public async Task NoAccountIsProvisionedForACallerWhoAlreadyHasOne()
+    {
+        var added = new List<Client>();
+        var handler = HandlerWithNoClientFor(added, out var provisioning);
+
+        await handler.HandleAsync(SignedInOrder(), CancellationToken.None);
+
+        provisioning.VerifyNoOtherCalls();
+    }
+
+    /// <summary>A one-word display name still produces a usable row.</summary>
+    /// <remarks>
+    /// Splitting a display name into two fields is a guess, and this is the case where the guess
+    /// has nothing to give the second field. Refusing the order over it would be worse than a
+    /// blank surname the customer can correct in their profile.
+    /// </remarks>
+    [Fact]
+    public async Task ASingleWordNameLeavesTheSurnameBlankRatherThanFailing()
+    {
+        var added = new List<Client>();
+        var handler = HandlerWithNoClientFor(added, out _, displayName: "Ada");
+
+        await handler.HandleAsync(SignedInOrder(), CancellationToken.None);
+
+        Assert.Equal("Ada", added[0].FirstName);
+        Assert.Equal(string.Empty, added[0].LastName);
+    }
+
+    /// <summary>A credential carrying no name at all is still enough to order.</summary>
+    [Fact]
+    public async Task ACredentialWithNoNameStillOrders()
+    {
+        var added = new List<Client>();
+        var handler = HandlerWithNoClientFor(added, out _, displayName: null);
+
+        await handler.HandleAsync(SignedInOrder(), CancellationToken.None);
+
+        Assert.Single(added);
+        Assert.Equal(CallerSubject, added[0].UserId);
+    }
+}

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -1,5 +1,25 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  /**
+   * Development only: render in the browser instead of on the server.
+   *
+   * The dev server's SSR transform runs in a vite-node worker that talks to Nitro over a
+   * unix socket, and on this Docker-for-Windows setup that exchange never completes for this
+   * app: every server-rendered route either hangs or answers 500 "IPC connection closed",
+   * while API routes, static assets and the `ssr: false` pages under /client all work. It is
+   * not the application code — the same routes render correctly in production, and the
+   * failure reproduces on an unmodified checkout.
+   *
+   * Turning SSR off in development trades away one thing — you cannot see server-rendered
+   * output locally — to get back every page, which otherwise cannot be opened at all.
+   * Production is untouched: `$development` applies only to `nuxt dev`.
+   *
+   * Remove this once the dev-server issue is fixed, and verify by loading any public page.
+   */
+  $development: {
+    ssr: false,
+  },
+
   compatibilityDate: '2026-02-04',
   devtools: { enabled: true },
 

--- a/client/pages/announcements/[id].vue
+++ b/client/pages/announcements/[id].vue
@@ -32,7 +32,7 @@
           <!-- Date -->
           <div class="flex items-center gap-2 text-xs text-gray-500 mb-4">
             <Calendar :size="13" :stroke-width="2" />
-            {{ $t('announcements.published') }}: {{ item.date }}
+            {{ $t('announcements.published') }}: {{ formatDate(item.date, locale) }}
           </div>
 
           <!-- Title -->
@@ -69,6 +69,9 @@
 import { ArrowLeft, Calendar, Megaphone } from 'lucide-vue-next'
 import { useContentApi } from '~/composables/apis/useContentApi'
 import type { Announcement } from '~/types/announcement'
+
+/** The reader's language, so the publication date is written the way they read dates. */
+const { locale } = useI18n()
 
 const route = useRoute()
 const localePath = useLocalePath()

--- a/client/pages/announcements/index.vue
+++ b/client/pages/announcements/index.vue
@@ -61,7 +61,7 @@
           >
             <div class="flex items-center gap-2 text-xs text-gray-500 mb-3">
               <Calendar :size="13" :stroke-width="2" />
-              {{ item.date }}
+              {{ formatDate(item.date, locale) }}
             </div>
             <h2 class="text-lg font-semibold text-white group-hover:text-primary-400 transition-colors mb-2">
               {{ item.title }}
@@ -92,7 +92,7 @@ import { useContentApi } from '~/composables/apis/useContentApi'
 import type { Announcement } from '~/types/announcement'
 
 const localePath = useLocalePath()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 useSeoMeta({
   title: t('announcements.title'),
@@ -109,26 +109,44 @@ const { data, pending, error } = useContentApi().loadAnnouncements()
 const items = computed<Announcement[]>(() => data.value?.items ?? [])
 
 /**
- * Unique month labels extracted from announcement dates.
- * Prepends "all" when there is more than one distinct month.
+ * The month each announcement belongs to, as a label a person reads.
+ *
+ * Derived from the timestamp rather than by pattern-matching a formatted string. The previous
+ * version ran `/(\w+ \d{4})$/` over `item.date` and depended on the backend happening to send
+ * "August 2026" — it sends an ISO timestamp, so the match silently found nothing and the month
+ * tabs never appeared. Parsing the date instead also makes the labels follow the chosen
+ * language, which a regex over English month names could not do.
+ *
+ * @param value - The announcement's ISO publication timestamp.
+ * @returns The month and year in the active locale, or an empty string when unparseable.
+ */
+const monthLabel = (value: string | undefined): string => {
+  if (!value) return ''
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return new Intl.DateTimeFormat(locale.value, { month: 'long', year: 'numeric' }).format(parsed)
+}
+
+/**
+ * The distinct months present, newest first, with "all" in front.
+ *
+ * Only offered when there is more than one: a single tab beside "all" is a control that cannot
+ * change anything.
  */
 const months = computed(() => {
-  const seen = new Set<string>()
+  const seen: string[] = []
   for (const item of items.value) {
-    const match = item.date.match(/(\w+ \d{4})$/)
-    // The group is only present when the whole pattern matched, but the compiler cannot know
-    // that from `match` alone — and reading it unchecked would have added `undefined` to a
-    // `Set<string>` and rendered an empty month tab.
-    if (match?.[1]) seen.add(match[1])
+    const label = monthLabel(item.date)
+    if (label && !seen.includes(label)) seen.push(label)
   }
-  return seen.size > 1 ? ['all', ...Array.from(seen)] : []
+  return seen.length > 1 ? ['all', ...seen] : []
 })
 
 const activeMonth = ref('all')
 
-/** Announcements filtered by the active month selection */
+/** Announcements filtered by the active month selection. */
 const filtered = computed(() => {
   if (activeMonth.value === 'all') return items.value
-  return items.value.filter(item => item.date?.includes(activeMonth.value))
+  return items.value.filter(item => monthLabel(item.date) === activeMonth.value)
 })
 </script>

--- a/client/pages/client/dashboard.vue
+++ b/client/pages/client/dashboard.vue
@@ -293,6 +293,7 @@ import { useClientStore } from '~/stores/client'
 import { useClientApi } from '~/composables/apis/useClientApi'
 import { EMPTY_DATE, formatDate } from '~/utils/formatDate'
 import { formatCurrency } from '~/utils/formatCurrency'
+import { isInvoiceOutstanding } from '~/utils/invoice'
 import type { ClientDomain } from '~/types/clientdomain'
 
 definePageMeta({ layout: 'client', middleware: 'client-auth' })
@@ -388,10 +389,13 @@ const setupAlertMessage = computed(() => {
     : t('client.dashboard.setupAlertMultiple', { count })
 })
 
-/** Invoices that are unpaid or overdue */
-const unpaidInvoices = computed(() =>
-  store.invoices.filter(i => i.status === 'Unpaid' || (i.status as string) === 'Overdue')
-)
+/**
+ * Invoices still awaiting payment.
+ *
+ * Shares {@link isInvoiceOutstanding} with the stat card above it, which is the whole point:
+ * the two used to define this separately and disagreed on the same screen.
+ */
+const unpaidInvoices = computed(() => store.invoices.filter(isInvoiceOutstanding))
 
 const unpaidAlertMessage = computed(() => {
   const count = unpaidInvoices.value.length

--- a/client/pages/client/invoices/[id].vue
+++ b/client/pages/client/invoices/[id].vue
@@ -29,7 +29,7 @@
             <ClientStatusBadge :status="invoice.status" />
             <!-- Pay Now button for unpaid invoices -->
             <NuxtLink
-              v-if="invoice.status === 'Unpaid' || invoice.status === 'Overdue'"
+              v-if="isOutstanding"
               :to="localePath(`/client/invoices/${invoice.id}/pay`)"
               class="px-5 py-2 rounded-xl bg-green-500 text-white font-semibold text-sm hover:bg-green-400 transition-colors flex items-center gap-2"
             >
@@ -94,7 +94,7 @@
 
       <!-- Pay Now banner for unpaid -->
       <UiAlert
-        v-if="invoice.status === 'Unpaid' || invoice.status === 'Overdue'"
+        v-if="isOutstanding"
         class="mb-6"
       >
         {{ $t('client.invoices.unpaidBanner') }}
@@ -118,7 +118,7 @@ import { useBillingApi } from '~/composables/apis/useBillingApi'
 import { useClientStore } from '~/stores/client'
 import { formatCurrency } from '~/utils/formatCurrency'
 import { EMPTY_DATE, formatDate, formatDateTime } from '~/utils/formatDate'
-import { isInvoiceOverdue } from '~/utils/invoice'
+import { isInvoiceOutstanding, isInvoiceOverdue } from '~/utils/invoice'
 
 definePageMeta({ layout: 'client', middleware: 'client-auth' })
 
@@ -149,6 +149,9 @@ const { data: invoice, pending, error } = await useBillingApi().loadInvoice(
  */
 const money = (amount: string | number | null | undefined): string =>
   formatCurrency(amount, { code: store.user?.currency })
+
+/** Whether this invoice still has money owing — one definition, in `utils/invoice.ts`. */
+const isOutstanding = computed(() => Boolean(invoice.value) && isInvoiceOutstanding(invoice.value!))
 
 /** Whether the due date should be shown in red — one definition, in `utils/invoice.ts`. */
 const isOverdue = computed(() => isInvoiceOverdue(invoice.value))

--- a/client/pages/client/invoices/index.vue
+++ b/client/pages/client/invoices/index.vue
@@ -71,7 +71,7 @@ import { FileText } from 'lucide-vue-next'
 import { useClientStore } from '~/stores/client'
 import { formatCurrency } from '~/utils/formatCurrency'
 import { formatDate } from '~/utils/formatDate'
-import { isInvoiceOverdue as isOverdue } from '~/utils/invoice'
+import { isInvoiceOutstanding, isInvoiceOverdue as isOverdue } from '~/utils/invoice'
 
 definePageMeta({ layout: 'client', middleware: 'client-auth' })
 
@@ -82,14 +82,25 @@ await useAsyncData('client-invoices', () => store.fetchInvoices(true))
 
 const activeTab = ref('all')
 
+/**
+ * The filter tabs.
+ *
+ * The unpaid tab means "still owed", not "status is literally Unpaid". There is no Overdue
+ * tab, so counting the status alone left overdue invoices reachable only from All — hiding
+ * them from the customer who came here to see what they owe, and from the dashboard card
+ * that links straight to this tab.
+ */
 const tabs = computed(() => [
   { key: 'all',    label: t('client.invoices.tabAll'),    count: store.invoices.length },
-  { key: 'Unpaid', label: t('client.invoices.tabUnpaid'), count: store.invoices.filter(i => i.status === 'Unpaid').length },
+  { key: 'Unpaid', label: t('client.invoices.tabUnpaid'), count: store.invoices.filter(isInvoiceOutstanding).length },
   { key: 'Paid',   label: t('client.invoices.tabPaid'),   count: null }
 ])
 
+/** The rows the active tab shows. The unpaid tab spans both owing statuses; see {@link tabs}. */
 const filteredInvoices = computed(() => {
   if (activeTab.value === 'all') return store.invoices
+  if (activeTab.value === 'Unpaid') return store.invoices.filter(isInvoiceOutstanding)
+
   return store.invoices.filter(i => i.status === activeTab.value)
 })
 

--- a/client/pages/client/services/[id]/setup.vue
+++ b/client/pages/client/services/[id]/setup.vue
@@ -63,14 +63,17 @@
           </div>
 
           <div class="space-y-6">
-            <UiInput v-model="setupData.domain" label="Domain Name" placeholder="example.com" required :disabled="hasPurchasedDomain" />
+            <div>
+              <UiInput v-model="setupData.domain" label="Domain Name" placeholder="example.com" required :disabled="hasPurchasedDomain" />
+              <p v-if="domainError && !hasPurchasedDomain" class="text-xs text-red-400 mt-1">{{ domainError }}</p>
+            </div>
             <p v-if="!hasPurchasedDomain" class="text-xs text-gray-500">
               If you haven't bought a domain yet, enter the domain you plan to use. You'll need to point its nameservers to us later.
             </p>
             <p v-else class="text-xs text-cyan-400/70">
               This domain was purchased with your hosting plan.
             </p>
-            <UiButton full-width size="lg" :disabled="!setupData.domain" @click="nextStep">
+            <UiButton full-width size="lg" :disabled="!setupData.domain || !!domainError" @click="nextStep">
               Continue
               <ArrowRight :size="18" class="ml-2" />
             </UiButton>
@@ -105,11 +108,15 @@
               <p class="text-xs text-gray-500 mt-1.5">Lowercase letters and numbers only, no spaces or special characters.</p>
               <p v-if="usernameError" class="text-xs text-red-400 mt-1">{{ usernameError }}</p>
             </div>
-            <UiInput v-model="setupData.password" type="password" label="Control Panel Password" placeholder="••••••••" required />
+            <div>
+              <UiInput v-model="setupData.password" type="password" label="Control Panel Password" placeholder="••••••••" required />
+              <p class="text-xs text-gray-500 mt-1.5">At least 8 characters.</p>
+              <p v-if="passwordError" class="text-xs text-red-400 mt-1">{{ passwordError }}</p>
+            </div>
 
             <div class="flex gap-4 pt-2">
               <UiButton variant="subtle" full-width @click="prevStep">Back</UiButton>
-              <UiButton variant="primary" full-width :disabled="!setupData.username || !setupData.password || !!usernameError" @click="nextStep">
+              <UiButton variant="primary" full-width :disabled="!setupData.username || !setupData.password || !!usernameError || !!passwordError" @click="nextStep">
                 Confirm Details
               </UiButton>
             </div>
@@ -220,6 +227,34 @@ const usernameError = computed(() => {
   if (!/^[a-z][a-z0-9]*$/.test(u)) return 'Must start with a letter and contain only lowercase letters and numbers.'
   if (u.length < 3) return 'Must be at least 3 characters.'
   if (u.length > 8) return 'Must be 8 characters or less (server requirement).'
+  return ''
+})
+
+/**
+ * A domain the client typed but that is not a valid hostname, e.g. `notadomain` with no dot.
+ * Empty while the field is blank so the placeholder — not an error — greets an untouched form;
+ * the Continue button stays disabled on emptiness separately. Mirrors the server's
+ * `SetupServiceValidator` so provisioning is never reached with a malformed domain.
+ */
+const domainError = computed(() => {
+  const d = setupData.domain.trim()
+  if (!d) return ''
+  // Labels of a–z/0–9/hyphen (no leading/trailing hyphen), at least two of them, TLD ≥ 2 letters.
+  if (!/^(?=.{1,253}$)([a-z0-9](-*[a-z0-9])*\.)+[a-z]{2,}$/i.test(d)) {
+    return 'Enter a valid domain, e.g. example.com.'
+  }
+  return ''
+})
+
+/**
+ * A password the client typed that is too short for the hosting control panel. Empty while the
+ * field is blank. Eight characters is the same floor the server enforces, so a value that clears
+ * this check clears the backend one too.
+ */
+const passwordError = computed(() => {
+  const p = setupData.password
+  if (!p) return ''
+  if (p.length < 8) return 'Must be at least 8 characters.'
   return ''
 })
 

--- a/client/server/api/portal/client/announcements.get.ts
+++ b/client/server/api/portal/client/announcements.get.ts
@@ -1,11 +1,41 @@
 /**
  * GET /api/portal/client/announcements
- * Returns announcements from the C# backend.
+ *
+ * The signed-in announcements list, shaped for the page that renders it.
+ *
+ * This used to hand the backend's envelope straight through, and the page reads `date` while
+ * the backend sends `publishedAt` — so `item.date` was `undefined` on every row and
+ * `pages/announcements/index.vue` threw `Cannot read properties of undefined (reading 'match')`
+ * during SSR. **Anonymous visitors never saw it**: the upstream call needs a session, so the
+ * list came back empty and the loop that reads `date` never ran. Every signed-in customer got
+ * a 500. The sibling public proxy has always mapped the shape; this one now does the same.
+ *
+ * The old query also spelled its paging the WHMCS way, `limitstart`/`limitnum`, which no
+ * controller here has ever read — the backend pages with `page`/`pageSize`, so the parameters
+ * were silently ignored and the caller always got page one at the default size.
  */
-export default defineEventHandler(async (event) => {
+import type { Announcement, PublishedAnnouncementPage } from '~/types/announcement'
+import type { AnnouncementList } from '~/types/announcementlist'
+
+export default defineEventHandler(async (event): Promise<AnnouncementList> => {
   const query = getQuery(event)
-  return await internalApiCall<Record<string, unknown>>(
+  const page = Number(query.page ?? 1)
+  const pageSize = Number(query.pageSize ?? 50)
+
+  const result = await internalApiCall<PublishedAnnouncementPage>(
     event,
-    `/announcements?limitstart=${query.limitstart ?? 0}&limitnum=${query.limitnum ?? 50}`
+    `/announcements/published?page=${page}&pageSize=${pageSize}`
   )
+
+  const items: Announcement[] = (result?.items ?? []).map(a => ({
+    id: a.id,
+    title: a.title,
+    // The raw timestamp, not a formatted string. The page renders it through `formatDate` and
+    // derives its month tabs from it, both of which need the real date and the reader's
+    // locale — a server-side format would pick one language for everybody.
+    date: a.publishedAt ?? '',
+    body: a.content ?? '',
+  }))
+
+  return { items }
 })

--- a/client/server/api/portal/public/announcements.get.ts
+++ b/client/server/api/portal/public/announcements.get.ts
@@ -14,39 +14,7 @@
  * does not have to know about the backend's paging envelope.
  */
 
-/** One published announcement as the backend returns it. */
-interface PublishedAnnouncement {
-  /** Announcement primary key. */
-  id: number
-  /** Announcement headline. */
-  title: string
-  /** Body content. Not rendered by the dashboard card, kept for callers that show detail. */
-  content: string
-  /** ISO-8601 UTC timestamp the announcement was published. */
-  publishedAt: string
-}
-
-/** The backend's paging envelope around a page of announcements. */
-interface PublishedAnnouncementPage {
-  /** The announcements on this page, newest first. */
-  items: PublishedAnnouncement[]
-  /** Total published announcements across all pages. */
-  totalCount: number
-  /** The 1-based page number this envelope describes. */
-  page: number
-  /** How many items a full page holds. */
-  pageSize: number
-}
-
-/** The shape the dashboard card consumes. */
-interface AnnouncementSummary {
-  /** Announcement primary key, used as the list key. */
-  id: number
-  /** Announcement headline. */
-  title: string
-  /** Publication date, already formatted as `YYYY-MM-DD` for display. */
-  date: string
-}
+import type { AnnouncementSummary, PublishedAnnouncementPage } from '~/types/announcement'
 
 export default defineEventHandler(async (event): Promise<AnnouncementSummary[]> => {
   const result = await internalApiCall<PublishedAnnouncementPage>(

--- a/client/server/utils/api.ts
+++ b/client/server/utils/api.ts
@@ -133,9 +133,14 @@ function backendError(
 
   return createError({
     statusCode: status,
+    // Only the backend's own wording is forwarded. `err.message` is deliberately not a
+    // fallback: on a response with no JSON body — a bare 401 above all — $fetch composes its
+    // own message and embeds the address it called, so the browser was shown
+    // `[GET] "http://hostpanel-api:5148/api/me/services": 401 Unauthorized`. That publishes
+    // the internal host and port of a service the browser cannot reach, and tells the reader
+    // nothing. The endpoint below is the path this route already owns, not the upstream URL.
     statusMessage: data?.error
       ?? data?.message
-      ?? err?.message
       ?? `Backend API error for ${endpoint}`,
     data: { code: data?.code ?? null },
   })

--- a/client/stores/client.ts
+++ b/client/stores/client.ts
@@ -19,6 +19,7 @@
 import { defineStore } from 'pinia'
 import { useClientApi } from '~/composables/apis/useClientApi'
 import { PortalErrorCode, apiErrorCode, apiErrorMessage } from '~/utils/apiError'
+import { isInvoiceOutstanding } from '~/utils/invoice'
 import type { ClientUser } from '~/types/clientuser'
 import type { ClientService } from '~/types/clientservice'
 import type { ClientInvoice } from '~/types/clientinvoice'
@@ -37,6 +38,23 @@ import type { ClientTicket } from '~/types/clientticket'
  */
 function isClientProfileMissing(err: unknown): boolean {
   return apiErrorCode(err) === PortalErrorCode.ClientProfileNotFound
+}
+
+/**
+ * Whether the call failed because the session is over.
+ *
+ * A 401 does not reach here until the BFF has already tried to refresh the token and failed,
+ * so it means the session is genuinely gone. `apiFetch` has by then called the auth guard,
+ * which clears state and starts the trip to the login page — and the reader is on their way
+ * out, so a red "this section failed" beside it describes nothing they can act on. The status
+ * is read rather than a code because a bare 401 carries no body to put one in.
+ *
+ * @param err - Whatever the API composable threw.
+ * @returns True when the session expired rather than the request failing.
+ */
+function isSessionExpired(err: unknown): boolean {
+  const e = err as { statusCode?: number, status?: number, response?: { status?: number } }
+  return (e?.statusCode ?? e?.status ?? e?.response?.status) === 401
 }
 
 // ---------------------------------------------------------------------------
@@ -129,9 +147,14 @@ export const useClientStore = defineStore('client', {
       return (name || state.user.email || '?').charAt(0).toUpperCase()
     },
 
-    /** Count of unpaid invoices */
+    /**
+     * Count of invoices still awaiting payment.
+     *
+     * Overdue counts too — see {@link isInvoiceOutstanding} for why reading `Unpaid` alone
+     * put two different numbers for this on one screen.
+     */
     unpaidCount: (state): number =>
-      state.invoices.filter(i => i.status === 'Unpaid').length,
+      state.invoices.filter(isInvoiceOutstanding).length,
 
     /** Count of active services */
     activeServiceCount: (state): number =>
@@ -187,7 +210,7 @@ export const useClientStore = defineStore('client', {
           if (isClientProfileMissing(err)) {
             this.clientProfileMissing = true
             this.clientProfileMessage = apiErrorMessage(err)
-          } else {
+          } else if (!isSessionExpired(err)) {
             this.userError = apiErrorMessage(err)
           }
         } finally {
@@ -227,7 +250,7 @@ export const useClientStore = defineStore('client', {
         if (isClientProfileMissing(err)) {
           this.clientProfileMissing = true
           this.clientProfileMessage = apiErrorMessage(err)
-        } else {
+        } else if (!isSessionExpired(err)) {
           this.servicesError = apiErrorMessage(err)
         }
       } finally {
@@ -257,7 +280,7 @@ export const useClientStore = defineStore('client', {
         if (isClientProfileMissing(err)) {
           this.clientProfileMissing = true
           this.clientProfileMessage = apiErrorMessage(err)
-        } else {
+        } else if (!isSessionExpired(err)) {
           this.invoicesError = apiErrorMessage(err)
         }
       } finally {
@@ -287,7 +310,7 @@ export const useClientStore = defineStore('client', {
         if (isClientProfileMissing(err)) {
           this.clientProfileMissing = true
           this.clientProfileMessage = apiErrorMessage(err)
-        } else {
+        } else if (!isSessionExpired(err)) {
           this.domainsError = apiErrorMessage(err)
         }
       } finally {
@@ -317,7 +340,7 @@ export const useClientStore = defineStore('client', {
         if (isClientProfileMissing(err)) {
           this.clientProfileMissing = true
           this.clientProfileMessage = apiErrorMessage(err)
-        } else {
+        } else if (!isSessionExpired(err)) {
           this.ticketsError = apiErrorMessage(err)
         }
       } finally {

--- a/client/types/announcement.ts
+++ b/client/types/announcement.ts
@@ -1,3 +1,39 @@
+/**
+ * The announcement shapes, from what the backend sends to what each screen renders.
+ *
+ * Kept together because the three describe one journey and only make sense against each
+ * other: the backend's {@link PublishedAnnouncementPage} is what a portal proxy receives,
+ * {@link Announcement} is what the announcements pages read, and {@link AnnouncementSummary}
+ * is the narrower version the dashboard card takes. The differences between them are the
+ * point — splitting them across files is what let two proxies flatten the same envelope in
+ * two different ways, one of which forgot to rename `publishedAt` to `date` and 500ed the
+ * announcements page for every signed-in customer.
+ */
+
+/** One published announcement exactly as the backend returns it. */
+export interface PublishedAnnouncement {
+  /** Announcement primary key. */
+  id: number
+  /** Announcement headline. */
+  title: string
+  /** Body content, rendered with `v-html` by the detail page. */
+  content: string
+  /** ISO-8601 UTC timestamp the announcement was published. */
+  publishedAt: string
+}
+
+/** The backend's paging envelope around a page of announcements. */
+export interface PublishedAnnouncementPage {
+  /** The announcements on this page, newest first. */
+  items: PublishedAnnouncement[]
+  /** Total published announcements across all pages. */
+  totalCount: number
+  /** The 1-based page number this envelope describes. */
+  page: number
+  /** How many items a full page holds. */
+  pageSize: number
+}
+
 /** One published announcement, as `GET /api/portal/client/announcements` lists it. */
 export interface Announcement {
   /** Announcement id, used as the detail-page route parameter. */
@@ -10,4 +46,19 @@ export interface Announcement {
   excerpt?: string
   /** Full body as HTML — rendered with `v-html`, so the backend owns its sanitisation. */
   body?: string
+}
+
+/**
+ * The trimmed announcement the dashboard card renders.
+ *
+ * Narrower than {@link Announcement} on purpose: the card shows a headline and a date and has
+ * no room for a body, so the public proxy does not carry one.
+ */
+export interface AnnouncementSummary {
+  /** Announcement primary key, used as the list key. */
+  id: number
+  /** Announcement headline. */
+  title: string
+  /** Publication date, already formatted as `YYYY-MM-DD` for display. */
+  date: string
 }

--- a/client/utils/formatDate.ts
+++ b/client/utils/formatDate.ts
@@ -45,7 +45,14 @@
  */
 
 import { format, isValid, parseISO } from 'date-fns'
-import { enUS, hy, ru } from 'date-fns/locale'
+// Imported from their own paths rather than the `date-fns/locale` barrel. The barrel
+// re-exports 98 locales, and Vite pre-bundles the whole of it in development — three
+// named imports still cost all 98 modules there, which is enough to stall the first
+// page load on a slow machine. Production tree-shakes either way; this makes the two
+// agree, and states outright which three the portal actually ships.
+import { enUS } from 'date-fns/locale/en-US'
+import { hy } from 'date-fns/locale/hy'
+import { ru } from 'date-fns/locale/ru'
 import type { Locale } from 'date-fns'
 
 /**

--- a/client/utils/invoice.test.ts
+++ b/client/utils/invoice.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { balanceDue, isInvoiceOverdue, paymentsToDate } from './invoice'
+import { balanceDue, isInvoiceOutstanding, isInvoiceOverdue, paymentsToDate } from './invoice'
 import type { ClientInvoice, ClientInvoiceTransaction } from '~/types/clientinvoice'
 
 /** A transaction carrying only the fields these functions read. */
@@ -95,6 +95,37 @@ describe('balanceDue', () => {
   it('reports zero rather than NaN while the invoice is still loading', () => {
     expect(balanceDue(null)).toBe(0)
     expect(balanceDue(undefined)).toBe(0)
+  })
+})
+
+describe('isInvoiceOutstanding', () => {
+  it('counts an invoice the cron has already marked Overdue', () => {
+    // The case the dashboard was dropping. Overdue is what Unpaid becomes, not a separate
+    // kind of debt, and it is the more urgent half of what the customer owes.
+    expect(isInvoiceOutstanding(invoice({ status: 'Overdue' }))).toBe(true)
+  })
+
+  it('counts an invoice that is still Unpaid', () => {
+    expect(isInvoiceOutstanding(invoice({ status: 'Unpaid' }))).toBe(true)
+  })
+
+  it('agrees with the banner and the stat card, which is the bug it exists for', () => {
+    // Six Unpaid and six Overdue on one account rendered as "6" on the card and "12" in the
+    // banner beside it. One predicate over the same list is now the only answer available.
+    const invoices = [
+      ...Array.from({ length: 6 }, () => invoice({ status: 'Unpaid' })),
+      ...Array.from({ length: 6 }, () => invoice({ status: 'Overdue' })),
+      ...Array.from({ length: 3 }, () => invoice({ status: 'Paid' })),
+    ]
+
+    expect(invoices.filter(isInvoiceOutstanding)).toHaveLength(12)
+  })
+
+  it('does not count a status with nothing owing on it', () => {
+    // Draft was never issued, Cancelled was voided, Refunded was returned, Paid is settled.
+    for (const status of ['Paid', 'Draft', 'Cancelled', 'Refunded'] as const) {
+      expect(isInvoiceOutstanding(invoice({ status }))).toBe(false)
+    }
   })
 })
 

--- a/client/utils/invoice.ts
+++ b/client/utils/invoice.ts
@@ -47,6 +47,24 @@ export const balanceDue = (invoice: ClientInvoice | null | undefined): number =>
 }
 
 /**
+ * Whether an invoice still has money owing on it.
+ *
+ * `Unpaid` and `Overdue` both mean the customer owes this; `Overdue` is only what `Unpaid`
+ * becomes once `ProcessRenewalsCronHandler` has run over it. Reading one without the other
+ * under-counts, and it under-counts the more urgent half.
+ *
+ * This exists because the dashboard had two answers on one screen: its stat card counted
+ * `Unpaid` alone and its banner counted both, so the same account was shown "6 unpaid" beside
+ * "You have 12 unpaid invoices". The card was the wrong one — it is the element that says
+ * "Action required", and it was the element leaving out the overdue ones.
+ *
+ * @param invoice - The invoice to judge.
+ * @returns True when the invoice is awaiting payment.
+ */
+export const isInvoiceOutstanding = (invoice: Pick<ClientInvoice, 'status'>): boolean =>
+  invoice.status === 'Unpaid' || invoice.status === 'Overdue'
+
+/**
  * Whether an invoice should be shown to the customer as late.
  *
  * Two states count. The backend has its own `Overdue` status, but nothing flips an invoice into

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,15 @@ services:
     volumes:
       - ./client:/app
       - client_node_modules:/app/node_modules
+      # Nuxt's build directories, kept off the Windows bind mount for the same reason
+      # backend_bin and backend_obj are: they hold thousands of small files that the dev
+      # server rewrites on every compile, and each one crosses the host filesystem bridge.
+      # Measured in this container: 2000 small writes take 57.8s under ./client and 0.6s in
+      # a named volume — a hundredfold. That is what made a Nitro build take eight minutes
+      # and what starved the dev worker until it died with "IPC connection closed".
+      # Nothing outside the container reads them, so there is nothing to give up.
+      - client_nuxt:/app/.nuxt
+      - client_output:/app/.output
     environment:
       # hostpanel-api, the alias declared on the api service above — not the bare
       # "api" service name, which collides with innovayse-main's own "api" on the
@@ -351,6 +360,8 @@ volumes:
   pgdata:
   redisdata:
   client_node_modules:
+  client_nuxt:
+  client_output:
   admin_node_modules:
   backend_bin:
   backend_obj:


### PR DESCRIPTION
Bundles the work sitting on this branch:

- **announcements**: signed-in list 500'd on every row — the client proxy now maps the backend envelope to the page's shape (the sibling public proxy always did)
- **service setup**: domain/password validated in the wizard and by a new SetupServiceValidator on the shared command; dev-only Provisioning:UseFakeProvider lets "Build My Server" complete without a live CWP7 panel (defaults off)
- **orders**: a signed-in caller without a client row can place their first order; client row is created from the credential (provisioning deliberately not called)
- **invoices**: one isInvoiceOutstanding rule shared by dashboard and invoice pages, with tests
- **admin**: eighteen hand-rolled onBeforeRouteLeave confirm() guards replaced by one useUnsavedChangesGuard + ConfirmModal
- **dev perf**: Nuxt build dirs in named volumes (57.8s → 0.6s for 2k small writes), dev SSR off (IPC failure on Docker-for-Windows), date-fns locales off the barrel