### PR TITLE
Fix the email-verification banner and the invented branding icon URLs

### DIFF
--- a/backend/src/Innovayse.API/Auth/AuthController.cs
+++ b/backend/src/Innovayse.API/Auth/AuthController.cs
@@ -139,12 +139,19 @@ public sealed class AuthController(
     /// Returns whether the current user's email is confirmed.
     /// With SSO, email confirmation is managed by the SSO service.
     /// </summary>
-    /// <returns>200 with <c>{ verified }</c>.</returns>
+    /// <returns>
+    /// 200 with <c>{ verified }</c>, where <c>verified</c> is <c>null</c> when the credential
+    /// carries no <c>email_verified</c> claim and so says nothing either way.
+    /// </returns>
     /// <remarks>
     /// The claim is read through <see cref="ICurrentRequestContext"/> rather than here. Two
     /// actions on this controller answered the same question, and each spelled the comparison
     /// out for itself — which is how one of them came to accept "true" and "True" and nothing
     /// else, silently reporting an issuer that writes "TRUE" as unverified.
+    /// <para>
+    /// Three-valued on purpose, and clients must keep it that way: prompting on anything other
+    /// than an explicit <c>false</c> nags every caller whose token simply lacks the claim.
+    /// </para>
     /// </remarks>
     [HttpGet("email-verified")]
     [Authorize]

--- a/backend/src/Innovayse.Application/Common/ICurrentRequestContext.cs
+++ b/backend/src/Innovayse.Application/Common/ICurrentRequestContext.cs
@@ -32,14 +32,23 @@ public interface ICurrentRequestContext
 
     /// <summary>
     /// Gets a value indicating whether the caller's email address has been confirmed, according
-    /// to the credential they presented.
+    /// to the credential they presented, or <see langword="null"/> when the credential does not
+    /// say either way.
     /// </summary>
     /// <remarks>
-    /// Read from the <c>email_verified</c> claim. A credential that does not carry the claim at
-    /// all answers <see langword="false"/>: an unverified address must never be mistaken for a
-    /// verified one because the issuer stayed silent about it.
+    /// Read from the <c>email_verified</c> claim, and deliberately three-valued. "The issuer says
+    /// this address is unconfirmed" and "the issuer never mentioned the address" are different
+    /// facts, and collapsing the second into <see langword="false"/> reports every caller whose
+    /// token simply lacks the claim as unverified.
+    /// <para>
+    /// That is not hypothetical: the claim rides on the OIDC <c>email</c> scope, so a client that
+    /// does not request that scope — or runs a build of the auth package predating the request —
+    /// receives no claim at all, and a confirmed account then reads as unconfirmed. Callers that
+    /// gate on this must treat <see langword="null"/> as "unknown" and decide for themselves,
+    /// rather than being handed a confident answer the credential never supported.
+    /// </para>
     /// </remarks>
-    bool IsEmailVerified { get; }
+    bool? IsEmailVerified { get; }
 
     /// <summary>Gets the remote IP address of the current request, or <see langword="null"/> if unavailable.</summary>
     string? IpAddress { get; }

--- a/backend/src/Innovayse.Infrastructure/Common/HttpCurrentRequestContext.cs
+++ b/backend/src/Innovayse.Infrastructure/Common/HttpCurrentRequestContext.cs
@@ -90,11 +90,23 @@ public sealed class HttpCurrentRequestContext(
         User?.FindFirstValue(ClaimTypes.Email) ?? User?.FindFirstValue("email");
 
     /// <inheritdoc/>
-    public bool IsEmailVerified =>
-        // Anything other than a literal "true" is not a confirmation, a missing claim
-        // included. The claim arrives as a JSON boolean rendered into a string, so the
-        // comparison is against the text and case-insensitive rather than parsed.
-        string.Equals(User?.FindFirstValue("email_verified"), "true", StringComparison.OrdinalIgnoreCase);
+    public bool? IsEmailVerified
+    {
+        get
+        {
+            // A claim that is not there is not an answer. It used to be read as "unverified",
+            // which made every session whose token lacks the claim look like an unconfirmed
+            // account — and the claim only travels when the OIDC `email` scope was granted, so
+            // that was the normal case for a client on an older auth package, not an edge one.
+            var claim = User?.FindFirstValue("email_verified");
+            if (string.IsNullOrEmpty(claim)) return null;
+
+            // Present, so it is an answer either way. The claim arrives as a JSON boolean
+            // rendered into a string, hence a case-insensitive text comparison rather than a
+            // parse: "true", "True" and "TRUE" are the same issuer saying the same thing.
+            return string.Equals(claim, "true", StringComparison.OrdinalIgnoreCase);
+        }
+    }
 
     /// <inheritdoc/>
     public string? IpAddress =>

--- a/backend/tests/Innovayse.Infrastructure.Tests/Common/HttpCurrentRequestContextTests.cs
+++ b/backend/tests/Innovayse.Infrastructure.Tests/Common/HttpCurrentRequestContextTests.cs
@@ -160,14 +160,15 @@ public sealed class HttpCurrentRequestContextTests
     }
 
     [Fact]
-    public void IsEmailVerified_WhenTheClaimIsAbsent_IsFalse()
+    public void IsEmailVerified_WhenTheClaimIsAbsent_IsNull()
     {
-        // An issuer that says nothing about the address has not confirmed it. Treating
-        // silence as confirmation is how an unverified account walks through a gate that
-        // exists to stop it.
+        // Silence is not a "no". The claim only travels when the OIDC `email` scope was
+        // granted, so a client that does not ask for that scope gets no claim at all — and
+        // reading that as "unverified" reported confirmed accounts as unconfirmed. Callers
+        // get null and decide what to do about not knowing.
         var (context, _) = Build(new Claim("sub", Subject));
 
-        context.IsEmailVerified.Should().BeFalse();
+        context.IsEmailVerified.Should().BeNull();
     }
 
     [Fact]

--- a/client/server/routes/site.webmanifest.get.ts
+++ b/client/server/routes/site.webmanifest.get.ts
@@ -43,11 +43,19 @@ export default defineEventHandler(async (event) => {
 
   const favicon = (settings['portal.favicon'] ?? '').trim()
 
-  // An upload has its generated set in its own directory; anything else -- nothing set, or a
-  // URL the operator pasted -- falls back to the committed set in `public/`. Both are real
-  // files, so the manifest never promises an icon that 404s. Sibling names are only guessed
-  // inside an upload directory, where this process wrote them and knows they are there.
-  const icons = favicon.startsWith(UPLOADS_PREFIX)
+  // An upload has its generated set in its own directory; anything else -- nothing set, a URL
+  // the operator pasted, or an upload from before the generator existed -- falls back to the
+  // committed set in `public/`. Both are real files, so the manifest never promises an icon
+  // that 404s. Sibling names are only guessed inside a generated directory, where this process
+  // wrote them and knows they are there.
+  //
+  // The depth check is the whole point: a pre-generator upload sits flat in the uploads root
+  // and matches the prefix while having no siblings at all. Testing the prefix by itself put
+  // four dead icon URLs into the production manifest.
+  const isGeneratedSet = favicon.startsWith(UPLOADS_PREFIX)
+    && favicon.slice(UPLOADS_PREFIX.length).split('/').length >= 3
+
+  const icons = isGeneratedSet
     ? MANIFEST_ICON_SIZES.map(icon => ({
         src: `${favicon.slice(0, favicon.lastIndexOf('/') + 1)}${icon.file}`,
         sizes: icon.sizes,

--- a/client/utils/brandingIcons.ts
+++ b/client/utils/brandingIcons.ts
@@ -71,13 +71,23 @@ const BUILT_IN_ICONS: BrandingIcon[] = [
 ]
 
 /**
- * Whether a favicon URL points at a file this deployment generated the set for.
+ * Whether a favicon URL points at a file this deployment generated the whole set for.
+ *
+ * The prefix alone is not enough. Uploads made before the icon generator existed sit flat in
+ * the uploads root (`/uploads/branding/favicon-<guid>.png`), and the generated ones sit one
+ * directory down (`/uploads/branding/<kind>/<id>/<file>`). Only the second kind has siblings,
+ * so accepting the first put five invented links into the page head that every browser then
+ * fetched and got a 404 for — observed in production.
  *
  * @param url The stored `portal.favicon` value.
- * @returns True when the URL is one of our own uploads.
+ * @returns True when the URL names a file inside a generated icon directory.
  */
-export const isUploadedBranding = (url: string): boolean =>
-  url.startsWith(UPLOADS_PREFIX)
+export const isUploadedBranding = (url: string): boolean => {
+  if (!url.startsWith(UPLOADS_PREFIX)) return false
+
+  // kind/id/file is three segments; a legacy flat upload is one.
+  return url.slice(UPLOADS_PREFIX.length).split('/').length >= 3
+}
 
 /**
  * Builds the icon links for a stored favicon URL.


### PR DESCRIPTION
Two production-visible defects.

**A confirmed admin was shown the "Verify Your Email" overlay.** `email_verified` travels only when the OIDC `email` scope was granted, and hostpanel pins `Innovayse.Auth` 1.0.0, whose login flow does not request it — so the claim never arrives. Reading its absence as `false` reported a super admin whose address SSO records as confirmed as unconfirmed. `IsEmailVerified` becomes `bool?`; the admin panel was already written for three values (`boolean | null` in the store, `=== false` in the banner). An explicit `false` still reports unverified.

**Dead icon URLs.** `isUploadedBranding()` and the manifest route tested the uploads prefix alone, so a pre-generator upload — flat in the uploads root, no siblings — produced five invented links in the page head and four in the manifest, all 404 in production. Both now require the generated `kind/id/file` depth.

Verified: full solution build 0 warnings / 0 errors, `Innovayse.Infrastructure.Tests` 53 passed / 1 skipped / 0 failed.

Not addressed here: bumping `Innovayse.Auth` past 1.0.0 so the `email` scope is actually requested — that is the root cause of the missing claim and it re-plumbs production auth, so it wants its own change. The overlay copy also still claims an enforcement that does not exist (`AdminOnly` checks role only).