### PR TITLE
fix(client): send forgot-password to the SSO under sso mode

### DIFF
--- a/client/pages/client/forgot-password.vue
+++ b/client/pages/client/forgot-password.vue
@@ -37,12 +37,23 @@
 <script setup lang="ts">
 /**
  * Password reset request page — takes an email address and asks the backend to send a
- * reset link.
+ * reset link. Local mode only: under SSO mode the page forwards to the SSO's reset page
+ * before rendering, because the C# API refuses the request there.
  */
 import { useAuthApi } from '~/composables/apis/useAuthApi'
 import { apiErrorMessage } from '~/utils/apiError'
 
 definePageMeta({ layout: false })
+
+const config = useRuntimeConfig()
+
+// Under SSO mode the accounts -- and their passwords -- belong to innovayse-sso, and the C# API
+// answers this page's request with 404 by design (`LocalAuthController.ForgotPasswordAsync`).
+// Sent here anyway, a visitor got a form that could never succeed; they go to the SSO's own
+// reset page instead, the same host `/client/login` hands them to for sign-in.
+if (config.public.authMode === 'sso') {
+  await navigateTo(`${config.public.ssoPublicUrl}/forgot-password`, { external: true })
+}
 
 const { requestPasswordReset } = useAuthApi()
 


### PR DESCRIPTION
Under `AUTH_MODE=sso` the accounts — and their passwords — belong to innovayse-sso, and `LocalAuthController.ForgotPasswordAsync` answers 404 by design. The page still rendered its form, and the request it sent was refused before that (403 from the SSO branch's CSRF check, since the BFF route forwards without `X-Requested-With`), so a visitor got a "send reset link" button that could never succeed and no mail.

The page now forwards to `<ssoPublicUrl>/forgot-password` before rendering when the mode is sso — the same host `/client/login` already hands sign-in to. Local mode is unchanged.

Verified on a host `nuxt build` of the client served locally under sso mode: `/client/forgot-password` lands on `sso.local/forgot-password`. vitest 128/128, lint and build clean.
