### PR TITLE
chore: take Innovayse.Auth 1.6.0

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -18,9 +18,14 @@
 
   <!-- ASP.NET Core & Identity -->
   <ItemGroup>
-    <PackageVersion Include="Innovayse.Auth" Version="1.0.0" />
+    <PackageVersion Include="Innovayse.Auth" Version="1.6.0" />
     <PackageVersion Include="DnsClient" Version="1.8.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+    <!--
+      9.0.20 rather than the 9.0.1 the other ASP.NET packages here carry: Innovayse.Auth 1.6.0
+      declares JwtBearer >= 9.0.20, and central package management turns the resulting
+      downgrade into NU1605, which TreatWarningsAsErrors makes a restore failure.
+    -->
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.20" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />


### PR DESCRIPTION
Brings the SSO callback fix (restart a sign-in whose cookie is gone; silent probes get their own cookie). JwtBearer 9.0.1 -> 9.0.20 for the package's floor. Built and all six suites run in a throwaway SDK container: 457 passed, 0 failed.