### PR TITLE
release: unify the mail contract and fix the SMTP username binding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,117 +1,92 @@
-# PostgreSQL
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=innovayse_dev
+# ── General ──────────────────────────────────────────────────────────────────
+# Development also runs DevDataSeeder, so a deployed host left on it re-seeds test
+# data on every restart. Migrations run in every environment except Testing.
+ASPNETCORE_ENVIRONMENT=Development
 
-# RabbitMQ
-RABBITMQ_USER=guest
-RABBITMQ_PASSWORD=guest
-
-# JWT
-JWT_SECRET=change-this-to-a-32-char-min-secret-key-here
-JWT_ISSUER=innovayse-api
-JWT_AUDIENCE=innovayse-clients
-
-# SMTP (dev: mailhog on port 1025, prod: real SMTP)
-# Read by hostpanel-api only. The client container held a second copy of these and sent
-# the contact form's mail itself; it no longer does, and nothing in client/ reads them.
-SMTP_HOST=mailhog
-SMTP_PORT=1025
-SMTP_USER=
-SMTP_PASSWORD=
-# Who the mail comes from. Defaults to noreply@<your DOMAIN> so a fresh install does not
-# send as somebody else's address.
-SMTP_FROM_EMAIL=
-SMTP_FROM_NAME=
-# Leave empty. The port decides: 465 is implicit TLS, 587 is STARTTLS, anything else is a
-# plain local relay. Set this to true only for a relay on a non-standard port that still
-# expects TLS from the first byte.
-SMTP_USE_SSL=
-
-# Where the public contact form delivers, as Notifications__ContactEmail on the API.
-# Unset, the form answers 503 CONTACT_NOT_CONFIGURED instead of silently dropping messages.
-EMAIL_TO=contact@yourdomain.com
-
-# Telegram bot the contact form's enquiries are also posted to (optional).
-# Read by hostpanel-api only, as Telegram__BotToken / Telegram__ChatId. The client container
-# held these and posted to Telegram itself; it no longer does, and nothing in client/ reads them.
-# Both or neither: half a bot posts nowhere while looking configured, so the API refuses to
-# start on it. With neither set, enquiries are delivered by email alone and the API says so in
-# its log; a Telegram outage is logged too and never fails a message the relay accepted.
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
-
-NUXT_PUBLIC_BASE_URL=https://host.innovayse.com
+# `sso` uses Innovayse SSO and registers no local credentials. `local` is the
+# standalone path: hostpanel authenticates its own users from its own table.
+AUTH_MODE=sso
 
 # Nginx (prod only)
 DOMAIN=yourdomain.com
 ADMIN_DOMAIN=admin.yourdomain.com
 
-# ── Authentication mode ──────────────────────────────────────────────────────
-# `sso` uses Innovayse SSO and registers no local credentials at all. `local` is
-# the standalone open-source path: hostpanel authenticates its own users from its
-# own table. Only this product implements both.
-AUTH_MODE=sso
+NUXT_PUBLIC_BASE_URL=https://host.innovayse.com
+ADMIN_BASE_URL_PATH=/
+
+# ── PostgreSQL ───────────────────────────────────────────────────────────────
+POSTGRES_HOST=hostpanel-db
+POSTGRES_PORT=5432
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=innovayse_dev
+
+# ── RabbitMQ ─────────────────────────────────────────────────────────────────
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+
+# ── Redis ────────────────────────────────────────────────────────────────────
+# Cookie sessions and the data protection key ring. Unused under AUTH_MODE=local.
+REDIS_CONNECTION=redis:6379
+
+# ── Mail ─────────────────────────────────────────────────────────────────────
+# Read by hostpanel-api only; nothing in client/ reads them.
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+# tls (STARTTLS, usually 587), ssl (implicit TLS, usually 465) or none (a local
+# catcher). Required: unset or misspelt, the API refuses to start and names this key
+# rather than come up and send the relay's password in the clear.
+SMTP_ENCRYPTION=none
+# Reaches the API as Smtp__From__Address / Smtp__From__Name. A real deployment sets
+# its own -- a fresh install must not send as somebody else's address.
+SMTP_FROM=noreply@innovayse.com
+SMTP_FROM_NAME=Innovayse
+
+# Where the public contact form delivers. Unset, the form answers 503
+# CONTACT_NOT_CONFIGURED instead of silently dropping messages.
+EMAIL_TO=contact@yourdomain.com
+
+# ── Telegram (optional) ──────────────────────────────────────────────────────
+# The contact form also posts enquiries here. Both or neither: half a bot posts
+# nowhere while looking configured, so the API refuses to start on it.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
 
 # ── SSO client ───────────────────────────────────────────────────────────────
-# One now, not two. The admin panel had its own public client because the SPA ran
-# the OIDC flow itself and kept both tokens in localStorage; the API performs the
-# exchange for it now, under this same client, so ADMIN_SSO_CLIENT_ID is gone.
-#
-# The admin's callback is <origin that served the SPA>/api/auth/callback. Where
-# that is a hostname of its own rather than a path on the portal's, register it in
-# the SSO under Apps:Hostpanel:ExtraRedirectUris.
+# The admin's callback is <origin that served the SPA>/api/auth/callback. Where that
+# is a hostname of its own, register it under Apps:Hostpanel:ExtraRedirectUris.
 SSO_URL=http://sso-api:8080
-# Where the BROWSER is sent to sign in. Always the SSO's own hostname — the one
-# that serves the sign-in pages and proxies /connect — and the same host as the
-# issuer stamped into every token:
+# Where the BROWSER is sent to sign in -- the SSO's own hostname, and the same host
+# as the issuer stamped into every token. Not the SSO's API hostname.
 #
 #   local development   https://sso.local
 #   staging             https://stage-sso.innovayse.com
 #   production          https://sso.innovayse.com
-#
-# Not the SSO's API hostname. Both reach /connect/authorize, but an unauthenticated
-# visitor is redirected from there to the frontend's /login anyway, and pointing at
-# the API host means the browser crosses two SSO hostnames to sign in once.
 SSO_PUBLIC_URL=https://sso.innovayse.com
 SSO_CLIENT_ID=hostpanel
 SSO_CLIENT_SECRET=changeme
 SSO_CALLBACK_URL=https://host.innovayse.com/api/portal/auth/sso/callback
 
-# Machine credential this product reads its people out of the SSO with, not a
-# user's. Under AUTH_MODE=sso every account lookup — the client list, the admin
-# user screens, resolving who owns a service — goes to the SSO's /api/service/*
-# endpoints, and they answer 401 to a caller without this.
-#
-# Must equal innovayse-sso's SERVICE_AUTH_API_KEY. Generate with:
-#   openssl rand -base64 24
-#
-# Left empty under AUTH_MODE=local, where nothing reads it: a standalone box owns
-# its own users and never asks anyone else about them.
+# Machine credential this product reads its people out of the SSO with. Must equal
+# innovayse-sso's SERVICE_AUTH_API_KEY; generate with: openssl rand -base64 24
+# Unused under AUTH_MODE=local.
 SSO_SERVICE_KEY=changeme
 
-# Client secret the API exchanges the admin SPA's authorization code with, server
-# to server; it never reaches a browser. Read only when AUTH_MODE=sso, and under
-# that mode the API refuses to start without it rather than come up and hand every
-# visitor an anonymous session. Leave it as-is on a local-mode box: nothing reads
-# it there.
+# Secret the API exchanges the admin SPA's authorization code with, server to server;
+# it never reaches a browser. Under AUTH_MODE=sso the API refuses to start without it.
 CLIENT_HOSTPANEL_SECRET=changeme
 
-# Where the cookie sessions and the data protection key ring are kept. `redis` is
-# the service in docker-compose.yml; inside the Innovayse workspace the platform
-# overlay parks that one and the shared instance answers to the same name, so this
-# value is right in both cases. Unused under AUTH_MODE=local.
-REDIS_CONNECTION=redis:6379
-
-ADMIN_BASE_URL_PATH=/
+# Shared with innovayse-main, which calls it to sign a user out of every product.
+HOSTPANEL_BACKCHANNEL_LOGOUT_KEY=dev-hostpanel-backchannel-key
 
 # ── Links to other products ──────────────────────────────────────────────────
 # Browser-facing addresses. A product left unset is hidden rather than broken.
-# The portal. Named MAIN_APP_URL because it is the same value the SSO, docs,
-# calendar, sheets and email all need; docker-compose passes it on to the client as
-# NUXT_PUBLIC_MAIN_URL, which is the name Nitro needs to override the frozen
-# runtimeConfig default. SSO_CALLBACK_URL above is unrelated — that is this panel's
-# own route on its own hostname.
+# MAIN_APP_URL is the portal; docker-compose passes it to the client as
+# NUXT_PUBLIC_MAIN_URL, the name Nitro needs to override its frozen default.
 MAIN_APP_URL=https://innovayse.com
 NUXT_PUBLIC_SHEETS_URL=https://sheets.innovayse.com
 NUXT_PUBLIC_EMAIL_URL=https://inbox.innovayse.com
