### PR TITLE
ci: put the staging deploy behind a switch, off by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,7 +240,11 @@ deploy:staging:
     ASPNETCORE_ENVIRONMENT: Staging
   environment: { name: staging/hostpanel }
   rules:
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
+    # Staging deploys are off: that host filled its disk and this job fails in get_sources,
+    # before the deploy script runs at all. Production is unaffected -- it deploys from main,
+    # on another host, and is manual. Set DEPLOY_STAGING=true in CI/CD variables to turn it
+    # back on; the condition below is the one this job had before, unchanged.
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop" && $DEPLOY_STAGING == "true"
   needs:
     - job: backend:build:api:prod
       optional: true


### PR DESCRIPTION
The staging host filled its disk. `deploy:staging` fails in `get_sources` with **No space left on device**, before its script runs a line.

The switch is on `deploy:staging` rather than on `.deploy-staging`: a job's own rules override what `extends` brings in, and this job declares its own, so a gate on the template would have read as configuration while doing nothing.

The condition is unchanged apart from `DEPLOY_STAGING`. Production is unaffected — it deploys from `main`, on another host, and is manual.