### PR TITLE
feat(admin): show what a connection test actually did

### DIFF
--- a/admin/src/modules/integrations/components/IntegrationStatusSidebar.vue
+++ b/admin/src/modules/integrations/components/IntegrationStatusSidebar.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
   testResult: IntegrationTestResult | null
   /** True while a connection test is in flight. */
   testing?: boolean
+  /** Host the integration talks to (e.g. "pg.inecoecom.am"), when it has one. */
+  endpointHost?: string
   /** Optional hint text shown in a callout box. */
   hint?: string
 }>()
@@ -23,6 +25,27 @@ const props = defineProps<{
  *
  * @returns Formatted string like "2 hours ago" or "Never".
  */
+/**
+ * Formats a test timestamp as local wall-clock time, e.g. "14:02:37".
+ *
+ * @param iso - ISO 8601 timestamp.
+ * @returns Local time, or an empty string when the input cannot be parsed.
+ */
+function formatClock(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+/**
+ * Formats a round-trip duration for the detail row.
+ *
+ * @param ms - Duration in milliseconds.
+ * @returns "812 ms" below a second, "2.4 s" above it.
+ */
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms} ms` : `${(ms / 1000).toFixed(1)} s`
+}
+
 function formatLastTested(): string {
   if (!props.lastTestedAt) return 'Never'
   const diff = Date.now() - new Date(props.lastTestedAt).getTime()
@@ -79,6 +102,23 @@ function formatLastTested(): string {
             </span>
           </div>
           <p class="text-[0.76rem] text-text-muted pl-4">{{ testResult.message }}</p>
+
+          <!-- What the probe actually did. Each row is shown only when its value exists, so a
+               built-in integration without a URL still gets a tidy card. -->
+          <dl class="mt-3 pl-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[0.72rem]">
+            <template v-if="endpointHost">
+              <dt class="text-text-muted">Endpoint</dt>
+              <dd class="text-text-secondary font-mono truncate">{{ endpointHost }}</dd>
+            </template>
+            <template v-if="testResult.testedAt">
+              <dt class="text-text-muted">Tested</dt>
+              <dd class="text-text-secondary">{{ formatClock(testResult.testedAt) }}</dd>
+            </template>
+            <template v-if="testResult.durationMs !== undefined">
+              <dt class="text-text-muted">Round trip</dt>
+              <dd class="text-text-secondary">{{ formatDuration(testResult.durationMs) }}</dd>
+            </template>
+          </dl>
         </div>
 
         <!-- Persisted last-tested -->

--- a/admin/src/modules/integrations/stores/integrationsStore.ts
+++ b/admin/src/modules/integrations/stores/integrationsStore.ts
@@ -131,12 +131,24 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     testing.value = true
     error.value = null
     testResult.value = null
+    const startedAt = performance.now()
     try {
-      testResult.value = await request<IntegrationTestResult>(`/admin/integrations/${slug}/test`, {
+      const result = await request<IntegrationTestResult>(`/admin/integrations/${slug}/test`, {
         method: 'POST',
       })
+      testResult.value = { ...result, durationMs: Math.round(performance.now() - startedAt) }
+      // The detail page's "Last tested" reads the persisted value, which the backend updates
+      // on a successful probe. Mirror it here so the card does not keep quoting the previous
+      // run until the next full reload.
+      if (result.success && current.value && result.testedAt) {
+        current.value = { ...current.value, lastTestedAt: result.testedAt }
+      }
     } catch {
-      testResult.value = { success: false, message: 'Connection test failed.' }
+      testResult.value = {
+        success: false,
+        message: 'Connection test failed.',
+        durationMs: Math.round(performance.now() - startedAt),
+      }
     } finally {
       testing.value = false
     }

--- a/admin/src/modules/integrations/types/integration.types.ts
+++ b/admin/src/modules/integrations/types/integration.types.ts
@@ -83,6 +83,14 @@ export interface IntegrationTestResult {
   success: boolean
   /** Human-readable message (error detail or "Connection OK"). */
   message: string
+  /** ISO 8601 UTC timestamp of when the backend ran the test. Sent by the API; it was being dropped. */
+  testedAt?: string
+  /**
+   * Round-trip time of the test as seen from the browser, in milliseconds. Measured here rather
+   * than on the server because it is the number an admin can act on: it includes the hop to our
+   * API and the API's hop to the provider, which is the whole path a real payment will take.
+   */
+  durationMs?: number
 }
 
 /**

--- a/admin/src/modules/integrations/views/IntegrationDetailView.vue
+++ b/admin/src/modules/integrations/views/IntegrationDetailView.vue
@@ -6,7 +6,7 @@
  * Layout: breadcrumb + 2/3 config form + 1/3 status sidebar.
  * Special case: if slug is "cwp", renders CwpIntegrationPage instead.
  */
-import { onMounted, defineAsyncComponent } from 'vue'
+import { computed, onMounted, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useIntegrationsStore } from '../stores/integrationsStore'
 import IntegrationConfigForm from '../components/IntegrationConfigForm.vue'
@@ -53,6 +53,18 @@ onMounted(() => {
 
 /** Static metadata hint for this integration. */
 const hint = INTEGRATION_META[slug as IntegrationSlug]?.hint
+
+/**
+ * Host the integration talks to, for the status card. Only hosted-gateway and server-backed
+ * integrations carry a URL field; for the rest this is undefined and the card omits the row.
+ * Parsed to a host so a pasted full URL still reads cleanly.
+ */
+const endpointHost = computed<string | undefined>(() => {
+  const cfg = store.current?.config ?? {}
+  const raw = cfg.gateway_url ?? cfg.host ?? cfg.api_url
+  if (!raw) return undefined
+  try { return new URL(raw.includes('://') ? raw : `https://${raw}`).host } catch { return raw }
+})
 
 /**
  * Handles save event from IntegrationConfigForm.
@@ -121,6 +133,7 @@ async function handleTest(): Promise<void> {
           :last-tested-at="store.current.lastTestedAt"
           :test-result="store.testResult"
           :testing="store.testing"
+          :endpoint-host="endpointHost"
           :hint="hint"
         />
       </div>


### PR DESCRIPTION
After a test the status card said only "Connection OK" and the message. The backend was already returning `TestedAt`; the frontend type dropped it, and the store never refreshed the persisted `lastTestedAt`.

Three rows now sit under the verdict, each only when it has a value:

| Row | Source |
|---|---|
| **Endpoint** | host parsed from `gateway_url` / `host` / `api_url` |
| **Tested** | wall-clock time from the backend's `TestedAt` |
| **Round trip** | measured in the browser — spans our API's hop to the provider too, which is the path a real payment takes |

A successful test also updates "Last tested" in place.

`vue-tsc --build` clean. Admin only.