### PR TITLE
ci: gate the staging-deploy template too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,10 @@ stages: [test, build, deploy]
   after_script:
     - docker logout "$CI_REGISTRY" || true
   rules:
-    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop"
+    # Off with the job that extends this. A rule here is overridden by any job that
+    # declares its own, so this is not what stops deploy:staging -- it is what stops a
+    # job added later that forgets to.
+    - if: $CI_SERVER_HOST == "gitlab.com" && $CI_COMMIT_BRANCH == "develop" && $DEPLOY_STAGING == "true"
 
 # ── backend (Innovayse.API, .NET) ──────────────────────────────────────────────
 


### PR DESCRIPTION
`deploy:staging` is already gated on `DEPLOY_STAGING` — that is the job whose rules decide, since a job's own rules override what `extends` brings in.

The `.deploy-staging` template it extends kept the old, ungated condition. That is dead today, but it is what the next staging job would inherit if it forgot to declare its own rules — a deploy to a host we have deliberately switched off.