### PR TITLE
release: put the staging deploy behind a switch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,7 +240,11 @@ deploy:staging:
     ASPNETCORE_ENVIRONMENT: Staging
   environment: { name: staging/hostpanel }
   rules:
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
+    # Staging deploys are off: that host filled its disk and this job fails in get_sources,
+    # before the deploy script runs at all. Production is unaffected -- it deploys from main,
+    # on another host, and is manual. Set DEPLOY_STAGING=true in CI/CD variables to turn it
+    # back on; the condition below is the one this job had before, unchanged.
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop" && $DEPLOY_STAGING == "true"
   needs:
     - job: backend:build:api:prod
       optional: true


### PR DESCRIPTION
Carries develop to main so the two match.

`deploy:staging` is now gated on `DEPLOY_STAGING == "true"`, off by default: that host filled its disk and the job was failing in `get_sources` before its script ran a line.

The switch is on the concrete job, not on `.deploy-staging` — a job's own rules override what `extends` brings in, and this one declares its own.

Production is unaffected: it deploys from this branch, on another host, and is manual. `SMTP_ENCRYPTION` is now set for `production/hostpanel` (ssl, matching that host's port 465), which the API requires since the encryption change.