@@ -119,81 +94,41 @@ NUXT_PUBLIC_ERP_URL=http://erp.local
 NUXT_PUBLIC_TASKS_URL=http://tasks.local
 NUXT_PUBLIC_DRIVE_URL=https://drive.innovayse.com
 
-# Shared with innovayse-main, which calls it to sign a user out of every product.
-HOSTPANEL_BACKCHANNEL_LOGOUT_KEY=dev-hostpanel-backchannel-key
-
 # ── Public site ──────────────────────────────────────────────────────────────
 # Which template renders the storefront. Unknown values fall back to `aurora`.
 NUXT_PUBLIC_PORTAL_TEMPLATE=aurora
 
-# Whether the site header offers the apps launcher. Off unless this deployment
-# actually runs the sibling products above: every one of those URLs has a
-# *.local development default, so "has a value" cannot decide it on its own, and
-# a launcher switched on without them would offer links into nothing.
-#
-# An operator can also set `portal.apps.enabled` from the admin panel, which
-# wins over this. Accepts true/1/yes/on.
+# Whether the header offers the apps launcher. Off unless this deployment actually
+# runs the products above -- each has a *.local default, so "has a value" cannot
+# decide it. `portal.apps.enabled` in the admin panel wins over this.
+# Accepts true/1/yes/on.
 NUXT_PUBLIC_PORTAL_APPS_ENABLED=false
 
-# ── WHMCS handoff ────────────────────────────────────────────────────────────
-# Address of a WHMCS install this panel hands visitors off to, for the few things it
-# does not do itself: the dashboard's announcements and domain-transfer links, adding
-# a card on the saved-methods page, and paying an invoice with a new card.
-#
-# An address ONLY. The WHMCS API identifier/secret/access-key trio used to sit beside
-# it and is gone on purpose: the WHMCS API is called by hostpanel-api, never by the
-# browser-facing client container, so keeping the credentials there gave a public app a
-# secret to leak and no reason to hold one.
-#
-# Optional. Left empty every link above is HIDDEN rather than rendered broken, which is
-# the right shape for a deployment that runs no WHMCS -- but it has to be a choice. Until
-# now no compose file passed this at all, so config.public.whmcsUrl was empty on every
-# containerised tier whatever the operator set.
-#
-# No trailing slash. docker-compose.yml passes this straight through for the dev target,
-# which re-evaluates nuxt.config.ts and strips one; the prod overlays pass it as
-# NUXT_PUBLIC_WHMCS_URL, the only name a built Nitro image reads, and Nitro substitutes
-# that verbatim -- past the strip. One variable either way; the two spellings are the
-# same value.
+# ── WHMCS handoff (optional) ─────────────────────────────────────────────────
+# An address ONLY, no trailing slash. The API identifier/secret/access-key trio is
+# gone on purpose: the WHMCS API is called by hostpanel-api, never by the browser.
+# Left empty, every handoff link is hidden rather than rendered broken.
 WHMCS_URL=
 
 # ── Payments ─────────────────────────────────────────────────────────────────
-# Stripe's publishable key, which is public by design — it identifies the account
-# to Stripe.js in the browser and cannot authorise anything on its own. The secret
-# key is not here and does not belong here; billing runs through WHMCS.
-#
-# docker-compose.prod.yml and docker-compose.server.yml both read this with an empty
-# default, so leaving it blank only means the card form has nothing to initialise.
-# docker-compose.yml carries a pk_test_ literal for local work instead of reading this.
-#
-# prod.yml passes it as NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, which is the only name a
-# built Nitro image reads. Until it did, only the standalone-VPS overlay carried the key
-# and neither CI deploy chain loads that one -- so stage and prod initialised no Stripe
-# at all.
+# Stripe's publishable key, public by design -- it identifies the account to
+# Stripe.js and authorises nothing. The secret key does not belong here; billing
+# runs through WHMCS. Empty means the card form has nothing to initialise.
 STRIPE_PUBLISHABLE_KEY=
 
-# ── Encryption ───────────────────────────────────────────────────────────────
-# Required outside Development. Without it the EF configurations silently drop
-# their encrypted-column converters and server passwords, API tokens and access
-# hashes are written to the database in plain text -- on a deployment that looks
-# healthy and logs nothing. The API now refuses to start instead.
-#
-# Must decode to exactly 32 bytes. Generate one with: openssl rand -base64 32
+# ── Secrets ──────────────────────────────────────────────────────────────────
+JWT_SECRET=change-this-to-a-32-char-min-secret-key-here
+JWT_ISSUER=innovayse-api
+JWT_AUDIENCE=innovayse-clients
+
+# Required outside Development. Without it the EF configurations silently drop their
+# encrypted-column converters and server passwords, API tokens and access hashes are
+# written in plain text. Must decode to exactly 32 bytes:
+#   openssl rand -base64 32
 ENCRYPTION_KEY=ZGV2LW9ubHkta2V5LW5vdC1mb3ItcHJvZHVjdGlvbiE=
 
-# Credential for the private NuGet registry that publishes Innovayse.Auth. Needed
-# only where this API restores at container start (a host that builds in place)
-# rather than consuming a prebuilt image. Use a deploy token scoped to
-# read_package_registry — never a personal access token.
+# Private NuGet registry that publishes Innovayse.Auth. Needed only where this API
+# restores at container start. Use a deploy token scoped to read_package_registry,
+# never a personal access token.
 #   NUGET_INNOVAYSE_CREDENTIALS=Username=<deploy-token-user>;Password=<token>
 NUGET_INNOVAYSE_CREDENTIALS=
-
-# ── Runtime ──────────────────────────────────────────────────────────────────
-# Development on a laptop, Staging on the stage host, Production on the prod one.
-#
-# This one is not cosmetic. Development serves developer exception pages, and it is
-# what runs DevDataSeeder — so a deployed host left on Development re-seeded test
-# data into its database on every restart. Migrations used to be tied to the same
-# flag and are not any more: they run in every environment except Testing, which is
-# what makes naming this honestly safe.
-ASPNETCORE_ENVIRONMENT=Development

--- a/README.md
+++ b/README.md
@@ -93,14 +93,23 @@ Copy `.env.example` to `.env` and fill in the values:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `POSTGRES_HOST` | PostgreSQL host the API connects to | `hostpanel-db` |
+| `POSTGRES_PORT` | PostgreSQL port | `5432` |
 | `POSTGRES_USER` | PostgreSQL username | `postgres` |
 | `POSTGRES_PASSWORD` | PostgreSQL password | `postgres` |
 | `POSTGRES_DB` | Database name | `innovayse_dev` |
 | `JWT_SECRET` | JWT signing key (min 32 chars) | **change this** |
+| `RABBITMQ_HOST` | Broker host the API connects to | `rabbitmq` |
+| `RABBITMQ_PORT` | Broker AMQP port | `5672` |
 | `RABBITMQ_USER` | RabbitMQ username | `guest` |
 | `RABBITMQ_PASSWORD` | RabbitMQ password | `guest` |
 | `SMTP_HOST` | SMTP server host | `mailhog` |
 | `SMTP_PORT` | SMTP server port | `1025` |
+| `SMTP_USERNAME` | SMTP username; empty for a local catcher, which refuses `AUTH` | *(empty)* |
+| `SMTP_PASSWORD` | SMTP password | *(empty)* |
+| `SMTP_ENCRYPTION` | `tls` (STARTTLS, 587), `ssl` (implicit TLS, 465) or `none`. **Required** — the API refuses to start without it rather than guess from the port | `none` |
+| `SMTP_FROM` | Sender address on outgoing mail | `noreply@innovayse.com` |
+| `SMTP_FROM_NAME` | Sender display name | `Innovayse` |
 
 For the client portal, copy `client/.env.example` to `client/.env`.
 

--- a/backend/src/Innovayse.API/appsettings.Testing.json
+++ b/backend/src/Innovayse.API/appsettings.Testing.json
@@ -26,10 +26,19 @@
     "",
     "The key is a throwaway. It encrypts nothing that outlives the test container,",
     "and it is a real key rather than an exemption so the tests exercise the same",
-    "encrypting EF converters production uses."
+    "encrypting EF converters production uses.",
+    "",
+    "Smtp:Encryption is here because AddInfrastructure validates it on start and the",
+    "base appsettings.json deliberately carries no value for it -- an absent key is a",
+    "refusal to boot, which is the point of it, and would otherwise take every test in",
+    "this suite down with the host. 'none' is what a test host that sends no mail at",
+    "all should say: stated, like every other tier has to state it."
   ],
   "Auth": {
     "Mode": "local"
+  },
+  "Smtp": {
+    "Encryption": "none"
   },
   "EncryptionKey": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
 }

