### PR TITLE
Replace mock notification feed with real admin activity data

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -15,6 +15,7 @@
         "@vuepic/vue-datepicker": "^14.0.0",
         "axios": "^1.15.0",
         "chart.js": "^4.5.1",
+        "date-fns": "^4.4.0",
         "daterangepicker": "^3.1.0",
         "md-editor-v3": "^6.5.1",
         "moment": "^2.30.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -21,6 +21,7 @@
     "@vuepic/vue-datepicker": "^14.0.0",
     "axios": "^1.15.0",
     "chart.js": "^4.5.1",
+    "date-fns": "^4.4.0",
     "daterangepicker": "^3.1.0",
     "md-editor-v3": "^6.5.1",
     "moment": "^2.30.1",

--- a/admin/src/components/layout/Topbar.vue
+++ b/admin/src/components/layout/Topbar.vue
@@ -5,11 +5,17 @@
  * Shows current page title, search, notifications, and user menu.
  * On mobile emits toggle-sidebar to open the drawer.
  */
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { formatDistanceToNowStrict, type Locale } from 'date-fns'
+import { enUS, ru, hy } from 'date-fns/locale'
 import { SUPPORTED_LOCALES, setLocale, type SupportedLocale } from '../../i18n'
 import { useAuthStore } from '../../modules/auth/stores/authStore'
