### PR TITLE
Add a real "View all notifications" destination page

### DIFF
--- a/admin/src/components/layout/Topbar.vue
+++ b/admin/src/components/layout/Topbar.vue
@@ -40,6 +40,7 @@ const titleKeys: Record<string, string> = {
   '/settings':    'nav.settings',
   '/reports':     'nav.reports',
   '/orders':      'nav.orders',
+  '/notifications': 'common.notifications',
 }
 
 /** Current page title derived from the active route. */
@@ -100,6 +101,12 @@ onMounted(() => {
 
 const router = useRouter()
 const auth = useAuthStore()
+
+/** Closes the dropdown and sends the operator to the full notification feed. */
+function viewAllNotifications(): void {
+  showNotifications.value = false
+  router.push('/notifications')
+}
 
 /** Controls the account menu visibility. */
 const showAccountMenu = ref(false)
@@ -240,7 +247,7 @@ async function signOut(): Promise<void> {
             </div>
           </div>
           <div class="px-4 py-2.5 border-t border-border">
-            <button class="text-[0.75rem] text-primary-400 hover:text-primary-300 transition-colors">{{ t('common.viewAllNotifications') }}</button>
+            <button class="text-[0.75rem] text-primary-400 hover:text-primary-300 transition-colors" @click="viewAllNotifications">{{ t('common.viewAllNotifications') }}</button>
           </div>
         </div>
 

--- a/admin/src/modules/dashboard/views/NotificationsView.vue
+++ b/admin/src/modules/dashboard/views/NotificationsView.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+/**
+ * Full-page admin notification feed — the destination for the Topbar bell's
+ * "View all notifications" link. Shows every event type the feed carries
+ * (client registrations, overdue invoices, domain expiries), not just invoices.
+ */
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { formatDistanceToNowStrict, type Locale } from 'date-fns'
+import { enUS, ru, hy } from 'date-fns/locale'
+import type { SupportedLocale } from '../../../i18n'
+import { useActivityStore } from '../stores/activityStore'
+import type { ActivityEventType } from '../../../types/activityevent'
+
+const { t, locale } = useI18n()
+const activity = useActivityStore()
+
+/** date-fns locale objects, keyed by this app's locale codes. */
+const dateFnsLocales: Record<SupportedLocale, Locale> = { en: enUS, ru, hy }
+
+/** Loads the full feed (more than the bell's 10-item preview) on mount. */
+onMounted(() => {
+  activity.fetchActivity(50)
+})
+
+/**
+ * Formats an ISO timestamp as a localized relative string.
+ *
+ * @param iso - ISO 8601 timestamp.
+ * @returns Human-readable relative time in the active locale.
+ */
+function relativeTime(iso: string): string {
+  return formatDistanceToNowStrict(new Date(iso), {
+    addSuffix: true,
+    locale: dateFnsLocales[locale.value as SupportedLocale],
+  })
+}
+
+/** Icon path and color per event type, so the list reads at a glance. */
+const typeStyle: Record<ActivityEventType, { icon: string; color: string }> = {
+  ClientRegistered: {
+    icon: 'M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75',
+    color: 'text-status-green',
+  },
+  InvoiceOverdue: {
+    icon: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    color: 'text-status-red',
+  },
+  DomainExpiring: {
+    icon: 'M12 2a15.3 15.3 0 000 20 15.3 15.3 0 000-20zM2 12h20',
+    color: 'text-status-yellow',
+  },
+}
+
+const events = computed(() => activity.events)
+</script>
+
+<template>
+  <div class="w-full">
+    <h1 class="text-xl font-display font-semibold text-text-primary mb-1">{{ t('common.notifications') }}</h1>
+    <p class="text-[0.85rem] text-text-muted mb-6">{{ t('common.viewAllNotifications') }}</p>
+
+    <div v-if="activity.loading && events.length === 0" class="text-center py-12 text-[0.85rem] text-text-muted">
+      {{ t('common.loading') }}
+    </div>
+    <div v-else-if="events.length === 0" class="text-center py-12 text-[0.85rem] text-text-muted">
+      {{ t('common.noNotifications') }}
+    </div>
+    <div v-else class="w-full bg-surface-card border border-border rounded-2xl divide-y divide-border overflow-hidden">
+      <div
+        v-for="(event, index) in events"
+        :key="`${event.type}-${event.occurredAt}-${index}`"
+        class="flex items-start gap-3 px-4 py-3.5"
+      >
+        <svg
+          class="w-4 h-4 mt-0.5 shrink-0"
+          :class="typeStyle[event.type].color"
+          viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
+        >
+          <path :d="typeStyle[event.type].icon" />
+        </svg>
+        <div class="min-w-0">
+          <p class="text-[0.85rem] text-text-primary">{{ event.message }}</p>
+          <p class="text-[0.72rem] text-text-muted">{{ relativeTime(event.occurredAt) }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -34,6 +34,7 @@ const router = createRouter({
       children: [
         { path: '', redirect: '/dashboard' },
         { path: 'dashboard', component: () => import('../modules/dashboard/views/DashboardView.vue') },
+        { path: 'notifications', component: () => import('../modules/dashboard/views/NotificationsView.vue') },
         { path: 'clients', component: () => import('../modules/clients/views/ClientsListView.vue') },
         { path: 'clients/add', component: () => import('../modules/clients/views/AddClientView.vue') },
         { path: 'clients/users', component: () => import('../modules/clients/views/ManageUsersView.vue') },


### PR DESCRIPTION
## Summary
- The Topbar bell's "View all notifications" button had no click handler, and a first pass wrongly routed it to the invoices list (only one of three event types the feed carries)
- Added a dedicated `/notifications` page listing the full activity feed (client registrations, overdue invoices, expiring domains) with per-type icons
- Fixed the Topbar page title falling back to "Admin" on this route

## Test plan
- [x] Clicked "View all notifications" in the bell, confirmed navigation to `/notifications`
- [x] Confirmed the page shows real data (not mock), full width, correct page title