### PR TITLE
fix(cwp7): call the route CWP7 actually serves for control-panel auto-login

### DIFF
--- a/backend/src/Innovayse.Providers.CWP7/Cwp7ApiClient.cs
+++ b/backend/src/Innovayse.Providers.CWP7/Cwp7ApiClient.cs
@@ -286,14 +286,24 @@ internal sealed class Cwp7ApiClient : ICwp7ApiClient
     /// <param name="apiKey">CWP7 API key for authentication.</param>
     /// <param name="username">Username to generate SSO link for.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The CWP7 API response containing the login URL.</returns>
+    /// <returns>
+    /// A response whose message is the control-panel URL on success, or CWP7's own refusal on
+    /// failure.
+    /// </returns>
+    /// <remarks>
+    /// <c>/v1/user_session</c>, not <c>/v1/autologin</c> — the latter is not a route CWP7 serves
+    /// and answered 404 for every client who ever pressed the button, which the page then showed
+    /// as the plain login form. This endpoint also breaks the shape every other call returns: its
+    /// <c>msj</c> is an object carrying one entry per matched account, so it is parsed with its
+    /// own model and flattened back into the shared response here.
+    /// </remarks>
     public async Task<Cwp7ApiResponse> GetAutoLoginUrlAsync(
         string host,
         string apiKey,
         string username,
         CancellationToken ct)
     {
-        var url = $"{host}/v1/autologin";
+        var url = $"{host}/v1/user_session";
         _logger.LogDebug("CWP7 API request: AutoLogin url={Url} user={User}", url, username);
 
         using var content = new FormUrlEncodedContent(
@@ -306,10 +316,52 @@ internal sealed class Cwp7ApiClient : ICwp7ApiClient
         using var response = await _http.PostAsync(url, content, ct);
         response.EnsureSuccessStatusCode();
 
-        var result = await ParseResponseAsync(response, ct);
+        var raw = await response.Content.ReadAsStringAsync(ct);
+        var session = TryParseUserSession(raw);
 
-        _logger.LogDebug("CWP7 AutoLogin response: status={Status}", result.Status);
-        return result;
+        // The account CWP7 was asked about, not merely the first it returned: a server that
+        // answered about somebody else must not hand this caller a session on their panel.
+        var detail = session?.Payload?.Details?
+            .Find(d => string.Equals(d.User, username, StringComparison.OrdinalIgnoreCase));
+
+        if (session is null
+            || !string.Equals(session.Status, "OK", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(detail?.Url))
+        {
+            var excerpt = raw.Length > MaxErrorBodyLength ? raw[..MaxErrorBodyLength] : raw;
+            _logger.LogWarning(
+                "CWP7 AutoLogin did not yield a session URL for {User}. Body starts: {Body}",
+                username,
+                excerpt);
+
+            return new Cwp7ApiResponse { Status = "Error", Msj = excerpt };
+        }
+
+        _logger.LogDebug("CWP7 AutoLogin response: session URL issued for {User}", username);
+        return new Cwp7ApiResponse { Status = "OK", Msj = detail.Url };
+    }
+
+    /// <summary>Deserializes a user-session body, returning null when it is not that shape.</summary>
+    /// <param name="raw">The raw response body.</param>
+    /// <returns>The parsed response, or <see langword="null"/> when it could not be read.</returns>
+    private Cwp7UserSessionResponse? TryParseUserSession(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<Cwp7UserSessionResponse>(raw);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            // An error from this endpoint arrives as `msj: "<sentence>"`, which is this model's
+            // object field holding a string. That is a refusal to report, not a fault to raise.
+            _logger.LogDebug(ex, "CWP7 user_session body was not a session payload.");
+            return null;
+        }
     }
 
     /// <summary>

--- a/backend/src/Innovayse.Providers.CWP7/Models/Cwp7UserSessionResponse.cs
+++ b/backend/src/Innovayse.Providers.CWP7/Models/Cwp7UserSessionResponse.cs
@@ -1,0 +1,55 @@
+namespace Innovayse.Providers.CWP7.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>Parsed response from the CWP7 <c>/v1/user_session</c> list action.</summary>
+/// <remarks>
+/// Its own model rather than <see cref="Cwp7ApiResponse"/>: this endpoint answers with an object
+/// under <c>msj</c> where every other one answers with a string, so deserializing it into the
+/// shared response throws and the call reads as a failure.
+/// </remarks>
+internal sealed class Cwp7UserSessionResponse
+{
+    /// <summary>Gets or initializes the result status — "OK" on success.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>Gets or initializes the payload carrying one entry per requested account.</summary>
+    [JsonPropertyName("msj")]
+    public Cwp7UserSessionPayload? Payload { get; init; }
+}
+
+/// <summary>The <c>msj</c> object of a CWP7 user-session response.</summary>
+internal sealed class Cwp7UserSessionPayload
+{
+    /// <summary>Gets or initializes how many accounts CWP7 matched.</summary>
+    [JsonPropertyName("accounts")]
+    public int Accounts { get; init; }
+
+    /// <summary>Gets or initializes one session entry per matched account.</summary>
+    [JsonPropertyName("details")]
+    public List<Cwp7UserSessionDetail>? Details { get; init; }
+}
+
+/// <summary>One account's freshly minted control-panel session.</summary>
+internal sealed class Cwp7UserSessionDetail
+{
+    /// <summary>Gets or initializes the account username the session belongs to.</summary>
+    [JsonPropertyName("user")]
+    public string User { get; init; } = string.Empty;
+
+    /// <summary>Gets or initializes the opaque session token.</summary>
+    /// <remarks>Carried inside <see cref="Url"/> already; kept because CWP7 sends it.</remarks>
+    [JsonPropertyName("token")]
+    public string Token { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or initializes the ready-to-open control-panel URL with the session token in it.
+    /// </summary>
+    /// <remarks>
+    /// Used as-is rather than rebuilt from <see cref="Token"/>: CWP7 composes it against its own
+    /// hostname and port, which need not be the address the API was called on.
+    /// </remarks>
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+}

--- a/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/Cwp7ApiClientTests.cs
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/Cwp7ApiClientTests.cs
@@ -91,4 +91,101 @@ public sealed class Cwp7ApiClientTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().Be("Account created.");
     }
+
+    /// <summary>
+    /// A real <c>/v1/user_session</c> body, captured from a live CWP7 server. Its <c>msj</c> is an
+    /// object, unlike every other endpoint's, which is the whole reason this call needs its own
+    /// parsing.
+    /// </summary>
+    private const string UserSessionJson =
+        """
+        {"status":"OK","msj":{"accounts":1,"details":[{"user":"rootsage",
+        "token":"eac44313.f2acd74d.3d04bdcb.1788432569",
+        "url":"https://host3.example.com:2083/rootsage/?user_session=eac44313.f2acd74d.3d04bdcb.1788432569"}]}}
+        """;
+
+    [Fact]
+    public async Task AutoLogin_ReturnsTheSessionUrl_WhenCwp7IssuesOneAsync()
+    {
+        var client = BuildClient(UserSessionJson, "application/json");
+
+        var result = await client.GetAutoLoginUrlAsync(
+            "https://cwp7.test:2304", "test-key", "rootsage", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Message.Should().Be(
+            "https://host3.example.com:2083/rootsage/?user_session=eac44313.f2acd74d.3d04bdcb.1788432569");
+    }
+
+    [Fact]
+    public async Task AutoLogin_Fails_WhenTheSessionIsForADifferentUserAsync()
+    {
+        // A session on somebody else's panel is worse than no session: the button would have
+        // opened it and signed this client in as them.
+        var client = BuildClient(UserSessionJson, "application/json");
+
+        var result = await client.GetAutoLoginUrlAsync(
+            "https://cwp7.test:2304", "test-key", "someoneelse", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AutoLogin_Fails_WhenCwp7RefusesWithAStringMessageAsync()
+    {
+        // The refusal shape: `msj` is a string here, where a success carries an object. Reading
+        // one into the other throws, and that must read as "no session", not as a crash.
+        var client = BuildClient(
+            """{"status":"Error","msj":"Unauthorized action abc123","format":"JSON"}""",
+            "application/json");
+
+        var result = await client.GetAutoLoginUrlAsync(
+            "https://cwp7.test:2304", "test-key", "rootsage", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Contain("Unauthorized action");
+    }
+
+    [Fact]
+    public async Task AutoLogin_Fails_WhenTheEndpointIsNotServedAsync()
+    {
+        // What every client actually got until this was fixed: the call named a route CWP7 does
+        // not serve, and its 404 page came back with HTTP 200.
+        var client = BuildClient(
+            "<html><head><title>404 Page Not Found</title></head><body></body></html>",
+            "text/html");
+
+        var result = await client.GetAutoLoginUrlAsync(
+            "https://cwp7.test:2304", "test-key", "rootsage", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AutoLogin_CallsTheUserSessionRouteAsync()
+    {
+        // The bug was the address, not the parsing, so the address is what this pins down.
+        var mockHandler = new Mock<HttpMessageHandler>();
+        HttpRequestMessage? sent = null;
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => sent = req)
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(UserSessionJson, Encoding.UTF8, "application/json"),
+            });
+
+        var client = new Cwp7ApiClient(
+            new HttpClient(mockHandler.Object), NullLogger<Cwp7ApiClient>.Instance);
+
+        await client.GetAutoLoginUrlAsync(
+            "https://cwp7.test:2304", "test-key", "rootsage", CancellationToken.None);
+
+        sent!.RequestUri!.AbsolutePath.Should().Be("/v1/user_session");
+    }
 }

--- a/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/Cwp7LiveAutoLoginTests.cs
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/Cwp7LiveAutoLoginTests.cs
@@ -1,0 +1,40 @@
+namespace Innovayse.Infrastructure.Tests.Integrations.Cwp7;
+
+using FluentAssertions;
+using Innovayse.Providers.CWP7;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Runs <see cref="Cwp7ApiClient.GetAutoLoginUrlAsync"/> against a real CWP7 server.
+/// </summary>
+/// <remarks>
+/// Skipped, and reported as skipped, unless a server is configured — see
+/// <see cref="LiveCwp7FactAttribute"/>. It exists because the unit tests prove the parsing against
+/// a body captured by hand, and would go on passing if the route were wrong again: only a real
+/// call can catch that. Run against a staging account, not a customer's.
+/// </remarks>
+public sealed class Cwp7LiveAutoLoginTests
+{
+    [LiveCwp7Fact]
+    public async Task AutoLogin_IssuesAUsableSessionUrl_AgainstTheRealServerAsync()
+    {
+        var host = Environment.GetEnvironmentVariable("CWP7_LIVE_HOST")!;
+        var key = Environment.GetEnvironmentVariable("CWP7_LIVE_KEY")!;
+        var user = Environment.GetEnvironmentVariable("CWP7_LIVE_USER")!;
+
+        // The panel's certificate is not the point of this test and is often self-signed.
+        using var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+
+        using var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+        var client = new Cwp7ApiClient(http, NullLogger<Cwp7ApiClient>.Instance);
+
+        var result = await client.GetAutoLoginUrlAsync(host, key, user, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(because: result.Message);
+        result.Message.Should().StartWith("https://").And.Contain("user_session=");
+    }
+}

--- a/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/LiveCwp7FactAttribute.cs
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Integrations/Cwp7/LiveCwp7FactAttribute.cs
@@ -1,0 +1,36 @@
+namespace Innovayse.Infrastructure.Tests.Integrations.Cwp7;
+
+using Xunit;
+
+/// <summary>
+/// Marks a test that talks to a real CWP7 server, and skips it unless one is configured.
+/// </summary>
+/// <remarks>
+/// The alternative — returning early from the test body — makes the runner report a pass, and a
+/// test that passes without asserting anything is worse than no test: it reads as coverage of the
+/// very call it did not make. Deciding here, at discovery, means the run says "Skipped" and says
+/// why.
+/// <para>
+/// Set <c>CWP7_LIVE_HOST</c> (scheme, host and API port), <c>CWP7_LIVE_KEY</c> and
+/// <c>CWP7_LIVE_USER</c> to run it.
+/// </para>
+/// </remarks>
+public sealed class LiveCwp7FactAttribute : FactAttribute
+{
+    /// <summary>The environment variables a live run needs, all of them.</summary>
+    private static readonly string[] RequiredVariables =
+        ["CWP7_LIVE_HOST", "CWP7_LIVE_KEY", "CWP7_LIVE_USER"];
+
+    /// <summary>Initialises the attribute, skipping the test when no server is configured.</summary>
+    public LiveCwp7FactAttribute()
+    {
+        var missing = Array.FindAll(
+            RequiredVariables,
+            name => string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name)));
+
+        if (missing.Length > 0)
+        {
+            Skip = $"No live CWP7 server configured; set {string.Join(", ", missing)} to run this.";
+        }
+    }
+}

--- a/client/pages/client/services/[id]/index.vue
+++ b/client/pages/client/services/[id]/index.vue
@@ -167,6 +167,8 @@
                 {{ $t('client.services.linkWebmail') }}
               </a>
             </nav>
+            <!-- Automatic sign-in failed; the panel's own login form was opened instead -->
+            <p v-if="ssoError" class="px-3 pb-3 text-xs text-red-500 dark:text-red-400">{{ ssoError }}</p>
           </div>
         </div>
 
@@ -831,14 +833,22 @@ const loadInvoices = async (): Promise<void> => {
 // ── cPanel SSO ────────────────────────────────────────────────────────────────
 const ssoLoading = ref(false)
 
+/** Why the last automatic control-panel sign-in failed. Empty means there is nothing to report. */
+const ssoError = ref('')
+
 async function loginToCpanel() {
   if (ssoLoading.value) return
   ssoLoading.value = true
+  ssoError.value = ''
   try {
     const { url } = await clientApi.fetchCpanelSsoUrl(serviceId)
     window.open(url, '_blank', 'noopener')
-  } catch {
-    // Fallback: open plain cPanel login page if SSO fails
+  } catch (err: unknown) {
+    // Say that the automatic sign-in failed, then still open the panel's own login form so the
+    // reader is not stranded. Falling back silently is how a server missing its API key looked
+    // exactly like a working button that happens to ask for a password: nobody could tell the
+    // difference, so nobody reported it. The API's own wording, through the shared reader.
+    ssoError.value = apiErrorMessage(err)
     const hostname = service.value?.serverhostname
     if (hostname) window.open(`https://${hostname}:2083`, '_blank', 'noopener')
   } finally {


### PR DESCRIPTION
`/v1/autologin` is not a CWP7 route — every client who pressed **Control Panel** got its 404 page, and the page opened the plain login form silently, so the button looked like it merely asks for a password.

- route corrected to `/v1/user_session`
- that endpoint returns `msj` as an object where every other returns a string, so it gets its own model
- the session is matched to the requested account: CWP7 answers `status: OK` with a usable token and `user: null` for an account that does not exist
- the page no longer swallows the failure; it says why, in the API's own words, and still opens the login form

Verified against a live CWP7 server: the call returns a session URL that signs in, and a deliberately wrong username makes the live test fail — which is how I know it is really running.