### PR TITLE
Make notification-feed items clickable and link to their record

### DIFF
--- a/admin/src/components/layout/Topbar.vue
+++ b/admin/src/components/layout/Topbar.vue
@@ -13,6 +13,8 @@ import { enUS, ru, hy } from 'date-fns/locale'
 import { SUPPORTED_LOCALES, setLocale, type SupportedLocale } from '../../i18n'
 import { useAuthStore } from '../../modules/auth/stores/authStore'
 import { useActivityStore } from '../../modules/dashboard/stores/activityStore'
+import { activityEventLink } from '../../utils/activityEventLink'
+import type { ActivityEvent } from '../../types/activityevent'
 
 /** date-fns locale objects, keyed by this app's locale codes. */
 const dateFnsLocales: Record<SupportedLocale, Locale> = { en: enUS, ru, hy }
@@ -106,6 +108,20 @@ const auth = useAuthStore()
 function viewAllNotifications(): void {
   showNotifications.value = false
   router.push('/notifications')
+}
+
+/**
+ * Closes the dropdown and navigates to the record a notification is about.
+ *
+ * Plain click + router.push, not a RouterLink — a RouterLink's own click handler
+ * races the dropdown's `v-if` toggle: closing it synchronously in the same click
+ * unmounts the link before its navigation completes, so the click does nothing.
+ *
+ * @param event - The activity event that was clicked.
+ */
+function goToActivityEvent(event: ActivityEvent): void {
+  showNotifications.value = false
+  router.push(activityEventLink(event))
 }
 
 /** Controls the account menu visibility. */
