### PR TITLE
fix: split EF queries by default and proxy the chat launcher icon

### DIFF
--- a/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Innovayse.Infrastructure/DependencyInjection.cs
@@ -135,7 +135,19 @@ public static class DependencyInjection
         {
             options.UseNpgsql(
                 configuration.GetConnectionString("DefaultConnection"),
-                npgsql => npgsql.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName));
+                npgsql =>
+                {
+                    npgsql.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName);
+
+                    // One SQL statement per collection navigation rather than one join
+                    // over all of them. DomainRepository includes four collections on
+                    // every read, and the single-query default multiplies their rows
+                    // together — EF warned about it on each domain cron run in
+                    // production. A query that needs the single statement's snapshot
+                    // consistency opts back in with AsSingleQuery(); none does today.
+                    npgsql.UseQuerySplittingBehavior(
+                        Microsoft.EntityFrameworkCore.QuerySplittingBehavior.SplitQuery);
+                });
 
             // Suppress PendingModelChangesWarning so MigrateAsync() works in Development
             // even when the snapshot is slightly out of sync with the model.

--- a/backend/tests/Innovayse.Integration.Tests/Persistence/QuerySplittingBehaviorTests.cs
+++ b/backend/tests/Innovayse.Integration.Tests/Persistence/QuerySplittingBehaviorTests.cs
@@ -1,0 +1,37 @@
+namespace Innovayse.Integration.Tests.Persistence;
+
+using FluentAssertions;
+using Innovayse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Pins the composition root's EF Core query-splitting default.
+/// </summary>
+/// <remarks>
+/// Several repositories load more than one collection navigation in a single query —
+/// <c>DomainRepository</c> alone includes four — and EF Core's default is one SQL
+/// statement whose row count is the product of those collections. Production logged
+/// EF's warning about it on every domain cron run. The fix is a default in
+/// <c>Infrastructure/DependencyInjection.cs</c>, and this test is what would notice if
+/// that line were lost in a later edit of the options builder.
+/// </remarks>
+public sealed class QuerySplittingBehaviorTests(IntegrationTestFactory factory)
+    : IClassFixture<IntegrationTestFactory>
+{
+    /// <summary>The registered <see cref="AppDbContext"/> options split multi-collection queries.</summary>
+    [Fact]
+    public void DbContextOptions_SplitQueriesByDefault()
+    {
+        // Arrange
+        using var scope = factory.Services.CreateScope();
+        var options = scope.ServiceProvider.GetRequiredService<DbContextOptions<AppDbContext>>();
+
+        // Act
+        var relational = options.Extensions.OfType<RelationalOptionsExtension>().Single();
+
+        // Assert
+        relational.QuerySplittingBehavior.Should().Be(QuerySplittingBehavior.SplitQuery);
+    }
+}

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -44,6 +44,15 @@ export default defineNuxtConfig({
     // from the bank. Development runs with `ssr: false` globally (see the note at the top
     // of this file), so this can only ever be caught against a production build.
     '/payment/**': { ssr: false, headers: { 'X-Robots-Tag': 'noindex, nofollow' } },
+    // The live-chat SDK (app.vue, chat.innovayse.com) draws its launcher bubble in
+    // *this* page and points the inbox icon at a root-relative `/brand-assets/...`, so
+    // the icon was requested from this origin, 404'd into the Vue Router, and left a
+    // broken bubble plus a router warning on every public page. Proxy the path to the
+    // chat host the widget is configured against — the same rule innovayse-main carries
+    // — so the icon stays whatever is set there instead of a copy here that would drift.
+    // Caching is whatever the chat host sends; a `headers` override here would be dead
+    // config, since a proxied response keeps the upstream's.
+    '/brand-assets/**': { proxy: 'https://chat.innovayse.com/brand-assets/**' },
   },
 
   nitro: {


### PR DESCRIPTION
DomainRepository loads four collections per domain in one statement, and EF
Core warned about the row multiplication on every domain cron run in
production. The Npgsql options now default to SplitQuery; a test pins the
setting.

The live-chat launcher asks this origin for its inbox icon with a
root-relative /brand-assets path. Nuxt had no route for it, so every public
page logged a router warning and drew a broken bubble. Same proxy rule the
portal already carries.