--- a/backend/src/Innovayse.API/appsettings.json
+++ b/backend/src/Innovayse.API/appsettings.json
@@ -118,19 +118,28 @@
     "DefaultCurrency": "AMD"
   },
   "//Smtp": [
-    "Host and Port come from the deployment. They named localhost:1025 -- a plain,",
-    "unencrypted local relay -- so a production deployment that forgot to override",
-    "them delivered every password reset and invitation nowhere, and said nothing.",
+    "Host, Port and Encryption come from the deployment. Host and Port named",
+    "localhost:1025 -- a plain, unencrypted local relay -- so a production deployment",
+    "that forgot to override them delivered every password reset and invitation",
+    "nowhere, and said nothing.",
     "",
-    "FromEmail and FromName were 'noreply@yourdomain.com' and 'YourBrand', template",
-    "values that would have gone out on real mail."
+    "Encryption is absent on purpose, and must stay absent. It replaced a UseSsl flag",
+    "this file set to false while production actually ran on 465, and a value here",
+    "would be that same disagreement again: a tier that never sets SMTP_ENCRYPTION",
+    "would silently inherit whatever this file said and send the relay password in the",
+    "clear. With nothing here, an unset key stops the API at startup and names itself.",
+    "",
+    "From.Address and From.Name were 'noreply@yourdomain.com' and 'YourBrand',",
+    "template values that would have gone out on real mail. What is left here is a",
+    "working local sender that every deployed overlay overrides."
   ],
   "Smtp": {
     "Username": "",
     "Password": "",
-    "FromEmail": "noreply@innovayse.com",
-    "FromName": "Innovayse",
-    "UseSsl": false
+    "From": {
+      "Address": "noreply@innovayse.com",
+      "Name": "Innovayse"
+    }
   },
   "//EncryptionKey": [
     "Supplied by the deployment; the API refuses to start outside Development without",

--- a/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
@@ -466,14 +466,28 @@ public static class DependencyInjection
         services.AddScoped<Innovayse.Application.Reports.Interfaces.IDiskUsageService, Innovayse.Infrastructure.Reports.DiskUsageService>();
 
         // Notifications
-        // Bound, but deliberately not validated on start, unlike the integration options above.
-        // Every deployed tier fills the Smtp section from a different overlay and none of them
-        // fills all of it -- docker-compose.prod.yml supplies only Host, Port and Password --
-        // and no tier configures the Notifications section at all. Refusing a partly filled
-        // section here would refuse to start the production API, so a missing value surfaces
-        // where the mail is actually sent instead. See each options class's remarks.
+        // The Smtp section as a whole is still deliberately not checked for completeness here,
+        // unlike the integration options above. Every deployed tier fills it from a different
+        // overlay and none of them fills all of it, and no tier configures the Notifications
+        // section at all. Refusing a partly filled section would refuse to start the production
+        // API, so a missing host or port surfaces where the mail is actually sent instead.
+        //
+        // Encryption is the one value that cannot wait for that, which is why this registration
+        // now validates at all. It replaced a UseSsl bool that was allowed to be absent only
+        // because the port silently decided in its place; with the guess gone, an unset enum
+        // would take its zero value -- None -- and hand the relay's password to the network in
+        // the clear on a host that looks healthy. Absent is refused here, by name. A value that
+        // is not tls/ssl/none never reaches this check: the binder fails on it first, and
+        // ValidateOnStart is what drags that failure forward from the first mail send to boot.
         services.AddOptions<SmtpOptions>()
-            .Bind(configuration.GetSection(SmtpOptions.SectionName));
+            .Bind(configuration.GetSection(SmtpOptions.SectionName))
+            .Validate(
+                o => o.HasEncryption,
+                $"{SmtpOptions.SectionName}:{nameof(SmtpOptions.Encryption)} is required and must "
+                    + "be one of tls (STARTTLS, conventionally port 587), ssl (implicit TLS, "
+                    + "conventionally port 465) or none (a local mail catcher). Set "
+                    + "SMTP_ENCRYPTION in this deployment's .env.")
+            .ValidateOnStart();
         services.AddOptions<NotificationOptions>()
             .Bind(configuration.GetSection(NotificationOptions.SectionName));
         services.AddScoped<IEmailSender, MailKitEmailSender>();

--- a/backend/src/Innovayse.Infrastructure/Notifications/MailKitEmailSender.cs
+++ b/backend/src/Innovayse.Infrastructure/Notifications/MailKitEmailSender.cs
@@ -26,7 +26,7 @@ public sealed class MailKitEmailSender(IOptions<SmtpOptions> options) : IEmailSe
     public async Task SendAsync(EmailMessage message, CancellationToken ct)
     {
         var mime = new MimeMessage();
-        mime.From.Add(new MailboxAddress(_settings.FromName, _settings.FromEmail));
+        mime.From.Add(new MailboxAddress(_settings.From.Name, _settings.From.Address));
         mime.To.Add(MailboxAddress.Parse(message.To));
         mime.Subject = message.Subject;
         var textPart = new TextPart(message.IsHtml ? "html" : "plain") { Text = message.Body };
@@ -36,15 +36,31 @@ public sealed class MailKitEmailSender(IOptions<SmtpOptions> options) : IEmailSe
         using var client = new SmtpClient();
 
         // SecureSocketOptions rather than the bool overload: that overload maps false to
-        // "no TLS at all", which is wrong for 465. 465 is implicit TLS — the session is
-        // encrypted before the first command — while 587 negotiates it with STARTTLS and a
-        // catcher on 1025 speaks neither. Port decides, with UseSsl left as an override for
-        // a relay on a non-standard port.
-        var security = _settings.UseSsl || _settings.Port == 465
-            ? SecureSocketOptions.SslOnConnect
-            : _settings.Port == 587
-                ? SecureSocketOptions.StartTls
-                : SecureSocketOptions.None;
+        // "no TLS at all", which cannot express the difference between the three wire
+        // protocols here. 465 is implicit TLS — the session is encrypted before the first
+        // command — while 587 negotiates it with STARTTLS after a plaintext greeting, and a
+        // catcher on 1025 speaks neither.
+        //
+        // The deployment states which; the port no longer decides. It used to, with UseSsl
+        // as an override, and that was one value short of the question: `false` could not be
+        // told apart from "nobody set this", so a relay on a non-standard port that wants TLS
+        // from the first byte looked exactly like a local catcher — and guessing that one
+        // wrong puts the relay's password on the wire in the clear. The override existed
+        // precisely because the guess was wrong somewhere; SmtpEncryption.Ssl is that
+        // override, now spelled as the answer rather than as a correction to one.
+        //
+        // Encryption is checked at startup (see AddInfrastructure), so null cannot reach here
+        // from a running host. It still refuses rather than falling through to None: an
+        // instance built without configuration must not quietly become the unencrypted case.
+        var security = _settings.Encryption switch
+        {
+            SmtpEncryption.Ssl => SecureSocketOptions.SslOnConnect,
+            SmtpEncryption.Tls => SecureSocketOptions.StartTls,
+            SmtpEncryption.None => SecureSocketOptions.None,
+            _ => throw new InvalidOperationException(
+                $"{SmtpOptions.SectionName}:{nameof(SmtpOptions.Encryption)} is not set. It must "
+                    + "be one of tls (STARTTLS), ssl (implicit TLS) or none (a local catcher)."),
+        };
         await client.ConnectAsync(_settings.Host, _settings.Port, security, ct);
 
         // Only when a username is configured. A local catcher accepts no credentials at all

--- a/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpEncryption.cs
+++ b/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpEncryption.cs
@@ -1,0 +1,40 @@
+namespace Innovayse.Infrastructure.Notifications.Options;
+
+/// <summary>
+/// How the SMTP session to the relay is encrypted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the former <c>UseSsl</c> boolean, which could say that encryption was wanted but not
+/// which of the two incompatible kinds -- and whose <c>false</c> could not be told apart from
+/// "nobody set this", so the port was left to decide in its place.
+/// </para>
+/// <para>
+/// The member names are the values a deployment writes. Configuration binds an enum by member
+/// name, case-insensitively, so <c>SMTP_ENCRYPTION=tls</c>, <c>ssl</c> and <c>none</c> all bind.
+/// Anything else fails the bind itself, at startup, naming the key -- it does not fall back to a
+/// value nobody chose.
+/// </para>
+/// </remarks>
+public enum SmtpEncryption
+{
+    /// <summary>
+    /// No encryption at all -- the plain SMTP a local mail catcher speaks, conventionally on port
+    /// 1025. Never correct against a relay that is given a password.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// STARTTLS: the session opens in the clear and is upgraded by the <c>STARTTLS</c> command
+    /// before any credential is sent. The mail submission standard, conventionally on port 587.
+    /// </summary>
+    Tls = 1,
+
+    /// <summary>
+    /// Implicit TLS: the connection is encrypted before the first SMTP command, with no plaintext
+    /// greeting at all. Conventionally port 465 -- but a relay that expects TLS from the first
+    /// byte on some other port is stated here rather than guessed from the port number, which is
+    /// what the old <c>UseSsl</c> override existed to correct.
+    /// </summary>
+    Ssl = 2
+}

--- a/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpFromOptions.cs
+++ b/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpFromOptions.cs
@@ -1,0 +1,29 @@
+namespace Innovayse.Infrastructure.Notifications.Options;
+
+/// <summary>
+/// The sender identity stamped into the <c>From</c> header of every notification this product
+/// sends. Bound from the "Smtp:From" subsection, which a deployment fills as
+/// <c>Smtp__From__Address</c> and <c>Smtp__From__Name</c>.
+/// </summary>
+/// <remarks>
+/// A nested subsection rather than the flat <c>Smtp__FromEmail</c> / <c>Smtp__FromName</c> pair
+/// this product used to read, because the nested shape is the one the rest of the Innovayse
+/// platform's mail configuration already uses and hostpanel was the only product spelling it
+/// differently. The two values are one thing -- an address and the name shown beside it -- and
+/// neither is meaningful without the other.
+/// </remarks>
+public sealed class SmtpFromOptions
+{
+    /// <summary>
+    /// Gets the sender email address. Carries no default: the one that used to be baked into
+    /// <c>appsettings.json</c> was this operator's own, which is the wrong address for anyone
+    /// else running this product and the wrong thing to discover on delivered mail.
+    /// </summary>
+    public required string Address { get; init; }
+
+    /// <summary>
+    /// Gets the sender display name shown beside <see cref="Address"/> in a mail client. A
+    /// human-readable brand name, not an address.
+    /// </summary>
+    public required string Name { get; init; }
+}

--- a/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpOptions.cs
+++ b/backend/src/Innovayse.Infrastructure/Notifications/Options/SmtpOptions.cs
@@ -6,20 +6,25 @@ namespace Innovayse.Infrastructure.Notifications.Options;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Deliberately <b>not</b> validated at startup, which is where this class differs from the
-/// integration options beside it. Every deployed tier fills this section from a different
-/// place and none of them fills all of it: <c>appsettings.json</c> supplies
-/// <see cref="FromEmail"/>, <see cref="FromName"/> and <see cref="UseSsl"/> and deliberately
-/// omits <see cref="Host"/> and <see cref="Port"/>; <c>docker-compose.yml</c> supplies the
-/// local mail catcher's host and port; <c>docker-compose.prod.yml</c> supplies only
-/// <c>Smtp__Host</c>, <c>Smtp__Port</c> and <c>Smtp__Password</c>. A rule that refused a
-/// half-filled section would refuse to start the production API, so a missing value surfaces
-/// where mail is actually sent instead -- see <see cref="MailKitEmailSender"/>.
+/// <b>The section as a whole is deliberately not validated at startup</b>, which is where this
+/// class differs from the integration options beside it. Every deployed tier fills it from a
+/// different overlay and none of them fills all of it, so a rule that refused a half-filled
+/// section would refuse to start the production API. A missing host or port surfaces where mail
+/// is actually sent instead -- see <see cref="MailKitEmailSender"/>.
 /// </para>
 /// <para>
-/// No property carries a default. The old defaults named <c>localhost:1025</c> and a template
-/// <c>noreply@yourdomain.com</c>, which meant a tier that forgot to override them delivered
-/// every password reset and invitation nowhere and said nothing about it.
+/// <b><see cref="Encryption"/> is the one exception, and has to be.</b> It replaced a
+/// <c>UseSsl</c> boolean whose absence was harmless only because the port silently decided in its
+/// place. There is no such fallback now, and the value an unset enum would otherwise take is
+/// <see cref="SmtpEncryption.None"/> -- handing the relay's password to the network in the clear.
+/// So it is nullable, "not set" is a state the type can express, and <c>AddInfrastructure</c>
+/// refuses to start the process on it. A misspelt value never reaches that check: the binder
+/// fails on it first, at startup, naming the key. Declared, not inferred, in both directions.
+/// </para>
+/// <para>
+/// No other property carries a default. The old defaults named <c>localhost:1025</c> and a
+/// template <c>noreply@yourdomain.com</c>, which meant a tier that forgot to override them
+/// delivered every password reset and invitation nowhere and said nothing about it.
 /// </para>
 /// </remarks>
 public sealed class SmtpOptions
@@ -33,18 +38,41 @@ public sealed class SmtpOptions
     /// <summary>Gets the SMTP server port number.</summary>
     public required int Port { get; init; }
 
-    /// <summary>Gets the SMTP authentication username.</summary>
+    /// <summary>
+    /// Gets the SMTP authentication username, bound from <c>Smtp__Username</c>. Empty where the
+    /// relay takes no credentials -- a local catcher refuses <c>AUTH</c> outright -- and the
+    /// sender then skips authentication rather than offering a blank user.
+    /// </summary>
     public required string Username { get; init; }
 
     /// <summary>Gets the SMTP authentication password. A secret, so it carries no default.</summary>
     public required string Password { get; init; }
 
-    /// <summary>Gets the sender email address used in the <c>From</c> header.</summary>
-    public required string FromEmail { get; init; }
+    /// <summary>
+    /// Gets how the session to the relay is encrypted -- <c>tls</c>, <c>ssl</c> or <c>none</c>.
+    /// See <see cref="SmtpEncryption"/> for what each means and which port conventionally carries
+    /// it.
+    /// </summary>
+    /// <remarks>
+    /// <b>Nullable on purpose.</b> <see langword="null"/> is "no deployment stated this", which is
+    /// a different thing from <see cref="SmtpEncryption.None"/> -- "this deployment stated that
+    /// the session is not encrypted" -- and the two must not be confused, because one of them is
+    /// a decision and the other is an omission that would send a password in the clear. The
+    /// composition root refuses to start on <see langword="null"/>; nothing anywhere substitutes
+    /// a value for it.
+    /// </remarks>
+    public required SmtpEncryption? Encryption { get; init; }
 
-    /// <summary>Gets the sender display name used in the <c>From</c> header.</summary>
-    public required string FromName { get; init; }
+    /// <summary>
+    /// Gets the sender identity used in the <c>From</c> header. Filled from the nested
+    /// <c>Smtp__From__Address</c> and <c>Smtp__From__Name</c> keys.
+    /// </summary>
+    public required SmtpFromOptions From { get; init; }
 
-    /// <summary>Gets a value indicating whether to use SSL/TLS when connecting to the SMTP server.</summary>
-    public bool UseSsl { get; init; } = true;
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Encryption"/> was stated by the deployment.
+    /// What the composition root checks at startup, so the reason for the refusal is written
+    /// beside the property it is about rather than only in the registration.
+    /// </summary>
+    public bool HasEncryption => Encryption is not null;
 }

--- a/client/README.md
+++ b/client/README.md
@@ -118,18 +118,15 @@ belongs to the API's environment instead.
 
 ### Contact Form Delivery — Email And Telegram
 
-**Neither is configured here.** The contact form posts to the C# backend, which sends the mail
-through the one SMTP relay this platform configures and posts the enquiry to Telegram itself — so
-the relay credentials and the bot token live in the API's environment and nowhere else. This app
-held both until they moved; putting either back would give a secret a second container to leak
-from, and the platform a second client of the same service.
+**Neither is configured here.** The contact form posts to the API, which sends the mail and
+posts to Telegram. The credentials belong in the API's environment only.
 
 Set them in the repository root's `.env`:
 
 ```env
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
-SMTP_USER=your-email@example.com
+SMTP_USERNAME=your-email@example.com
 SMTP_PASSWORD=your-password
 # Where contact-form enquiries are delivered (Notifications__ContactEmail on the API).
 EMAIL_TO=contact@yourdomain.com

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -1,85 +1,41 @@
-# Platform overlay — joins this product to the Innovayse shared network.
+# Platform overlay — joins this product to the shared innovayse_network and parks the
+# broker the platform already runs once. The base file is standalone on purpose; this is
+# the other half.
 #
-# The base docker-compose.yml is deliberately standalone: it declares no external
-# network and brings its own dependencies, so `docker compose up` works in a fresh
-# clone with nothing else running. That is what makes this repo usable as an
-# open-source project on its own, and what lets it be moved to a server of its own.
+# Goes LAST in both of this repo's chains, after the prod overlay:
 #
-# This file is the other half. It renames the project's default network to the
-# shared one, which puts every service in this compose file on it without a
-# per-service edit — so containers here are reachable by name from the other
-# Innovayse stacks, and can reach theirs.
+#     docker compose -f docker-compose.prod.yml -f docker-compose.platform.yml up -d
+#     docker compose -f docker-compose.prod.yml -f docker-compose.prodserver.yml \
+#                    -f docker-compose.platform.yml up -d
 #
-# Used together:
-#
-#     docker compose -f docker-compose.yml -f docker-compose.platform.yml up -d
-#
-# ORDER MATTERS: this file goes LAST in the chain, after any prod overlay.
-#
-#     docker compose -f docker-compose.yml -f docker-compose.prod.yml #                    -f docker-compose.platform.yml up -d
-#
-# It parks services the platform already runs once and rewrites depends_on to drop
-# them. A file applied after this one merges its own service definitions back in,
-# which reintroduces a dependency on something no active profile includes — compose
-# then refuses the whole project with "depends on undefined service".
-#
-# The shared network is created by ../docker-compose.shared.yml, which also runs
-# the Redis, RabbitMQ and mail catcher the platform shares. None of that is
-# required to run this repo on its own.
+# Neither loads docker-compose.yml, so only services prod.yml defines can be parked here:
+# an entry for anything else creates a service with no image, and the project stops being
+# valid the moment a profile activates it.
 
 networks:
   default:
     name: innovayse_network
     external: true
 
-# This repo carries its own copy of infrastructure the platform already runs once.
-# Standalone that copy is the point — it is what lets this product be deployed on a
-# server of its own. Inside the workspace it is a second instance of something
-# shared, so it is parked behind a profile nothing activates.
-#
-# The depends_on entries have to be restated: compose refuses a project where a
-# service waits on one that no active profile includes.
 services:
   # the shared broker answers to the same name
   rabbitmq:
     profiles: ["standalone-only"]
 
-  # replaced by the shared mailpit
-  mailhog:
-    profiles: ["standalone-only"]
-
-  # the shared Redis answers to the same name, so Auth__RedisConnection is unchanged
-  redis:
-    profiles: ["standalone-only"]
-
   hostpanel-api:
-    # The aliases these services answer to are declared in docker-compose.yml, so
-    # they hold for a standalone deployment as well as this one.
-    #
-    # !override replaces the base list instead of merging into it. Without it the
-    # parked rabbitmq and mailhog would still be waited on, and compose refuses a
-    # project where a service depends on one no active profile includes.
-    #
-    # postgres stays: it is this product's own data, never shared.
+    # hostpanel-db stays: this product's own data, never shared. rabbitmq is dropped
+    # because the entry above parks it.
     depends_on: !override
       hostpanel-db:
         condition: service_healthy
     environment:
-      # Defaulted, not forced, and all four together.
+      # Host, port and credentials override together: the host alone would leave prod.yml's
+      # port and credentials, reaching the catcher on 465 to authenticate against something
+      # that accepts no credentials at all.
       #
-      # This overlay is applied last on every tier including production, so a bare
-      # `Smtp__Host: mailpit` overrode the real relay docker-compose.prod.yml had
-      # already set from SMTP_HOST — production aimed every password reset and address
-      # verification at a development catcher that is not even on this network, so the
-      # connection threw and nothing arrived.
-      #
-      # Overriding the host alone is half a switch: the port and credentials would still
-      # come from prod.yml, so the fallback would reach the catcher on 465 and try to
-      # authenticate against something that accepts no credentials at all. mailpit speaks
-      # plain SMTP on 1025 and refuses AUTH, so the whole group defaults together — a tier
-      # that sets SMTP_HOST keeps its own relay, port and user, and one that does not gets
-      # a catcher that is consistent with itself.
-      Smtp__Host: ${SMTP_HOST:-mailpit}
-      Smtp__Port: ${SMTP_PORT:-1025}
-      Smtp__Username: ${SMTP_USER:-}
-      Smtp__Password: ${SMTP_PASSWORD:-}
+      # Smtp__Encryption is deliberately not here. This overlay is applied last on every tier,
+      # so a value would reach production too; the base file and prod.yml both pass it.
+      Smtp__Host: ${SMTP_HOST}
+      Smtp__Port: ${SMTP_PORT}
+      Smtp__Username: ${SMTP_USERNAME}
+      Smtp__Password: ${SMTP_PASSWORD}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,42 +48,33 @@ services:
         # fresh base and never re-declares the ARG, so nothing carries it.
         NuGetPackageSourceCredentials_innovayse: ${NUGET_INNOVAYSE_CREDENTIALS}
     environment:
-      # The alias, not the bare service name: several products call their database
-      # service "postgres", so on the shared network that name resolved to three
-      # addresses and connections landed in another product's database.
-      ConnectionStrings__DefaultConnection: "Host=hostpanel-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       # Named here rather than in docker-compose.yml because neither deploy chain
       # loads that file: staging composes prod+platform, production composes
       # prod+prodserver+platform. This overlay is the one file both have in common,
       # so it is where a deployed container can actually read the setting. The value
       # comes from the deploy job, one line per tier, not from this file.
-      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Production}
-      Jwt__Secret: ${JWT_SECRET}
-      Jwt__Issuer: ${JWT_ISSUER}
-      Jwt__Audience: ${JWT_AUDIENCE}
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+
+      # The alias, not the bare service name: several products call their database
+      # service "postgres", so on the shared network that name resolved to three
+      # addresses and connections landed in another product's database.
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST};Port=${POSTGRES_PORT};Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+
+      Auth__RedisConnection: ${REDIS_CONNECTION}
+
+      RabbitMQ__Host: ${RABBITMQ_HOST}
+      RabbitMQ__Port: ${RABBITMQ_PORT}
+      RabbitMQ__User: ${RABBITMQ_USER}
+      RabbitMQ__Password: ${RABBITMQ_PASSWORD}
+
+      # Encryption: tls (STARTTLS), ssl (implicit TLS), or none.
       Smtp__Host: ${SMTP_HOST}
-      # No default. An unset key here means every server credential this product
-      # stores goes to the database unencrypted, so the API refuses to start instead.
-      EncryptionKey: ${ENCRYPTION_KEY:?required}
       Smtp__Port: ${SMTP_PORT}
-      # Username, not User. The options class declares Username, and configuration
-      # binds by property name — Smtp__User matched nothing and bound silently to
-      # empty, so this deployment has been authenticating with a blank user and a
-      # real password since the key was written.
-      Smtp__Username: ${SMTP_USER}
+      Smtp__Username: ${SMTP_USERNAME}
       Smtp__Password: ${SMTP_PASSWORD}
-      # The sender, and the one TLS override. All three had their only value in
-      # appsettings.json, so a deployment could not change who its mail came from without
-      # rebuilding the image — and the address baked in there is this operator's, which is
-      # the wrong default for anyone else running this product.
-      #
-      # UseSsl is an override, not the switch: MailKitEmailSender picks implicit TLS for 465
-      # and STARTTLS for 587 on its own. It is here for a relay on a non-standard port that
-      # still expects TLS from the first byte. appsettings said false while production ran on
-      # 465, which is why it is worth being able to correct from the deployment.
-      Smtp__FromEmail: ${SMTP_FROM_EMAIL:-noreply@${DOMAIN}}
-      Smtp__FromName: ${SMTP_FROM_NAME:-Innovayse}
-      Smtp__UseSsl: ${SMTP_USE_SSL:-false}
+      Smtp__Encryption: ${SMTP_ENCRYPTION}
+      Smtp__From__Address: ${SMTP_FROM}
+      Smtp__From__Name: ${SMTP_FROM_NAME}
       # The contact form's recipient. Not defaulted: an unset value here makes the API
       # refuse the submission naming this setting, rather than answer the visitor "sent"
       # and deliver nothing -- which is what the frontend did with this value for as long
@@ -94,13 +85,15 @@ services:
       # absent chat post loses nothing: the mail is the delivery. Half of a pair is refused at
       # startup instead, because a token with no chat id posts nowhere while looking configured.
       # This is where the client container's TELEGRAM_BOT_TOKEN stopped being a frontend secret.
-      Telegram__BotToken: ${TELEGRAM_BOT_TOKEN:-}
-      Telegram__ChatId: ${TELEGRAM_CHAT_ID:-}
-      RabbitMQ__Host: rabbitmq
-      RabbitMQ__User: ${RABBITMQ_USER}
-      RabbitMQ__Password: ${RABBITMQ_PASSWORD}
-      Cors__AllowedOrigins__0: https://${DOMAIN}
-      Cors__AllowedOrigins__1: https://${ADMIN_DOMAIN}
+      Telegram__BotToken: ${TELEGRAM_BOT_TOKEN}
+      Telegram__ChatId: ${TELEGRAM_CHAT_ID}
+
+      Jwt__Secret: ${JWT_SECRET}
+      Jwt__Issuer: ${JWT_ISSUER}
+      Jwt__Audience: ${JWT_AUDIENCE}
+      # No default. An unset key here means every server credential this product
+      # stores goes to the database unencrypted, so the API refuses to start instead.
+      EncryptionKey: ${ENCRYPTION_KEY:?required}
       # SSO is optional — only meaningful where a real SSO deployment shares
       # innovayse_network with this stack (see the `networks:` block below).
       #
@@ -110,6 +103,20 @@ services:
       # and the API takes the SSO path and refuses to start without a client secret.
       # .env.example carries `sso`; set it to `local` on a standalone box.
       Auth__Mode: ${AUTH_MODE}
+      # The cookie session for the admin SPA, read only when AUTH_MODE=sso.
+      # AddInnovayseAuth is skipped entirely under local — what a standalone box
+      # runs — so none of these have to be filled in there. Under sso all of them
+      # are required: the API refuses to start naming the missing one, rather than
+      # come up and hand every visitor an anonymous session.
+      #
+      # No :?required on the secret, unlike the other products: it would stop a
+      # local-mode host from starting over a value it never reads.
+      Auth__AppName: hostpanel
+      Auth__Authority: ${SSO_URL}
+      Auth__PublicAuthority: ${SSO_PUBLIC_URL}
+      Auth__ClientId: ${SSO_CLIENT_ID}
+      Auth__ClientSecret: ${CLIENT_HOSTPANEL_SECRET}
+
       Sso__Authority: ${SSO_URL}
       Sso__ClientId: ${SSO_CLIENT_ID}
       # How this product reads its people out of the SSO, under AUTH_MODE=sso. It is
@@ -124,20 +131,9 @@ services:
       # No :?required, for the same reason as the client secret below: a local-mode
       # host never reads it and should not be stopped over it.
       Sso__ServiceKey: ${SSO_SERVICE_KEY}
-      # The cookie session for the admin SPA, read only when AUTH_MODE=sso.
-      # AddInnovayseAuth is skipped entirely under local — what a standalone box
-      # runs — so none of these have to be filled in there. Under sso all of them
-      # are required: the API refuses to start naming the missing one, rather than
-      # come up and hand every visitor an anonymous session.
-      #
-      # No :?required on the secret, unlike the other products: it would stop a
-      # local-mode host from starting over a value it never reads.
-      Auth__AppName: hostpanel
-      Auth__Authority: ${SSO_URL}
-      Auth__PublicAuthority: ${SSO_PUBLIC_URL}
-      Auth__ClientId: ${SSO_CLIENT_ID}
-      Auth__ClientSecret: ${CLIENT_HOSTPANEL_SECRET}
-      Auth__RedisConnection: ${REDIS_CONNECTION}
+
+      Cors__AllowedOrigins__0: https://${DOMAIN}
+      Cors__AllowedOrigins__1: https://${ADMIN_DOMAIN}
     volumes:
       # Operator-uploaded branding: the logo, the favicon and the icon set generated
       # from them. These are written at runtime into the web root, which otherwise
@@ -189,27 +185,24 @@ services:
       # Public only. There is no server-side ssoPublicUrl key in runtimeConfig, so the
       # NUXT_SSO_PUBLIC_URL that used to sit here overrode nothing at all.
       NUXT_PUBLIC_SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
-      NUXT_SSO_CLIENT_ID: ${SSO_CLIENT_ID}
-      NUXT_SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
       NUXT_SSO_CALLBACK_URL: https://${DOMAIN}/api/portal/auth/sso/callback
-      NUXT_AUTH_MODE: ${AUTH_MODE}
       NUXT_PUBLIC_AUTH_MODE: ${AUTH_MODE}
       # Which template renders the public site, and whether its header offers the
       # apps launcher. Both were missing here, and because a production Nitro
       # build freezes runtimeConfig defaults (see the note above), the image's
       # build-time values were the only ones that could ever apply: the launcher
       # was permanently off on this tier and no .env edit could turn it on.
-      NUXT_PUBLIC_PORTAL_TEMPLATE: ${NUXT_PUBLIC_PORTAL_TEMPLATE:-aurora}
-      NUXT_PUBLIC_PORTAL_APPS_ENABLED: ${NUXT_PUBLIC_PORTAL_APPS_ENABLED:-}
+      NUXT_PUBLIC_PORTAL_TEMPLATE: ${NUXT_PUBLIC_PORTAL_TEMPLATE}
+      NUXT_PUBLIC_PORTAL_APPS_ENABLED: ${NUXT_PUBLIC_PORTAL_APPS_ENABLED}
       # Where each sibling product lives. Left unset these fall back to the
       # *.local development hostnames baked into nuxt.config.ts, so a launcher
       # switched on without them would offer links into nothing. An app with no
       # URL is dropped from the launcher rather than rendered broken.
-      NUXT_PUBLIC_TASKS_URL: ${NUXT_PUBLIC_TASKS_URL:-}
-      NUXT_PUBLIC_ERP_URL: ${NUXT_PUBLIC_ERP_URL:-}
-      NUXT_PUBLIC_SHEETS_URL: ${NUXT_PUBLIC_SHEETS_URL:-}
-      NUXT_PUBLIC_EMAIL_URL: ${NUXT_PUBLIC_EMAIL_URL:-}
-      NUXT_PUBLIC_DRIVE_URL: ${NUXT_PUBLIC_DRIVE_URL:-}
+      NUXT_PUBLIC_TASKS_URL: ${NUXT_PUBLIC_TASKS_URL}
+      NUXT_PUBLIC_ERP_URL: ${NUXT_PUBLIC_ERP_URL}
+      NUXT_PUBLIC_SHEETS_URL: ${NUXT_PUBLIC_SHEETS_URL}
+      NUXT_PUBLIC_EMAIL_URL: ${NUXT_PUBLIC_EMAIL_URL}
+      NUXT_PUBLIC_DRIVE_URL: ${NUXT_PUBLIC_DRIVE_URL}
       # Address of the WHMCS install the client area hands visitors off to -- the
       # dashboard's announcements and domain-transfer links, the saved-cards page and
       # the new-card path on invoice payment. It had no entry here at all, and the
@@ -219,12 +212,16 @@ services:
       # has to be the operator's choice, not an accident of the variable's name.
       # No trailing slash: this value is substituted verbatim, past the strip in
       # nuxt.config.ts.
-      NUXT_PUBLIC_WHMCS_URL: ${WHMCS_URL:-}
+      NUXT_PUBLIC_WHMCS_URL: ${WHMCS_URL}
       # Stripe.js's publishable key. Only docker-compose.server.yml carried it, and that
       # overlay is for a standalone VPS install -- neither CI deploy chain loads it, so
       # useStripe() logged "Stripe publishable key is not configured" and returned null
       # on stage and prod. Public by design; the secret key is the API's.
-      NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY:-}
+      NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY}
+
+      NUXT_SSO_CLIENT_ID: ${SSO_CLIENT_ID}
+      NUXT_SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
+      NUXT_AUTH_MODE: ${AUTH_MODE}
     depends_on:
       - hostpanel-api
     restart: unless-stopped

--- a/docker-compose.prodserver.yml
+++ b/docker-compose.prodserver.yml
@@ -1,18 +1,15 @@
-# ProdServer (10.0.0.4) overlay. Use instead of docker-compose.server.yml.
+# ProdServer (10.0.0.4) overlay — the one thing production needs that staging does not.
 #
-# server.yml publishes api/client/admin on localhost ports for a host nginx to reach.
-# That is the VPS shape, not this one: here innovayse-edge sits on the shared
-# innovayse_network and proxies to containers by name, so published ports buy nothing
-# and actively collide — 5148 is already held by calendar-api, which is
-# what stopped the first deploy.
+# innovayse-edge already owns :80 on this host and proxies to containers by name over the
+# shared network, so the bundled nginx has no role and would fail to bind. Disabling it is
+# also what drops prod.yml's 80/443 publications. Staging has no edge container and serves
+# through that nginx, which is why this is an overlay rather than part of prod.yml.
 #
-# Usage:
+# The platform overlay goes LAST, after this one:
 #   docker compose -f docker-compose.prod.yml \
-#                  -f docker-compose.platform.yml \
-#                  -f docker-compose.prodserver.yml up -d --build
+#                  -f docker-compose.prodserver.yml \
+#                  -f docker-compose.platform.yml up -d --build
 services:
-  # innovayse-edge already owns :80 on this host and terminates nothing itself (the VPS
-  # does TLS), so the bundled nginx has no role and would fail to bind.
   nginx:
     # Not in docker-compose.yml, so it cannot inherit a name from there like the
     # other services do. Prefixed for the same reason they are: container names
@@ -21,10 +18,3 @@ services:
     container_name: hostpanel-nginx
     profiles:
       - disabled
-
-  admin:
-    build:
-      args:
-        # The admin SPA is served under /admin on the same hostname rather than a
-        # second domain, so its asset URLs have to be built for that base path.
-        VITE_BASE_URL: /admin

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -46,20 +46,21 @@ services:
       # backend on the shared platform network, and Docker's DNS round-robins
       # between the two — the panel would intermittently talk to another product.
       NUXT_API_URL: http://hostpanel-api:5148
-      NUXT_AUTH_MODE: ${AUTH_MODE}
       NUXT_SSO_URL: ${SSO_URL}
-      NUXT_SSO_CLIENT_ID: ${SSO_CLIENT_ID}
-      NUXT_SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
       NUXT_SSO_CALLBACK_URL: ${SSO_CALLBACK_URL}
       NUXT_MAIN_API_URL: http://main-client:3000
       NUXT_PUBLIC_AUTH_MODE: ${AUTH_MODE}
       NUXT_PUBLIC_SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
-      NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY:-}
+      NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY}
       # The WHMCS install this panel hands visitors off to. Restated here for the same
       # reason as everything above it: docker-compose.yml passes WHMCS_URL, which the
       # prod target cannot read, so only Nitro's override name takes effect. No trailing
       # slash -- the value is substituted verbatim.
-      NUXT_PUBLIC_WHMCS_URL: ${WHMCS_URL:-}
+      NUXT_PUBLIC_WHMCS_URL: ${WHMCS_URL}
+
+      NUXT_AUTH_MODE: ${AUTH_MODE}
+      NUXT_SSO_CLIENT_ID: ${SSO_CLIENT_ID}
+      NUXT_SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
 
   admin:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,69 +131,52 @@ services:
       # can reach this socket can do anything the daemon can.
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      # Testcontainers starts sibling containers on the host, not children of this one,
-      # so the address it hands the test is a host port. "localhost" from in here is
-      # this container; host.docker.internal is the machine the daemon runs on.
-      TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
-      # The alias, not the bare service name: on the shared platform network several
-      # products' database services are all called "postgres", so the name resolved to
-      # more than one address and connections landed in another product's database.
-      ConnectionStrings__DefaultConnection: "Host=hostpanel-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       # Development on a laptop, Staging on the stage host, Production on the prod one.
       # It was pinned to Development here, which meant a deployed host served developer
       # exception pages and re-ran the test-data seeder on every restart.
-      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
-      Jwt__Secret: ${JWT_SECRET}
-      Jwt__Issuer: ${JWT_ISSUER}
-      Jwt__Audience: ${JWT_AUDIENCE}
-      RabbitMQ__Host: rabbitmq
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
+      DOTNET_USE_POLLING_FILE_WATCHER: 1
+      DOTNET_NUGET_SIGNATURE_VERIFICATION: "false"
+
+      # The alias, not the bare service name: on the shared platform network several
+      # products' database services are all called "postgres", so the name resolved to
+      # more than one address and connections landed in another product's database.
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST};Port=${POSTGRES_PORT};Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+
+      Auth__RedisConnection: ${REDIS_CONNECTION}
+
+      RabbitMQ__Host: ${RABBITMQ_HOST}
+      RabbitMQ__Port: ${RABBITMQ_PORT}
       RabbitMQ__User: ${RABBITMQ_USER}
       RabbitMQ__Password: ${RABBITMQ_PASSWORD}
-      Cors__AllowedOrigins__0: http://localhost:3001
-      Cors__AllowedOrigins__1: http://localhost:5174
-      Cors__AllowedOrigins__2: http://panel.local
-      Cors__AllowedOrigins__3: https://stage-panel.innovayse.com
-      Smtp__Host: mailhog
-      Smtp__Port: 1025
-      Smtp__Username: ""
-      Smtp__Password: ""
-      Smtp__FromEmail: noreply@innovayse.com
-      Smtp__FromName: Innovayse
-      Smtp__UseSsl: "false"
+
+      Smtp__Host: ${SMTP_HOST}
+      Smtp__Port: ${SMTP_PORT}
+      Smtp__Username: ${SMTP_USERNAME}
+      Smtp__Password: ${SMTP_PASSWORD}
+      Smtp__From__Address: ${SMTP_FROM}
+      Smtp__From__Name: ${SMTP_FROM_NAME}
+      Smtp__Encryption: ${SMTP_ENCRYPTION}
       # Where the public site's contact form delivers. It used to be EMAIL_TO on the
       # client container, next to a second copy of the relay credentials; the mail is sent
       # here now. A literal default is safe on this file only -- neither deploy chain loads
       # docker-compose.yml, and everything it sends goes to the mailhog catcher above.
-      Notifications__ContactEmail: ${EMAIL_TO:-contact@innovayse.com}
+      Notifications__ContactEmail: ${EMAIL_TO}
       # The chat the same enquiry is announced on. Optional, and defaulted to empty rather than
       # to a value: with both unset the API posts nowhere and says so in its log, which is the
       # right behaviour on a laptop. These two were the client container's TELEGRAM_BOT_TOKEN and
       # TELEGRAM_CHAT_ID; the post is made here now, so the token is not in a browser-facing app.
-      Telegram__BotToken: ${TELEGRAM_BOT_TOKEN:-}
-      Telegram__ChatId: ${TELEGRAM_CHAT_ID:-}
+      Telegram__BotToken: ${TELEGRAM_BOT_TOKEN}
+      Telegram__ChatId: ${TELEGRAM_CHAT_ID}
+
+      Jwt__Secret: ${JWT_SECRET}
+      Jwt__Issuer: ${JWT_ISSUER}
+      Jwt__Audience: ${JWT_AUDIENCE}
       # Required outside Development: without it the EF configurations silently drop
       # their encrypted-column converters and server passwords, API tokens and access
       # hashes are written to the database in plain text. .env.example carries a real
       # 32-byte key so a fresh clone exercises the same code path production does.
       EncryptionKey: ${ENCRYPTION_KEY}
-      DOTNET_USE_POLLING_FILE_WATCHER: 1
-      DOTNET_NUGET_SIGNATURE_VERIFICATION: "false"
-      NUGET_AUDIT: "false"
-      # Restoring Innovayse.Auth needs a credential for the private registry, and
-      # this API restores at container start rather than at image build — it runs
-      # `dotnet watch`. CI passes the same value as a build-arg for the products
-      # whose images are built in the pipeline; this is the equivalent for a host
-      # that builds in place. A deploy token scoped to read_package_registry, never
-      # a personal one: it can read packages and do nothing else.
-      NuGetPackageSourceCredentials_innovayse: ${NUGET_INNOVAYSE_CREDENTIALS}
-      Sso__Authority: http://sso-api:8080
-      Sso__ClientId: hostpanel
-      # How this product reads its people out of the SSO, under AUTH_MODE=sso. The
-      # SSO gates /api/service/* on it and answers 401 without it, so an unset value
-      # makes every account lookup fail — loudly, by design, rather than by reporting
-      # live customers as missing. Must equal innovayse-sso's SERVICE_AUTH_API_KEY,
-      # which is what SERVICE_AUTH_API_KEY feeds there.
-      Sso__ServiceKey: ${SSO_SERVICE_KEY}
       # The cookie session for the admin SPA. Read only when the mode is sso —
       # AddInnovayseAuth is skipped entirely under local, which is what keeps this
       # product deployable on its own with no SSO anywhere. Under sso all of them
@@ -211,7 +194,33 @@ services:
       # required variable here would stop a standalone box from starting at all.
       # Under sso an empty value fails at startup by name instead.
       Auth__ClientSecret: ${CLIENT_HOSTPANEL_SECRET}
-      Auth__RedisConnection: ${REDIS_CONNECTION}
+
+      Sso__Authority: http://sso-api:8080
+      Sso__ClientId: hostpanel
+      # How this product reads its people out of the SSO, under AUTH_MODE=sso. The
+      # SSO gates /api/service/* on it and answers 401 without it, so an unset value
+      # makes every account lookup fail — loudly, by design, rather than by reporting
+      # live customers as missing. Must equal innovayse-sso's SERVICE_AUTH_API_KEY,
+      # which is what SERVICE_AUTH_API_KEY feeds there.
+      Sso__ServiceKey: ${SSO_SERVICE_KEY}
+
+      Cors__AllowedOrigins__0: http://localhost:3001
+      Cors__AllowedOrigins__1: http://localhost:5174
+      Cors__AllowedOrigins__2: http://panel.local
+      Cors__AllowedOrigins__3: https://stage-panel.innovayse.com
+
+      # Testcontainers starts sibling containers on the host, not children of this one,
+      # so the address it hands the test is a host port. "localhost" from in here is
+      # this container; host.docker.internal is the machine the daemon runs on.
+      TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
+      NUGET_AUDIT: "false"
+      # Restoring Innovayse.Auth needs a credential for the private registry, and
+      # this API restores at container start rather than at image build — it runs
+      # `dotnet watch`. CI passes the same value as a build-arg for the products
+      # whose images are built in the pipeline; this is the equivalent for a host
+      # that builds in place. A deploy token scoped to read_package_registry, never
+      # a personal one: it can read packages and do nothing else.
+      NuGetPackageSourceCredentials_innovayse: ${NUGET_INNOVAYSE_CREDENTIALS}
       BackchannelLogout__Key: ${HOSTPANEL_BACKCHANNEL_LOGOUT_KEY}
     healthcheck:
       # wget, not curl: neither aspnet image ships curl. --spider makes it a HEAD-like
@@ -265,6 +274,14 @@ services:
       - client_nuxt:/app/.nuxt
       - client_output:/app/.output
     environment:
+      AUTH_MODE: ${AUTH_MODE}
+
+      SSO_URL: http://sso-api:8080
+      SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
+      SSO_CLIENT_ID: hostpanel
+      SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
+      SSO_CALLBACK_URL: ${SSO_CALLBACK_URL}
+
       # hostpanel-api, the alias declared on the api service above — not the bare
       # "api" service name, which collides with innovayse-main's own "api" on the
       # shared network and has Docker's DNS round-robin between two products'
@@ -272,25 +289,20 @@ services:
       API_URL: http://hostpanel-api:5148
       NUXT_PUBLIC_BASE_URL: ${NUXT_PUBLIC_BASE_URL}
       NUXT_PUBLIC_MAIN_URL: ${MAIN_APP_URL}
-      SSO_URL: http://sso-api:8080
-      SSO_PUBLIC_URL: ${SSO_PUBLIC_URL}
       NUXT_PUBLIC_TASKS_URL: ${NUXT_PUBLIC_TASKS_URL}
       NUXT_PUBLIC_ERP_URL: ${NUXT_PUBLIC_ERP_URL}
       NUXT_PUBLIC_SHEETS_URL: ${NUXT_PUBLIC_SHEETS_URL}
       NUXT_PUBLIC_EMAIL_URL: ${NUXT_PUBLIC_EMAIL_URL}
       NUXT_PUBLIC_DRIVE_URL: ${NUXT_PUBLIC_DRIVE_URL}
-      SSO_CLIENT_ID: hostpanel
-      SSO_CLIENT_SECRET: ${SSO_CLIENT_SECRET}
-      SSO_CALLBACK_URL: ${SSO_CALLBACK_URL}
-      STRIPE_PUBLISHABLE_KEY: pk_test_51Tc3tOEHRuUOoZmggqrvyuddpdtx6FtKaUSvqQXkwokJakOBFCLRDlX6troVkkjFw966agSmLKnu1NSlOAki6u9600PatIOktW
       # Address of the WHMCS install the client area hands visitors off to. The dev
       # target evaluates nuxt.config.ts at container start, so the source name is what
       # it reads here; the prod overlays pass the same variable under Nitro's
       # NUXT_PUBLIC_WHMCS_URL override name, because a built image cannot see this one.
       # Optional: with nothing set every WHMCS handoff link is hidden, not broken.
-      WHMCS_URL: ${WHMCS_URL:-}
-      AUTH_MODE: ${AUTH_MODE}
+      WHMCS_URL: ${WHMCS_URL}
       NUXT_MAIN_API_URL: http://main-client:3000
+
+      STRIPE_PUBLISHABLE_KEY: pk_test_51Tc3tOEHRuUOoZmggqrvyuddpdtx6FtKaUSvqQXkwokJakOBFCLRDlX6troVkkjFw966agSmLKnu1NSlOAki6u9600PatIOktW
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"
     healthcheck:
@@ -331,6 +343,7 @@ services:
       - admin_node_modules:/app/node_modules
     environment:
       VITE_API_BASE: /api
+
       # The alias, not the bare service name: "api" is also innovayse-main's backend
       # on the shared platform network, and Docker's DNS round-robins between the two.
       API_PROXY_TARGET: http://hostpanel-api:5148

--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,8 @@ POSTGRES_PASSWORD=${PG_PASS}
 POSTGRES_DB=hostpanel_prod
 
 # RabbitMQ
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
 RABBITMQ_USER=hostpanel
 RABBITMQ_PASSWORD=${RMQ_PASS}
 
@@ -134,10 +136,16 @@ JWT_ISSUER=innovayse-api
 JWT_AUDIENCE=innovayse-clients
 
 # SMTP (configure after install)
+# SMTP_ENCRYPTION names one of tls (STARTTLS, port 587), ssl (implicit TLS, port 465) or
+# none (a local catcher). The API refuses to start without it rather than guess from the
+# port, so it is filled in to match the 587 above and edited alongside the host.
 SMTP_HOST=
 SMTP_PORT=587
-SMTP_USER=
+SMTP_USERNAME=
 SMTP_PASSWORD=
+SMTP_ENCRYPTION=tls
+SMTP_FROM=noreply@${DOMAIN}
+SMTP_FROM_NAME=${DOMAIN}
 
 # Domains
 DOMAIN=${DOMAIN}
@@ -147,35 +155,6 @@ EOF
 chmod 600 "$INSTALL_DIR/.env"
 success ".env created"
 
-# ── Create docker-compose.server.yml ─────────────────────────────────────────
-step "Creating docker-compose.server.yml"
-
-cat > "$INSTALL_DIR/docker-compose.server.yml" <<'EOF'
-# Server overlay: exposes services on localhost ports for host nginx to proxy.
-services:
-  api:
-    ports:
-      - "127.0.0.1:5148:5148"
-
-  client:
-    ports:
-      - "127.0.0.1:3200:3000"
-    environment:
-      NUXT_API_URL: http://api:5148
-
-  admin:
-    ports:
-      - "127.0.0.1:5173:80"
-    build:
-      args:
-        VITE_BASE_URL: /admin
-
-  nginx:
-    profiles:
-      - disabled
-EOF
-
-success "docker-compose.server.yml created"
 
 # ── Fix Dockerfile for duplicate plugin.json ──────────────────────────────────
 step "Patching api.Dockerfile"
@@ -188,13 +167,16 @@ success "api.Dockerfile patched"
 step "Building Docker images (this takes ~5-10 minutes)"
 
 cd "$INSTALL_DIR"
-docker compose -f docker-compose.prod.yml -f docker-compose.server.yml --env-file .env build
+# docker-compose.server.yml ships with the repo: it disables the bundled nginx and
+# publishes the services on loopback for the host nginx to proxy.
+COMPOSE="docker compose -f docker-compose.prod.yml -f docker-compose.server.yml --env-file .env"
+$COMPOSE build
 success "Images built"
 
 # ── Start services ─────────────────────────────────────────────────────────────
 step "Starting services"
 
-docker compose -f docker-compose.prod.yml -f docker-compose.server.yml --env-file .env up -d
+$COMPOSE up -d
 info "Waiting for database to be ready..."
 sleep 10
 success "Services started"
@@ -205,10 +187,18 @@ step "Running database migrations"
 # Fix permissions for SDK container
 chmod -R 777 "$INSTALL_DIR/backend/"
 
-CONTAINER_NAME=$(docker compose -f docker-compose.prod.yml -f docker-compose.server.yml --env-file .env ps -q postgres 2>/dev/null | head -1)
 COMPOSE_PROJECT=$(basename "$INSTALL_DIR")
 NETWORK="${COMPOSE_PROJECT}_default"
-DB_CONTAINER="${COMPOSE_PROJECT}-postgres-1"
+
+# Resolved from compose, not guessed: these services declare container_name, so the
+# <project>-<service>-<index> form does not apply to them.
+DB_CONTAINER=$($COMPOSE ps -q hostpanel-db)
+API_CONTAINER=$($COMPOSE ps -q hostpanel-api)
+API_IMAGE=$($COMPOSE images -q hostpanel-api | head -1)
+
+# The address the API and the migration container dial is the service name, which is a
+# DNS alias on the compose network whatever the container ends up being called.
+DB_HOST=hostpanel-db
 
 docker run --rm \
   --network "$NETWORK" \
@@ -219,14 +209,13 @@ docker run --rm \
          export PATH=\"\$PATH:/root/.dotnet/tools\" && \
          dotnet restore Innovayse.Backend.sln -q && \
          dotnet-ef database update --project src/Innovayse.API/Innovayse.API.csproj \
-         --connection 'Host=${DB_CONTAINER};Port=5432;Database=hostpanel_prod;Username=hostpanel;Password=${PG_PASS}'" 2>&1
+         --connection 'Host=${DB_HOST};Port=5432;Database=hostpanel_prod;Username=hostpanel;Password=${PG_PASS}'" 2>&1
 
 success "Migrations applied"
 
 # ── Restart API ────────────────────────────────────────────────────────────────
 step "Restarting API"
 
-API_CONTAINER="${COMPOSE_PROJECT}-api-1"
 docker restart "$API_CONTAINER"
 sleep 8
 success "API restarted"
@@ -261,15 +250,17 @@ if [[ "$SEED_DEMO" == "y" || "$SEED_DEMO" == "Y" ]]; then
   docker run --rm \
     --name "$SEED_CONTAINER" \
     --network "$NETWORK" \
-    -e "ConnectionStrings__DefaultConnection=Host=${DB_CONTAINER};Port=5432;Database=hostpanel_prod;Username=hostpanel;Password=${PG_PASS}" \
+    -e "ConnectionStrings__DefaultConnection=Host=${DB_HOST};Port=5432;Database=hostpanel_prod;Username=hostpanel;Password=${PG_PASS}" \
     -e "ASPNETCORE_ENVIRONMENT=Development" \
     -e "Jwt__Secret=${JWT_SECRET}" \
     -e "Jwt__Issuer=innovayse-api" \
     -e "Jwt__Audience=innovayse-clients" \
-    -e "RabbitMQ__Host=${COMPOSE_PROJECT}-rabbitmq-1" \
+    -e "RabbitMQ__Host=rabbitmq" \
+    -e "RabbitMQ__Port=5672" \
     -e "RabbitMQ__User=hostpanel" \
     -e "RabbitMQ__Password=${RMQ_PASS}" \
-    "${COMPOSE_PROJECT}-api" \
+    -e "Smtp__Encryption=none" \
+    "$API_IMAGE" \
     sh -c "timeout 30 dotnet Innovayse.API.dll --urls http://0.0.0.0:5148 2>&1 | grep -E 'Seed|seeded|INF|clients' || true" &>/dev/null || true
 
   # Confirm all demo user emails


### PR DESCRIPTION
Carries develop to main.

Every compose file here passes `Smtp__Username`; `SmtpOptions` declared `User`, so the key bound nothing, the property stayed empty, and the sender's `IsNullOrWhiteSpace` guard skipped `AuthenticateAsync` entirely — a relay that requires credentials refuses every message.

`SmtpEncryption` (none/tls/ssl) replaces the port guess and is validated at startup. `From` becomes the nested `Smtp__From__Address` / `Smtp__From__Name`.

`install.sh` overwrote the repo's `docker-compose.server.yml` with a generated copy naming services `api` and `client`, which do not exist here — the open-source install failed on its first build step. The generator is gone; containers and images are resolved with `docker compose ps -q` / `images -q` instead of rebuilt names.

Verified before merge to develop: 372 unit + 61 integration tests, 0 failures; all four compose chains render.

**Before deploying:** `SMTP_ENCRYPTION` must be set for this tier — the API refuses to start without it rather than guessing from the port.