@@ -241,6 +257,7 @@ async function signOut(): Promise<void> {
               v-for="(event, index) in activity.events"
               :key="`${event.type}-${event.occurredAt}-${index}`"
               class="px-4 py-3 hover:bg-white/[0.03] transition-colors cursor-pointer"
+              @click="goToActivityEvent(event)"
             >
               <p class="text-[0.8rem] text-text-primary mb-0.5">{{ event.message }}</p>
               <p class="text-[0.72rem] text-text-muted">{{ relativeTime(event.occurredAt) }}</p>

--- a/admin/src/modules/dashboard/views/NotificationsView.vue
+++ b/admin/src/modules/dashboard/views/NotificationsView.vue
@@ -11,6 +11,7 @@ import { enUS, ru, hy } from 'date-fns/locale'
 import type { SupportedLocale } from '../../../i18n'
 import { useActivityStore } from '../stores/activityStore'
 import type { ActivityEventType } from '../../../types/activityevent'
+import { activityEventLink } from '../../../utils/activityEventLink'
 
 const { t, locale } = useI18n()
 const activity = useActivityStore()
@@ -67,10 +68,11 @@ const events = computed(() => activity.events)
       {{ t('common.noNotifications') }}
     </div>
     <div v-else class="w-full bg-surface-card border border-border rounded-2xl divide-y divide-border overflow-hidden">
-      <div
+      <RouterLink
         v-for="(event, index) in events"
         :key="`${event.type}-${event.occurredAt}-${index}`"
-        class="flex items-start gap-3 px-4 py-3.5"
+        :to="activityEventLink(event)"
+        class="flex items-start gap-3 px-4 py-3.5 no-underline hover:bg-white/[0.03] transition-colors"
       >
         <svg
           class="w-4 h-4 mt-0.5 shrink-0"
@@ -83,7 +85,7 @@ const events = computed(() => activity.events)
           <p class="text-[0.85rem] text-text-primary">{{ event.message }}</p>
           <p class="text-[0.72rem] text-text-muted">{{ relativeTime(event.occurredAt) }}</p>
         </div>
-      </div>
+      </RouterLink>
     </div>
   </div>
 </template>

--- a/admin/src/types/activityevent.ts
+++ b/admin/src/types/activityevent.ts
@@ -9,4 +9,6 @@ export interface ActivityEvent {
   message: string
   /** ISO timestamp of when the event happened. */
   occurredAt: string
+  /** Primary key of the client, invoice or domain this event is about. */
+  entityId: number
 }

--- a/admin/src/utils/activityEventLink.ts
+++ b/admin/src/utils/activityEventLink.ts
@@ -1,0 +1,23 @@
+import type { ActivityEvent } from '../types/activityevent'
+
+/**
+ * Resolves where a notification-feed item should navigate to.
+ *
+ * A domain has no top-level detail route — only nested under its client
+ * (`/clients/:id/domains/:domainId`), and the feed does not carry the owning
+ * client's id — so a domain-expiring event links to the domains list instead
+ * of a specific record.
+ *
+ * @param event - The activity event to link.
+ * @returns The admin SPA route path for this event.
+ */
+export const activityEventLink = (event: ActivityEvent): string => {
+  switch (event.type) {
+    case 'ClientRegistered':
+      return `/clients/${event.entityId}`
+    case 'InvoiceOverdue':
+      return `/billing/${event.entityId}`
+    case 'DomainExpiring':
+      return '/domains'
+  }
+}

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventDto.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/ActivityEventDto.cs
@@ -6,4 +6,9 @@ namespace Innovayse.Application.Admin.Queries.GetRecentActivity;
 /// <param name="Type">Machine-readable event kind, used by the frontend to pick an icon/label.</param>
 /// <param name="Message">Human-readable summary of the event.</param>
 /// <param name="OccurredAt">When the event happened (client registration, invoice due date, domain expiry).</param>
-public record ActivityEventDto(ActivityEventType Type, string Message, DateTimeOffset OccurredAt);
+/// <param name="EntityId">
+/// Primary key of the client, invoice or domain the event is about, so the frontend can link
+/// to it. A domain's own id has no dedicated top-level route (only nested under its client),
+/// so the frontend falls back to the domains list for that type regardless of this value.
+/// </param>
+public record ActivityEventDto(ActivityEventType Type, string Message, DateTimeOffset OccurredAt, int EntityId);

--- a/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityHandler.cs
+++ b/backend/src/Innovayse.Application/Admin/Queries/GetRecentActivity/GetRecentActivityHandler.cs
@@ -42,17 +42,20 @@ public sealed class GetRecentActivityHandler(
         events.AddRange(recentClients.Select(c => new ActivityEventDto(
             ActivityEventType.ClientRegistered,
             $"{c.FirstName} {c.LastName} registered",
-            c.CreatedAt)));
+            c.CreatedAt,
+            c.Id)));
 
         events.AddRange(overdueInvoices.Select(i => new ActivityEventDto(
             ActivityEventType.InvoiceOverdue,
             $"Invoice #{i.Id} overdue",
-            i.DueDate)));
+            i.DueDate,
+            i.Id)));
 
         events.AddRange(expiringDomains.Select(d => new ActivityEventDto(
             ActivityEventType.DomainExpiring,
             $"{d.Name} expiring soon",
-            d.ExpiresAt)));
+            d.ExpiresAt,
+            d.Id)));
 
         return events
             .OrderByDescending(e => e.OccurredAt)


### PR DESCRIPTION
## Summary
- Notification items (dropdown and /notifications page) had cursor-pointer styling but no click handler
- Added `EntityId` to `ActivityEventDto` so the frontend can link each event: overdue invoices to `/billing/:id`, client registrations to `/clients/:id`, domain expiries to the domains list (no top-level domain detail route exists)
- Dropdown items use a plain click handler + `router.push`, not `RouterLink` — RouterLink's own navigation raced the dropdown's `v-if` toggle, so closing it synchronously in the same click unmounted the link before navigation completed

## Test plan
- [x] Clicked an overdue-invoice item in the bell dropdown, confirmed navigation to `/billing/:id`
- [x] Clicked an item on the full `/notifications` page, confirmed navigation to `/billing/:id`