### PR TITLE
feat(admin): show a connection test while it runs, and land the verdict with motion

### DIFF
--- a/admin/src/modules/integrations/components/IntegrationConfigForm.vue
+++ b/admin/src/modules/integrations/components/IntegrationConfigForm.vue
@@ -14,8 +14,10 @@ import type { IntegrationDetailDto, IntegrationConfigPayload, IntegrationSlug } 
 const props = defineProps<{
   /** Full integration detail loaded from the store. */
   integration: IntegrationDetailDto
-  /** True while a save or test request is in flight. */
+  /** True while a save request is in flight. */
   loading: boolean
+  /** True while a connection test is in flight. Separate from `loading` so Save never claims to be saving during a test. */
+  testing: boolean
 }>()
 
 /** Emits for IntegrationConfigForm. */
@@ -146,7 +148,7 @@ function handleSave(): void {
           type="button"
           class="gradient-brand text-white rounded-[10px] px-5 py-2 text-[0.85rem] font-semibold transition-all duration-150 hover:-translate-y-px disabled:opacity-50 disabled:translate-y-0 disabled:cursor-not-allowed"
           style="box-shadow: 0 3px 14px rgba(14,165,233,0.2);"
-          :disabled="loading"
+          :disabled="loading || testing"
           @click="handleSave"
         >
           {{ loading ? 'Saving…' : 'Save Changes' }}
@@ -154,10 +156,19 @@ function handleSave(): void {
         <button
           type="button"
           class="bg-white/[0.05] border border-border text-text-secondary rounded-[10px] px-5 py-2 text-[0.85rem] font-semibold transition-all duration-150 hover:text-text-primary hover:border-primary-500/30 hover:bg-primary-500/[0.05] disabled:opacity-50 disabled:cursor-not-allowed"
-          :disabled="loading"
+          :disabled="loading || testing"
           @click="emit('test')"
         >
-          Test Connection
+          <!-- The probe is a real round-trip to the provider, and for a hosted gateway it can
+               take a few seconds. Without a visible in-flight state the button looked inert and
+               got clicked again. Same ring as the list views use. -->
+          <span class="inline-flex items-center gap-2">
+            <span
+              v-if="testing"
+              class="w-3.5 h-3.5 rounded-full border-2 border-primary-500/20 border-t-primary-500 animate-spin"
+            />
+            {{ testing ? 'Testing…' : 'Test Connection' }}
+          </span>
         </button>
       </div>
     </div>

--- a/admin/src/modules/integrations/components/IntegrationStatusSidebar.vue
+++ b/admin/src/modules/integrations/components/IntegrationStatusSidebar.vue
@@ -12,6 +12,8 @@ const props = defineProps<{
   lastTestedAt: string | null
   /** Result of the most recent in-session test, or null. */
   testResult: IntegrationTestResult | null
+  /** True while a connection test is in flight. */
+  testing?: boolean
   /** Optional hint text shown in a callout box. */
   hint?: string
 }>()
@@ -39,33 +41,61 @@ function formatLastTested(): string {
     <div class="bg-surface-card border border-border rounded-2xl p-4">
       <p class="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-text-muted mb-3">Connection Status</p>
 
-      <!-- In-session test result -->
-      <template v-if="testResult">
-        <div class="flex items-center gap-2 mb-1">
-          <span
-            class="w-2 h-2 rounded-full shrink-0"
-            :class="testResult.success ? 'bg-status-green' : 'bg-status-red'"
-          />
-          <span class="text-[0.82rem] font-medium" :class="testResult.success ? 'text-status-green' : 'text-status-red'">
-            {{ testResult.success ? 'Connection OK' : 'Connection Failed' }}
-          </span>
-        </div>
-        <p class="text-[0.76rem] text-text-muted pl-4">{{ testResult.message }}</p>
-      </template>
+      <!-- The three states swap through one transition so a result never just snaps into
+           place: the probe's skeleton fades out and the verdict slides up in its place. -->
+      <Transition name="status-swap" mode="out-in">
 
-      <!-- Persisted last-tested -->
-      <template v-else>
-        <div class="flex items-center gap-2 mb-1.5">
-          <span
-            class="w-2 h-2 rounded-full shrink-0"
-            :class="lastTestedAt ? 'bg-status-green animate-pulse' : 'bg-border'"
-          />
-          <span class="text-[0.82rem] font-medium text-text-primary">
-            {{ lastTestedAt ? 'Previously tested OK' : 'Not tested yet' }}
-          </span>
+        <!-- Test in flight. Checked first: the store clears the previous result when a test
+             starts, so without this branch the card fell straight through to "Not tested yet"
+             for the duration of the probe and gave no sign anything was happening. The two
+             skeleton bars sit exactly where the verdict and its message will land. -->
+        <div v-if="testing" key="testing">
+          <div class="flex items-center gap-2 mb-2">
+            <span class="w-3.5 h-3.5 shrink-0 rounded-full border-2 border-primary-500/20 border-t-primary-500 animate-spin" />
+            <span class="text-[0.82rem] font-medium text-text-primary">Testing connection…</span>
+          </div>
+          <div class="pl-[1.375rem] flex flex-col gap-1.5" aria-hidden="true">
+            <span class="skeleton-bar h-2.5 w-3/4" />
+            <span class="skeleton-bar h-2.5 w-1/2" />
+          </div>
         </div>
-        <p class="text-[0.75rem] text-text-muted pl-4">Last tested: {{ formatLastTested() }}</p>
-      </template>
+
+        <!-- In-session test result -->
+        <div v-else-if="testResult" :key="testResult.success ? 'ok' : 'failed'">
+          <div class="flex items-center gap-2 mb-1">
+            <span class="relative flex w-2 h-2 shrink-0">
+              <!-- One-shot ping on success: the only moment the card has news worth a glance. -->
+              <span
+                v-if="testResult.success"
+                class="absolute inline-flex h-full w-full rounded-full bg-status-green opacity-75 animate-ping-once"
+              />
+              <span
+                class="relative inline-flex w-2 h-2 rounded-full"
+                :class="testResult.success ? 'bg-status-green' : 'bg-status-red'"
+              />
+            </span>
+            <span class="text-[0.82rem] font-medium" :class="testResult.success ? 'text-status-green' : 'text-status-red'">
+              {{ testResult.success ? 'Connection OK' : 'Connection Failed' }}
+            </span>
+          </div>
+          <p class="text-[0.76rem] text-text-muted pl-4">{{ testResult.message }}</p>
+        </div>
+
+        <!-- Persisted last-tested -->
+        <div v-else key="idle">
+          <div class="flex items-center gap-2 mb-1.5">
+            <span
+              class="w-2 h-2 rounded-full shrink-0"
+              :class="lastTestedAt ? 'bg-status-green animate-pulse' : 'bg-border'"
+            />
+            <span class="text-[0.82rem] font-medium text-text-primary">
+              {{ lastTestedAt ? 'Previously tested OK' : 'Not tested yet' }}
+            </span>
+          </div>
+          <p class="text-[0.75rem] text-text-muted pl-4">Last tested: {{ formatLastTested() }}</p>
+        </div>
+
+      </Transition>
     </div>
 
     <!-- Hint callout -->
@@ -79,3 +109,39 @@ function formatLastTested(): string {
 
   </div>
 </template>
+
+<style scoped>
+/* Skeleton placeholder with the shared shimmer sweep (keyframe lives in assets/main.css). */
+.skeleton-bar {
+  position: relative;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgb(255 255 255 / 0.06);
+}
+.skeleton-bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.12), transparent);
+  animation: shimmer 1.4s infinite;
+}
+
+/* Verdict swap: outgoing state fades, incoming one rises into place. */
+.status-swap-enter-active { transition: opacity 180ms ease-out, transform 180ms ease-out; }
+.status-swap-leave-active { transition: opacity 120ms ease-in; }
+.status-swap-enter-from { opacity: 0; transform: translateY(4px); }
+.status-swap-leave-to { opacity: 0; }
+
+/* Tailwind's animate-ping loops forever; a verdict deserves one ring, not a beacon. */
+@keyframes ping-once {
+  0%   { transform: scale(1);   opacity: 0.75; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+.animate-ping-once { animation: ping-once 700ms cubic-bezier(0, 0, 0.2, 1) 1 forwards; }
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-bar::after, .animate-ping-once { animation: none; }
+  .status-swap-enter-active, .status-swap-leave-active { transition: none; }
+}
+</style>

--- a/admin/src/modules/integrations/stores/integrationsStore.ts
+++ b/admin/src/modules/integrations/stores/integrationsStore.ts
@@ -42,6 +42,13 @@ export const useIntegrationsStore = defineStore('integrations', () => {
 
   /** True while any request is in flight. */
   const loading = ref(false)
+  /**
+   * True while a connection test is in flight. Kept apart from `loading` on purpose: that flag
+   * also drives the Save button's "Saving…" label and the initial page skeleton, so reusing it
+   * for the test made the Save button claim it was saving and gave the status sidebar nothing
+   * to distinguish "testing now" from "not tested yet".
+   */
+  const testing = ref(false)
 
   /** Error message, null when no error. */
   const error = ref<string | null>(null)
@@ -121,7 +128,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
    * @returns Promise that resolves with the test result.
    */
   async function testConnection(slug: string): Promise<void> {
-    loading.value = true
+    testing.value = true
     error.value = null
     testResult.value = null
     try {
@@ -131,7 +138,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     } catch {
       testResult.value = { success: false, message: 'Connection test failed.' }
     } finally {
-      loading.value = false
+      testing.value = false
     }
   }
 
@@ -139,6 +146,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     integrations,
     current,
     loading,
+    testing,
     error,
     testResult,
     fetchAll,

--- a/admin/src/modules/integrations/views/CwpIntegrationPage.vue
+++ b/admin/src/modules/integrations/views/CwpIntegrationPage.vue
@@ -107,6 +107,7 @@ async function handleTest(): Promise<void> {
           v-if="store.current"
           :integration="store.current"
           :loading="saving || store.loading"
+          :testing="store.testing"
           @save="handleSave"
           @test="handleTest"
         />

--- a/admin/src/modules/integrations/views/IntegrationDetailView.vue
+++ b/admin/src/modules/integrations/views/IntegrationDetailView.vue
@@ -111,6 +111,7 @@ async function handleTest(): Promise<void> {
         <IntegrationConfigForm
           :integration="store.current"
           :loading="store.loading"
+          :testing="store.testing"
           @save="handleSave"
           @test="handleTest"
         />
@@ -119,6 +120,7 @@ async function handleTest(): Promise<void> {
         <IntegrationStatusSidebar
           :last-tested-at="store.current.lastTestedAt"
           :test-result="store.testResult"
+          :testing="store.testing"
           :hint="hint"
         />
       </div>


### PR DESCRIPTION
The store had one `loading` flag for fetching, saving and testing. During a test that meant: the status card fell through to "Not tested yet" with no sign a probe was running, the Test button looked inert, and the Save button read **"Saving…"** — which was untrue.

A dedicated `testing` flag fixes all three.

- **While testing** — spinner + "Testing connection…" + two shimmering skeleton bars where the verdict will land (reuses the existing `shimmer` keyframe).
- **Result arrives** — the three states swap through one `<Transition mode="out-in">`, so the verdict rises into place rather than snapping.
- **Success** — one expanding ring on the status dot. One, not `animate-ping`'s beacon. Failure gets none.
- `prefers-reduced-motion` — every animation off.

`vue-tsc --build` clean. Admin only.