+import { useActivityStore } from '../../modules/dashboard/stores/activityStore'
+
+/** date-fns locale objects, keyed by this app's locale codes. */
+const dateFnsLocales: Record<SupportedLocale, Locale> = { en: enUS, ru, hy }
 
 /** Emitted when the hamburger button is clicked on mobile. */
 const emit = defineEmits<{
@@ -61,13 +67,36 @@ function chooseLocale(code: SupportedLocale): void {
 /** Controls the notification popover visibility. */
 const showNotifications = ref(false)
 
-/** Mock notification count — will come from store later. */
-const notificationCount = ref(3)
+const activity = useActivityStore()
 
-/** Toggles notification dropdown. */
+/** Number of events in the feed, shown as the badge and header count. */
+const notificationCount = computed(() => activity.events.length)
+
+/** Toggles notification dropdown, loading the feed the first time it opens. */
 function toggleNotifications(): void {
   showNotifications.value = !showNotifications.value
+  if (showNotifications.value && activity.events.length === 0 && !activity.loading) {
+    activity.fetchActivity()
+  }
 }
+
+/**
+ * Formats an ISO timestamp as a localized relative string ("2 minutes ago", "3 hours ago").
+ *
+ * @param iso - ISO 8601 timestamp.
+ * @returns Human-readable relative time in the active locale.
+ */
+function relativeTime(iso: string): string {
+  return formatDistanceToNowStrict(new Date(iso), {
+    addSuffix: true,
+    locale: dateFnsLocales[locale.value as SupportedLocale],
+  })
+}
+
+/** Loads the notification feed once on mount so the badge reflects real data immediately. */
+onMounted(() => {
+  activity.fetchActivity()
+})
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -194,18 +223,20 @@ async function signOut(): Promise<void> {
             <span class="text-[0.8rem] font-semibold font-display text-text-primary">{{ t('common.notifications') }}</span>
             <span class="text-[0.65rem] font-medium text-primary-400 bg-primary-500/10 border border-primary-500/20 rounded-full px-2 py-0.5">{{ t('common.newCount', { count: notificationCount }) }}</span>
           </div>
-          <div class="divide-y divide-border">
-            <div class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <p class="text-[0.8rem] text-text-primary mb-0.5">New client registered</p>
-              <p class="text-[0.72rem] text-text-muted">2 minutes ago</p>
-            </div>
-            <div class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <p class="text-[0.8rem] text-text-primary mb-0.5">Invoice #1042 overdue</p>
-              <p class="text-[0.72rem] text-text-muted">1 hour ago</p>
-            </div>
-            <div class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <p class="text-[0.8rem] text-text-primary mb-0.5">Domain expiring soon</p>
-              <p class="text-[0.72rem] text-text-muted">3 hours ago</p>
+          <div v-if="activity.loading && activity.events.length === 0" class="px-4 py-6 text-center text-[0.75rem] text-text-muted">
+            {{ t('common.loading') }}
+          </div>
+          <div v-else-if="activity.events.length === 0" class="px-4 py-6 text-center text-[0.75rem] text-text-muted">
+            {{ t('common.noNotifications') }}
+          </div>
+          <div v-else class="divide-y divide-border max-h-80 overflow-y-auto">
+            <div
+              v-for="(event, index) in activity.events"
+              :key="`${event.type}-${event.occurredAt}-${index}`"
+              class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer"
+            >
+              <p class="text-[0.8rem] text-text-primary mb-0.5">{{ event.message }}</p>
+              <p class="text-[0.72rem] text-text-muted">{{ relativeTime(event.occurredAt) }}</p>
             </div>
           </div>
           <div class="px-4 py-2.5 border-t border-border">

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -9,7 +9,8 @@
     "notifications": "Notifications",
     "toggleSidebar": "Toggle sidebar",
     "viewAllNotifications": "View all notifications",
-    "newCount": "{count} new"
+    "newCount": "{count} new",
+    "noNotifications": "No notifications"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/admin/src/locales/hy.json
+++ b/admin/src/locales/hy.json
@@ -9,7 +9,8 @@
     "notifications": "Ծանուցումներ",
     "toggleSidebar": "Ցույց տալ/թաքցնել մենյուն",
     "viewAllNotifications": "Դիտել բոլոր ծանուցումները",
-    "newCount": "{count} նոր"
+    "newCount": "{count} նոր",
+    "noNotifications": "Ծանուցումներ չկան"
   },
   "nav": {
     "dashboard": "Ամփոփագիր",

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -9,7 +9,8 @@
     "notifications": "Уведомления",
     "toggleSidebar": "Показать/скрыть меню",
     "viewAllNotifications": "Смотреть все уведомления",
-    "newCount": "{count} новых"
+    "newCount": "{count} новых",
+    "noNotifications": "Нет уведомлений"
   },
   "nav": {
     "dashboard": "Панель управления",

--- a/admin/src/modules/dashboard/stores/activityStore.ts
+++ b/admin/src/modules/dashboard/stores/activityStore.ts
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useApi } from '../../../composables/useApi'
+import type { ActivityEvent } from '../../../types/activityevent'
+
+/**
+ * Pinia store for the admin notification feed.
+ *
+ * Fetches recent events (new clients, overdue invoices, expiring domains) from
+ * GET /api/admin/dashboard/activity.
+ */
+export const useActivityStore = defineStore('activity', () => {
+  const { request } = useApi()
+
+  /** Recent events, newest first. Empty until loaded. */
+  const events = ref<ActivityEvent[]>([])
+
+  /** True while events are being fetched. */
+  const loading = ref(false)
+
+  /** Error message, null when no error. */
+  const error = ref<string | null>(null)
+
+  /**
+   * Loads the recent activity feed from the backend.
+   *
+   * @param limit - Maximum number of events to fetch.
+   * @returns Promise that resolves when data is loaded.
+   */
+  async function fetchActivity(limit = 10): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      events.value = await request<ActivityEvent[]>(`/admin/dashboard/activity?limit=${limit}`)
+    } catch {
+      error.value = 'Failed to load notifications.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { events, loading, error, fetchActivity }
+})

--- a/admin/src/types/activityevent.ts
+++ b/admin/src/types/activityevent.ts
@@ -1,0 +1,12 @@
+/** The kinds of event the admin notification feed can surface. */
+export type ActivityEventType = 'ClientRegistered' | 'InvoiceOverdue' | 'DomainExpiring'
+
+/** A single event in the admin notification feed. */
+export interface ActivityEvent {
+  /** Machine-readable event kind, used to pick an icon/label. */
+  type: ActivityEventType
+  /** Human-readable summary of the event. */
+  message: string
+  /** ISO timestamp of when the event happened. */
+  occurredAt: string
+}

--- a/backend/src/Innovayse.API/Admin/DashboardController.cs
+++ b/backend/src/Innovayse.API/Admin/DashboardController.cs
@@ -1,6 +1,7 @@
 namespace Innovayse.API.Admin;
 
 using Innovayse.Application.Admin.Queries.GetDashboardStats;
+using Innovayse.Application.Admin.Queries.GetRecentActivity;
 using Innovayse.Domain.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,5 +24,17 @@ public sealed class DashboardController(IMessageBus bus) : ControllerBase
     {
         var stats = await bus.InvokeAsync<DashboardStatsDto>(new GetDashboardStatsQuery(), ct);
         return Ok(stats);
+    }
+
+    /// <summary>Returns the most recent noteworthy events for the notification bell.</summary>
+    /// <param name="limit">Maximum number of events to return, newest first. Defaults to 10.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Merged, newest-first activity events.</returns>
+    [HttpGet("activity")]
+    public async Task<ActionResult<IReadOnlyList<ActivityEventDto>>> GetActivityAsync([FromQuery] int limit, CancellationToken ct)
+    {
+        var events = await bus.InvokeAsync<IReadOnlyList<ActivityEventDto>>(
+            new GetRecentActivityQuery(limit is > 0 and <= 50 ? limit : 10), ct);
+        return Ok(events);
     }
 }

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventDto.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventDto.cs
@@ -1,0 +1,9 @@
+namespace Innovayse.Application.Admin.Queries.GetRecentActivity;
+
+/// <summary>
+/// A single event surfaced in the admin notification feed.
+/// </summary>
+/// <param name="Type">Machine-readable event kind, used by the frontend to pick an icon/label.</param>
+/// <param name="Message">Human-readable summary of the event.</param>
+/// <param name="OccurredAt">When the event happened (client registration, invoice due date, domain expiry).</param>
+public record ActivityEventDto(ActivityEventType Type, string Message, DateTimeOffset OccurredAt);

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventType.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventType.cs
@@ -1,0 +1,14 @@
+namespace Innovayse.Application.Admin.Queries.GetRecentActivity;
+
+/// <summary>The kinds of event the admin notification feed surfaces.</summary>
+public enum ActivityEventType
+{
+    /// <summary>A new client account was created.</summary>
+    ClientRegistered,
+
+    /// <summary>An invoice's due date has passed without payment.</summary>
+    InvoiceOverdue,
+
+    /// <summary>A domain is approaching its expiry date.</summary>
+    DomainExpiring,
+}

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityHandler.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityHandler.cs
@@ -1,0 +1,62 @@
+namespace Innovayse.Application.Admin.Queries.GetRecentActivity;
+
+using Innovayse.Domain.Billing;
+using Innovayse.Domain.Billing.Interfaces;
+using Innovayse.Domain.Clients.Interfaces;
+using Innovayse.Domain.Domains.Interfaces;
+
+/// <summary>
+/// Handles <see cref="GetRecentActivityQuery"/> by pulling the newest client registration,
+/// invoice-overdue and domain-expiry events from their own repositories and merging them by time.
+/// </summary>
+/// <param name="clientRepo">Client repository, for recently registered clients.</param>
+/// <param name="invoiceRepo">Invoice repository, for overdue invoices.</param>
+/// <param name="domainRepo">Domain repository, for domains nearing expiry.</param>
+public sealed class GetRecentActivityHandler(
+    IClientRepository clientRepo,
+    IInvoiceRepository invoiceRepo,
+    IDomainRepository domainRepo)
+{
+    /// <summary>How far back a client registration is still worth surfacing.</summary>
+    private static readonly TimeSpan ClientLookback = TimeSpan.FromDays(14);
+
+    /// <summary>How far ahead a domain expiry is worth surfacing.</summary>
+    private static readonly TimeSpan DomainLookahead = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Builds the merged, newest-first activity feed.
+    /// </summary>
+    /// <param name="query">The query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Up to <see cref="GetRecentActivityQuery.Limit"/> events, newest first.</returns>
+    public async Task<IReadOnlyList<ActivityEventDto>> HandleAsync(GetRecentActivityQuery query, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var recentClients = await clientRepo.GetCreatedBetweenAsync(now - ClientLookback, now, ct);
+        var (overdueInvoices, _) = await invoiceRepo.ListAsync(1, query.Limit, InvoiceStatus.Overdue, null, null, ct);
+        var expiringDomains = await domainRepo.ListExpiringBeforeAsync(now + DomainLookahead, ct);
+
+        var events = new List<ActivityEventDto>(recentClients.Count + overdueInvoices.Count + expiringDomains.Count);
+
+        events.AddRange(recentClients.Select(c => new ActivityEventDto(
+            ActivityEventType.ClientRegistered,
+            $"{c.FirstName} {c.LastName} registered",
+            c.CreatedAt)));
+
+        events.AddRange(overdueInvoices.Select(i => new ActivityEventDto(
+            ActivityEventType.InvoiceOverdue,
+            $"Invoice #{i.Id} overdue",
+            i.DueDate)));
+
+        events.AddRange(expiringDomains.Select(d => new ActivityEventDto(
+            ActivityEventType.DomainExpiring,
+            $"{d.Name} expiring soon",
+            d.ExpiresAt)));
+
+        return events
+            .OrderByDescending(e => e.OccurredAt)
+            .Take(query.Limit)
+            .ToList();
+    }
+}

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityQuery.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityQuery.cs
@@ -1,0 +1,5 @@
+namespace Innovayse.Application.Admin.Queries.GetRecentActivity;
+
+/// <summary>Query that returns the most recent noteworthy events for the admin notification feed.</summary>
+/// <param name="Limit">Maximum number of events to return, newest first.</param>
+public record GetRecentActivityQuery(int Limit = 10);


### PR DESCRIPTION
## Summary
- Adds `GET /api/admin/dashboard/activity` (GetRecentActivityQuery/Handler) merging recent client registrations, overdue invoices, and domains expiring within 30 days into one newest-first feed
- Wires the admin SPA's notification dropdown (Topbar.vue) to real data via a new activityStore, replacing the hardcoded mock list
- Relative timestamps via date-fns with the admin's active locale (en/ru/hy)

## Test plan
- [x] Verified endpoint returns 401 unauthenticated, 200 with real overdue-invoice data when logged in (browser + Playwright)
- [x] Confirmed dashboard bell shows real invoice numbers and relative times, badge count matches real event count